### PR TITLE
fix(api): 세션 계약과 이미지 비밀값 노출을 수정

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { initGame, progressGame } from './api/gameApi'
+import { initGame, progressGame, resolveGameAssetUrl } from './api/gameApi'
 import GameImage from './components/GameImage'
 import TypewriterText from './components/TypewriterText'
 import './App.css'
@@ -11,7 +11,8 @@ function App() {
     const [gameData, setGameData] = useState(null);
     const [isTypingComplete, setIsTypingComplete] = useState(false);
 
-    const sessionId = gameData?.characterImageUrl;
+    const sessionId = gameData?.sessionId;
+    const mainImageUrl = resolveGameAssetUrl(gameData?.mainImageUrl);
 
     const handleStartGame = async () => {
         if (!world || !character) {
@@ -53,7 +54,7 @@ function App() {
                 <h1>📖 {gameData.title}</h1>
 
                 <div className="image-container">
-                    <GameImage key={gameData.mainImageUrl} src={gameData.mainImageUrl} alt="Game Scene" />
+                    <GameImage key={mainImageUrl} src={mainImageUrl} alt="Game Scene" />
                 </div>
 
                 <div className="story-box">

--- a/frontend/src/api/gameApi.js
+++ b/frontend/src/api/gameApi.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
 const BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080/api/game';
+const API_ORIGIN = new URL(BASE_URL).origin;
 
 export const initGame = async (worldSetting, characterSetting) => {
     const response = await axios.post(`${BASE_URL}/init`, {
@@ -16,6 +17,13 @@ export const progressGame = async (sessionId, choiceId) => {
         choiceId
     });
     return response.data;
+};
+
+export const resolveGameAssetUrl = (assetUrl) => {
+    if (!assetUrl || !assetUrl.startsWith('/')) {
+        return assetUrl;
+    }
+    return new URL(assetUrl, API_ORIGIN).toString();
 };
 
 export const verifyPassword = async (password) => {

--- a/src/main/java/com/uctale/uctale/controller/ApiExceptionHandler.java
+++ b/src/main/java/com/uctale/uctale/controller/ApiExceptionHandler.java
@@ -1,0 +1,28 @@
+package com.uctale.uctale.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+
+@RestControllerAdvice
+public class ApiExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleIllegalArgument(IllegalArgumentException exception) {
+        return ResponseEntity.badRequest().body(Map.of("message", exception.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidation(MethodArgumentNotValidException exception) {
+        String message = exception.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .map(error -> error.getDefaultMessage())
+                .orElse("요청값이 올바르지 않습니다.");
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("message", message));
+    }
+}

--- a/src/main/java/com/uctale/uctale/controller/GameController.java
+++ b/src/main/java/com/uctale/uctale/controller/GameController.java
@@ -4,6 +4,7 @@ import com.uctale.uctale.dto.GameInitRequest;
 import com.uctale.uctale.dto.GameProgressRequest;
 import com.uctale.uctale.dto.GameResponse;
 import com.uctale.uctale.service.GameService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,25 +25,23 @@ public class GameController {
     @Value("${game.access.password}")
     private String accessPassword;
 
-    // 비밀번호 검증 API
     @PostMapping("/verify-password")
     public ResponseEntity<?> verifyPassword(@RequestBody Map<String, String> payload) {
         String inputPassword = payload.get("password");
         if (accessPassword.equals(inputPassword)) {
-            return ResponseEntity.ok().build(); // 성공 (200 OK)
-        } else {
-            return ResponseEntity.status(401).body("비밀번호가 틀렸습니다."); // 실패 (401 Unauthorized)
+            return ResponseEntity.ok().build();
         }
+        return ResponseEntity.status(401).body("비밀번호가 틀렸습니다.");
     }
 
     @PostMapping("/init")
-    public ResponseEntity<GameResponse> initGame(@RequestBody GameInitRequest request) {
+    public ResponseEntity<GameResponse> initGame(@Valid @RequestBody GameInitRequest request) {
         log.info("게임 초기화 요청: 세계관={}, 사용자={}", request.worldSetting(), request.characterSetting());
         return ResponseEntity.ok(gameService.initGame(request));
     }
 
     @PostMapping("/progress")
-    public ResponseEntity<GameResponse> progressGame(@RequestBody GameProgressRequest request) {
+    public ResponseEntity<GameResponse> progressGame(@Valid @RequestBody GameProgressRequest request) {
         log.info("게임 진행: 세션ID={}, 선택지={}", request.sessionId(), request.choiceId());
         return ResponseEntity.ok(gameService.progressGame(request));
     }

--- a/src/main/java/com/uctale/uctale/controller/ImageController.java
+++ b/src/main/java/com/uctale/uctale/controller/ImageController.java
@@ -1,0 +1,42 @@
+package com.uctale.uctale.controller;
+
+import com.uctale.uctale.service.NanoBananaService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.concurrent.TimeUnit;
+
+@RestController
+@RequestMapping("/api/game")
+@RequiredArgsConstructor
+@CrossOrigin(origins = "*")
+public class ImageController {
+
+    private final NanoBananaService nanoBananaService;
+
+    @GetMapping("/image")
+    public ResponseEntity<byte[]> image(
+            @RequestParam String prompt,
+            @RequestParam(defaultValue = "16:9") String aspectRatio
+    ) {
+        if (prompt == null || prompt.isBlank()) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        NanoBananaService.GeneratedImage generatedImage = nanoBananaService.fetchImage(prompt, aspectRatio);
+        if (generatedImage == null || generatedImage.bytes() == null || generatedImage.bytes().length == 0) {
+            return ResponseEntity.status(502).build();
+        }
+
+        return ResponseEntity.ok()
+                .contentType(generatedImage.contentType())
+                .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic())
+                .body(generatedImage.bytes());
+    }
+}

--- a/src/main/java/com/uctale/uctale/dto/GameProgressRequest.java
+++ b/src/main/java/com/uctale/uctale/dto/GameProgressRequest.java
@@ -1,6 +1,13 @@
 package com.uctale.uctale.dto;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
 public record GameProgressRequest(
-        Long sessionId, // 어떤 게임 세션인지 식별
-        int choiceId    // 사용자가 고른 선택지 번호 (1, 2, 3)
+        @NotNull(message = "세션 ID는 필수입니다.")
+        @Positive(message = "세션 ID는 양수여야 합니다.")
+        Long sessionId,
+
+        @Positive(message = "선택지 ID는 양수여야 합니다.")
+        int choiceId
 ) {}

--- a/src/main/java/com/uctale/uctale/dto/GameResponse.java
+++ b/src/main/java/com/uctale/uctale/dto/GameResponse.java
@@ -3,9 +3,10 @@ package com.uctale.uctale.dto;
 import java.util.List;
 
 public record GameResponse(
+        Long sessionId,
         String title,
         String storyText,
-        List<GeminiResponse.Choice> choices, // 선택지는 그대로 재사용
-        String mainImageUrl,                 // 생성된 배경+캐릭터 합성 또는 배경 이미지 URL
-        String characterImageUrl             // (선택적) 캐릭터 초상화 URL (오프닝 때 사용)
+        List<GeminiResponse.Choice> choices,
+        String mainImageUrl,
+        String characterImageUrl
 ) {}

--- a/src/main/java/com/uctale/uctale/dto/GameResponse.java
+++ b/src/main/java/com/uctale/uctale/dto/GameResponse.java
@@ -7,6 +7,5 @@ public record GameResponse(
         String title,
         String storyText,
         List<GeminiResponse.Choice> choices,
-        String mainImageUrl,
-        String characterImageUrl
+        String mainImageUrl
 ) {}

--- a/src/main/java/com/uctale/uctale/service/GameService.java
+++ b/src/main/java/com/uctale/uctale/service/GameService.java
@@ -53,8 +53,7 @@ public class GameService {
                 geminiResponse.title(),
                 geminiResponse.story_text(),
                 geminiResponse.choices(),
-                imageUrl,
-                null
+                imageUrl
         );
     }
 
@@ -97,8 +96,7 @@ public class GameService {
                 nextTurnResponse.title(),
                 nextTurnResponse.story_text(),
                 nextTurnResponse.choices(),
-                imageUrl,
-                null
+                imageUrl
         );
     }
 

--- a/src/main/java/com/uctale/uctale/service/GameService.java
+++ b/src/main/java/com/uctale/uctale/service/GameService.java
@@ -31,13 +31,9 @@ public class GameService {
     private final GameLogRepository gameLogRepository;
     private final ObjectMapper objectMapper;
 
-    /**
-     * 게임 초기화 및 오프닝 생성
-     */
     public GameResponse initGame(GameInitRequest request) {
         GeminiResponse geminiResponse = geminiService.getOpening(request);
 
-        // 오프닝은 무조건 이미지를 생성하도록 유도 (없으면 기본값 사용)
         String imagePrompt = determineImagePrompt(geminiResponse.visual_assets());
         if (imagePrompt == null || imagePrompt.isBlank()) {
             imagePrompt = "mysterious atmosphere, " + request.worldSetting();
@@ -53,15 +49,15 @@ public class GameService {
         gameLogRepository.save(log);
 
         return new GameResponse(
+                session.getId(),
                 geminiResponse.title(),
                 geminiResponse.story_text(),
                 geminiResponse.choices(),
                 imageUrl,
-                session.getId().toString()
+                null
         );
     }
 
-    // 게임 진행 (다음 턴)
     public GameResponse progressGame(GameProgressRequest request) {
         GameSession session = gameSessionRepository.findById(request.sessionId())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 세션입니다."));
@@ -79,13 +75,11 @@ public class GameService {
                 userChoiceText
         );
 
-        // [핵심] 이미지 생성 판단 로직
-        String imageUrl = lastLog.getImageUrl(); // 기본값: 이전 이미지 유지
+        String imageUrl = lastLog.getImageUrl();
         String newPrompt = determineImagePrompt(nextTurnResponse.visual_assets());
 
-        // 새로운 프롬프트가 '존재할 때만' 생성 (null이면 이전 이미지 재사용)
         if (newPrompt != null && !newPrompt.isBlank()) {
-            log.info("새로운 이미지 생성 요청: {}", newPrompt);
+            log.info("새로운 이미지 생성 요청");
             String newImage = nanoBananaService.generateImage(newPrompt, "16:9");
             if (newImage != null) {
                 imageUrl = newImage;
@@ -99,43 +93,36 @@ public class GameService {
         gameLogRepository.save(newLog);
 
         return new GameResponse(
+                session.getId(),
                 nextTurnResponse.title(),
                 nextTurnResponse.story_text(),
                 nextTurnResponse.choices(),
                 imageUrl,
-                session.getId().toString()
+                null
         );
     }
 
-    // [수정] 프롬프트 결정 헬퍼 메서드: '선택'이 아닌 '조합'으로 변경
     private String determineImagePrompt(GeminiResponse.VisualAssets assets) {
         if (assets == null) return null;
 
         List<String> prompts = new ArrayList<>();
 
-        // 1. 캐릭터 (적/NPC)
         if (assets.characters() != null && !assets.characters().isEmpty()) {
             prompts.addAll(assets.characters());
         }
 
-        // 2. 아이템/사물 (상호작용)
         if (assets.assets() != null && !assets.assets().isEmpty()) {
             prompts.addAll(assets.assets());
         }
 
-        // 3. 배경 (장소)
         if (assets.background() != null && !assets.background().isBlank()) {
             prompts.add(assets.background());
         }
 
-        // 모든 요소가 비어있으면 null 반환 (이미지 생성 안 함)
         if (prompts.isEmpty()) {
             return null;
         }
 
-        // 요소들을 콤마로 연결하여 하나의 풍성한 프롬프트 생성
-        // 예: "bloody zombie, red fire extinguisher, dark subway station"
-        // AI 화가(Flux)가 이 조합을 바탕으로 '지하철에서 소화기가 있는 좀비 씬'을 그려줌
         return String.join(", ", prompts);
     }
 
@@ -143,21 +130,22 @@ public class GameService {
         try {
             return objectMapper.writeValueAsString(choices);
         } catch (JsonProcessingException e) {
-            log.error("선택지 JSON 변환 실패", e);
-            return "[]";
+            throw new IllegalStateException("선택지 JSON 변환에 실패했습니다.", e);
         }
     }
 
     private String findChoiceText(String json, int choiceId) {
+        final List<GeminiResponse.Choice> choices;
         try {
-            List<GeminiResponse.Choice> choices = objectMapper.readValue(json, new TypeReference<>() {});
-            return choices.stream()
-                    .filter(c -> c.id() == choiceId)
-                    .findFirst()
-                    .map(GeminiResponse.Choice::text)
-                    .orElse("알 수 없는 행동");
-        } catch (Exception e) {
-            return "선택지 처리 중 오류";
+            choices = objectMapper.readValue(json, new TypeReference<>() {});
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("저장된 선택지를 읽을 수 없습니다.", e);
         }
+
+        return choices.stream()
+                .filter(choice -> choice.id() == choiceId)
+                .findFirst()
+                .map(GeminiResponse.Choice::text)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 선택지입니다."));
     }
 }

--- a/src/main/java/com/uctale/uctale/service/NanoBananaService.java
+++ b/src/main/java/com/uctale/uctale/service/NanoBananaService.java
@@ -2,7 +2,10 @@ package com.uctale.uctale.service;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -11,39 +14,64 @@ import java.nio.charset.StandardCharsets;
 @Service
 public class NanoBananaService {
 
+    private static final String STYLE_SUFFIX = ", rough charcoal sketch, high contrast black and white, gritty texture, white background, pencil drawing style, no colors, concept art";
+    private static final String PROVIDER_BASE_URL = "https://gen.pollinations.ai/image/";
+
+    private final RestClient restClient;
+
     @Value("${pollinations.token}")
     private String pollinationsToken;
 
-    private static final String STYLE_SUFFIX = ", rough charcoal sketch, high contrast black and white, gritty texture, white background, pencil drawing style, no colors, concept art";
-
-    public NanoBananaService() {
+    public NanoBananaService(RestClient.Builder restClientBuilder) {
+        this.restClient = restClientBuilder.build();
     }
 
     public String generateImage(String prompt, String aspectRatio) {
+        if (prompt == null || prompt.isBlank()) {
+            return null;
+        }
+
+        String encodedPrompt = URLEncoder.encode(prompt, StandardCharsets.UTF_8);
+        String encodedAspectRatio = URLEncoder.encode(normalizeAspectRatio(aspectRatio), StandardCharsets.UTF_8);
+        return "/api/game/image?prompt=" + encodedPrompt + "&aspectRatio=" + encodedAspectRatio;
+    }
+
+    public GeneratedImage fetchImage(String prompt, String aspectRatio) {
         try {
-            String fullPrompt = prompt + STYLE_SUFFIX;
+            String providerUrl = buildProviderUrl(prompt, aspectRatio);
+            ResponseEntity<byte[]> response = restClient.get()
+                    .uri(providerUrl)
+                    .retrieve()
+                    .toEntity(byte[].class);
 
-            String encodedPrompt = URLEncoder.encode(fullPrompt, StandardCharsets.UTF_8);
-
-            String sizeParam = "width=512&height=512";
-            if ("16:9".equals(aspectRatio)) {
-                sizeParam = "width=768&height=432";
+            MediaType contentType = response.getHeaders().getContentType();
+            if (contentType == null) {
+                contentType = MediaType.IMAGE_JPEG;
             }
 
-            String tokenParam = (pollinationsToken != null && !pollinationsToken.isBlank())
-                    ? "&key=" + pollinationsToken
-                    : "";
-
-            String finalUrl = String.format("https://gen.pollinations.ai/image/%s?%s&nologo=true&model=flux%s",
-                    encodedPrompt, sizeParam, tokenParam);
-
-            log.info("생성된 이미지 URL: {}", finalUrl);
-
-            return finalUrl;
-
+            return new GeneratedImage(response.getBody(), contentType);
         } catch (Exception e) {
-            log.error("이미지 URL 생성 실패: {}", e.getMessage());
+            log.error("Pollinations 이미지 생성 요청 실패: {}", e.getClass().getSimpleName());
             return null;
         }
     }
+
+    private String buildProviderUrl(String prompt, String aspectRatio) {
+        String fullPrompt = prompt + STYLE_SUFFIX;
+        String encodedPrompt = URLEncoder.encode(fullPrompt, StandardCharsets.UTF_8);
+        String sizeParam = "1:1".equals(normalizeAspectRatio(aspectRatio))
+                ? "width=512&height=512"
+                : "width=768&height=432";
+        String tokenParam = pollinationsToken == null || pollinationsToken.isBlank()
+                ? ""
+                : "&key=" + URLEncoder.encode(pollinationsToken, StandardCharsets.UTF_8);
+
+        return PROVIDER_BASE_URL + encodedPrompt + "?" + sizeParam + "&nologo=true&model=flux" + tokenParam;
+    }
+
+    private String normalizeAspectRatio(String aspectRatio) {
+        return "1:1".equals(aspectRatio) ? "1:1" : "16:9";
+    }
+
+    public record GeneratedImage(byte[] bytes, MediaType contentType) {}
 }

--- a/src/test/java/com/uctale/uctale/controller/GameControllerTest.java
+++ b/src/test/java/com/uctale/uctale/controller/GameControllerTest.java
@@ -35,20 +35,23 @@ class GameControllerTest {
 
     @BeforeEach
     void setUp() {
-        mockMvc = MockMvcBuilders.standaloneSetup(new GameController(gameService)).build();
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new GameController(gameService))
+                .setControllerAdvice(new ApiExceptionHandler())
+                .build();
         objectMapper = new ObjectMapper();
     }
 
     @Test
-    @DisplayName("게임 초기화 요청 시 GameService 응답을 그대로 반환한다")
-    void initGame_Success() throws Exception {
+    @DisplayName("게임 초기화 응답은 명시적인 sessionId를 제공하고 잘못된 캐릭터 이미지 필드를 노출하지 않는다")
+    void initGame_UsesExplicitSessionIdContract() throws Exception {
         GameInitRequest request = new GameInitRequest("좀비 아포칼립스", "김대리");
         GameResponse response = new GameResponse(
+                42L,
                 "첫날 밤",
                 "오프닝 스토리입니다.",
                 List.of(new GeminiResponse.Choice(1, "도망간다")),
-                "https://example.com/opening.png",
-                "42"
+                "/api/game/image?prompt=test&aspectRatio=16%3A9"
         );
         given(gameService.initGame(any(GameInitRequest.class))).willReturn(response);
 
@@ -56,10 +59,11 @@ class GameControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sessionId").value(42))
                 .andExpect(jsonPath("$.title").value("첫날 밤"))
                 .andExpect(jsonPath("$.storyText").value("오프닝 스토리입니다."))
-                .andExpect(jsonPath("$.mainImageUrl").value("https://example.com/opening.png"))
-                .andExpect(jsonPath("$.characterImageUrl").value("42"))
+                .andExpect(jsonPath("$.mainImageUrl").value("/api/game/image?prompt=test&aspectRatio=16%3A9"))
+                .andExpect(jsonPath("$.characterImageUrl").doesNotExist())
                 .andExpect(jsonPath("$.choices[0].id").value(1))
                 .andExpect(jsonPath("$.choices[0].text").value("도망간다"));
     }
@@ -69,11 +73,11 @@ class GameControllerTest {
     void progressGame_Success() throws Exception {
         GameProgressRequest request = new GameProgressRequest(42L, 1);
         GameResponse response = new GameResponse(
+                42L,
                 "두 번째 장면",
                 "다음 턴 스토리입니다.",
                 List.of(new GeminiResponse.Choice(2, "숨는다")),
-                "https://example.com/turn-2.png",
-                "42"
+                "/api/game/image?prompt=turn2&aspectRatio=16%3A9"
         );
         given(gameService.progressGame(any(GameProgressRequest.class))).willReturn(response);
 
@@ -81,7 +85,33 @@ class GameControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sessionId").value(42))
                 .andExpect(jsonPath("$.storyText").value("다음 턴 스토리입니다."))
                 .andExpect(jsonPath("$.choices[0].text").value("숨는다"));
+    }
+
+    @Test
+    @DisplayName("빈 세계관 설정은 400으로 거부한다")
+    void initGame_RejectsBlankWorldSetting() throws Exception {
+        GameInitRequest request = new GameInitRequest("", "김대리");
+
+        mockMvc.perform(post("/api/game/init")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("세계관 설정은 필수입니다."));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 선택지 오류는 400으로 반환한다")
+    void progressGame_MapsUnknownChoiceToBadRequest() throws Exception {
+        given(gameService.progressGame(any(GameProgressRequest.class)))
+                .willThrow(new IllegalArgumentException("존재하지 않는 선택지입니다."));
+
+        mockMvc.perform(post("/api/game/progress")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new GameProgressRequest(42L, 999))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("존재하지 않는 선택지입니다."));
     }
 }

--- a/src/test/java/com/uctale/uctale/controller/ImageControllerTest.java
+++ b/src/test/java/com/uctale/uctale/controller/ImageControllerTest.java
@@ -1,0 +1,47 @@
+package com.uctale.uctale.controller;
+
+import com.uctale.uctale.service.NanoBananaService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ImageControllerTest {
+
+    @Mock
+    private NanoBananaService nanoBananaService;
+
+    @Test
+    @DisplayName("이미지 provider 실패 시 502를 반환한다")
+    void image_ReturnsBadGatewayWhenProviderFails() {
+        ImageController controller = new ImageController(nanoBananaService);
+        given(nanoBananaService.fetchImage("zombie", "16:9")).willReturn(null);
+
+        ResponseEntity<byte[]> response = controller.image("zombie", "16:9");
+
+        assertThat(response.getStatusCode().value()).isEqualTo(502);
+        assertThat(response.getBody()).isNull();
+    }
+
+    @Test
+    @DisplayName("이미지 provider 성공 시 이미지 바이트와 콘텐츠 타입을 반환한다")
+    void image_ReturnsGeneratedImage() {
+        ImageController controller = new ImageController(nanoBananaService);
+        byte[] bytes = new byte[]{1, 2, 3};
+        given(nanoBananaService.fetchImage("zombie", "16:9"))
+                .willReturn(new NanoBananaService.GeneratedImage(bytes, MediaType.IMAGE_PNG));
+
+        ResponseEntity<byte[]> response = controller.image("zombie", "16:9");
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response.getHeaders().getContentType()).isEqualTo(MediaType.IMAGE_PNG);
+        assertThat(response.getBody()).containsExactly(bytes);
+    }
+}

--- a/src/test/java/com/uctale/uctale/service/GameServiceTest.java
+++ b/src/test/java/com/uctale/uctale/service/GameServiceTest.java
@@ -21,8 +21,10 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -54,8 +56,8 @@ class GameServiceTest {
     }
 
     @Test
-    @DisplayName("게임 초기화는 세션과 첫 로그를 저장하고 현재 API 응답 계약을 유지한다")
-    void initGame_SavesSessionAndOpeningLog() {
+    @DisplayName("게임 초기화는 명시적인 세션 ID와 첫 로그를 반환한다")
+    void initGame_ReturnsExplicitSessionId() {
         GameInitRequest request = new GameInitRequest("좀비 아포칼립스", "김대리");
         GeminiResponse opening = new GeminiResponse(
                 "첫날 밤",
@@ -65,7 +67,7 @@ class GameServiceTest {
         );
 
         given(geminiService.getOpening(request)).willReturn(opening);
-        given(nanoBananaService.generateImage(any(), any())).willReturn("https://example.com/opening.png");
+        given(nanoBananaService.generateImage(any(), any())).willReturn("/api/game/image?prompt=test&aspectRatio=16%3A9");
         given(gameSessionRepository.save(any(GameSession.class))).willAnswer(invocation -> {
             GameSession session = invocation.getArgument(0);
             ReflectionTestUtils.setField(session, "id", 42L);
@@ -74,10 +76,10 @@ class GameServiceTest {
 
         GameResponse response = gameService.initGame(request);
 
+        assertThat(response.sessionId()).isEqualTo(42L);
         assertThat(response.title()).isEqualTo("첫날 밤");
         assertThat(response.storyText()).isEqualTo("오프닝 스토리");
-        assertThat(response.mainImageUrl()).isEqualTo("https://example.com/opening.png");
-        assertThat(response.characterImageUrl()).isEqualTo("42");
+        assertThat(response.mainImageUrl()).startsWith("/api/game/image?");
         assertThat(response.choices()).extracting(GeminiResponse.Choice::text).containsExactly("도망간다");
         verify(gameSessionRepository).save(any(GameSession.class));
         verify(gameLogRepository).save(any(GameLog.class));
@@ -92,7 +94,7 @@ class GameServiceTest {
         String choicesJson = new ObjectMapper().writeValueAsString(
                 List.of(new GeminiResponse.Choice(1, "문을 잠근다"))
         );
-        GameLog lastLog = new GameLog(session, 1, "직전 스토리", choicesJson, "https://example.com/old.png");
+        GameLog lastLog = new GameLog(session, 1, "직전 스토리", choicesJson, "/api/game/image?prompt=old&aspectRatio=16%3A9");
 
         GeminiResponse nextTurn = new GeminiResponse(
                 "다음 장면",
@@ -109,9 +111,31 @@ class GameServiceTest {
         GameResponse response = gameService.progressGame(new GameProgressRequest(42L, 1));
 
         assertThat(lastLog.getUserChoice()).isEqualTo("문을 잠근다");
+        assertThat(response.sessionId()).isEqualTo(42L);
         assertThat(response.storyText()).isEqualTo("다음 스토리");
-        assertThat(response.mainImageUrl()).isEqualTo("https://example.com/old.png");
+        assertThat(response.mainImageUrl()).isEqualTo("/api/game/image?prompt=old&aspectRatio=16%3A9");
         verify(geminiService).getNextTurn("좀비 아포칼립스", "김대리", "직전 스토리", "문을 잠근다");
         verify(gameLogRepository).save(any(GameLog.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 선택지는 다음 스토리를 생성하지 않고 실패한다")
+    void progressGame_RejectsUnknownChoice() throws Exception {
+        GameSession session = new GameSession("좀비 아포칼립스", "김대리");
+        ReflectionTestUtils.setField(session, "id", 42L);
+        String choicesJson = new ObjectMapper().writeValueAsString(
+                List.of(new GeminiResponse.Choice(1, "문을 잠근다"))
+        );
+        GameLog lastLog = new GameLog(session, 1, "직전 스토리", choicesJson, null);
+
+        given(gameSessionRepository.findById(42L)).willReturn(Optional.of(session));
+        given(gameLogRepository.findTopByGameSessionOrderByTurnNumberDesc(session)).willReturn(Optional.of(lastLog));
+
+        assertThatThrownBy(() -> gameService.progressGame(new GameProgressRequest(42L, 999)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 선택지입니다.");
+
+        verify(geminiService, never()).getNextTurn(any(), any(), any(), any());
+        verify(gameLogRepository, never()).save(any(GameLog.class));
     }
 }

--- a/src/test/java/com/uctale/uctale/service/NanoBananaServiceTest.java
+++ b/src/test/java/com/uctale/uctale/service/NanoBananaServiceTest.java
@@ -1,43 +1,47 @@
 package com.uctale.uctale.service;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
-@TestPropertySource(properties = {
-        "pollinations.token=TEST_TOKEN",
-        "game.access.password=TEST_PASSWORD"
-})
 class NanoBananaServiceTest {
 
-    @Autowired
     private NanoBananaService nanoBananaService;
 
-    @Test
-    @DisplayName("이미지 생성 요청 시 현재 Pollinations URL 형식을 반환해야 한다")
-    void generateImage_Success() {
-        String resultUrl = nanoBananaService.generateImage("zombie", "16:9");
-
-        assertThat(resultUrl).startsWith("https://gen.pollinations.ai/image/");
-        assertThat(resultUrl).contains("zombie");
-        assertThat(resultUrl).contains("width=768");
-        assertThat(resultUrl).contains("height=432");
-        assertThat(resultUrl).contains("charcoal");
-        assertThat(resultUrl).contains("model=flux");
-        assertThat(resultUrl).contains("key=TEST_TOKEN");
+    @BeforeEach
+    void setUp() {
+        nanoBananaService = new NanoBananaService(RestClient.builder());
+        ReflectionTestUtils.setField(nanoBananaService, "pollinationsToken", "TEST_SECRET_TOKEN");
     }
 
     @Test
-    @DisplayName("기본 비율 요청 시 512x512 해상도를 반환해야 한다")
-    void generateImage_DefaultRatio() {
-        String resultUrl = nanoBananaService.generateImage("test", "1:1");
+    @DisplayName("게임 응답용 이미지 경로에는 Pollinations 토큰이 포함되지 않는다")
+    void generateImage_DoesNotExposeProviderToken() {
+        String resultUrl = nanoBananaService.generateImage("zombie in dark street", "16:9");
 
-        assertThat(resultUrl).contains("width=512");
-        assertThat(resultUrl).contains("height=512");
+        assertThat(resultUrl).startsWith("/api/game/image?");
+        assertThat(resultUrl).contains("prompt=zombie+in+dark+street");
+        assertThat(resultUrl).contains("aspectRatio=16%3A9");
+        assertThat(resultUrl).doesNotContain("TEST_SECRET_TOKEN");
+        assertThat(resultUrl).doesNotContain("key=");
+        assertThat(resultUrl).doesNotContain("pollinations.ai");
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 비율은 16대9 프록시 경로로 정규화한다")
+    void generateImage_NormalizesAspectRatio() {
+        String resultUrl = nanoBananaService.generateImage("test", "unknown");
+
+        assertThat(resultUrl).contains("aspectRatio=16%3A9");
+    }
+
+    @Test
+    @DisplayName("빈 프롬프트는 이미지 생성을 요청하지 않는다")
+    void generateImage_BlankPrompt() {
+        assertThat(nanoBananaService.generateImage(" ", "16:9")).isNull();
     }
 }


### PR DESCRIPTION
## 변경 이유

게임 응답에서 `characterImageUrl`이 실제 캐릭터 이미지가 아니라 세션 ID로 사용되고 있었고, Pollinations token이 브라우저에 전달되는 이미지 URL과 서버 로그에 포함될 수 있었습니다. 또한 잘못된 선택지 ID가 정상 게임 진행으로 처리되는 문제가 있었습니다.

## 변경 내용

- `GameResponse.sessionId`를 명시적인 숫자 필드로 추가
- 실제 용도가 없던 `characterImageUrl` 제거
- frontend에서 `gameData.sessionId` 사용
- backend가 반환한 내부 이미지 경로를 frontend에서 API 서버 기준 URL로 해석
- Pollinations token을 backend 내부 provider 호출에서만 사용
- 브라우저에는 `/api/game/image` 프록시 경로만 노출
- Pollinations secret이 포함된 provider URL 전체 로그 제거
- 이미지 provider 실패 시 프록시가 502를 반환하도록 처리
- `@Valid`를 게임 요청 DTO에 적용
- 세션 ID/선택지 ID 기본 검증 추가
- 존재하지 않는 선택지는 400으로 반환하고 Gemini 다음 턴 호출을 차단
- API 계약, 선택지 오류, 이미지 secret 비노출 테스트 보강

## 검증

GitHub Actions에서 다음 필수 체크를 확인합니다.

- `Backend test and build`
- `Frontend lint and build`

## 보안 / 게임 상태

- provider credential은 client-visible URL에 포함하지 않습니다.
- 잘못된 선택지 요청은 게임 상태를 진행시키거나 LLM 호출을 발생시키지 않습니다.
- 이미지 생성 사실은 서버가 중계하며, provider 세부 구현은 client API 계약에서 분리합니다.

Resolves #3