### PR TITLE
refactor(game): GameState와 Story Memory 기반 마련

### DIFF
--- a/docs/architecture/game-state-story-memory.md
+++ b/docs/architecture/game-state-story-memory.md
@@ -1,0 +1,78 @@
+# UCTale V2 GameState / Story Memory
+
+## 목표
+
+UCTale의 결정적 게임 상태는 서버가 소유하고, LLM은 그 상태를 서사로 표현하는 Narrative Engine으로만 동작한다.
+
+## canonical GameState
+
+`GameState`는 한 세션의 복원 가능한 현재 상태다.
+
+- `turnNumber`: 현재 적용된 턴 번호
+- `PlayerCharacter`: 플레이어의 서버 소유 상태. #7부터 stats를 확장한다.
+- `WorldState`: 세계의 서버 소유 상태와 flags 확장 지점
+- `StoryMemory`: 장기 서사를 위한 제한된 내러티브 문맥
+
+운영 DB에는 `game_state_snapshot`에 JSON 스냅샷으로 저장한다. `game_session`과 `game_log`는 세션/턴 무결성과 원장 역할을 계속 담당한다.
+
+## Story Memory
+
+Story Memory는 세 계층으로 구분한다.
+
+1. `canonicalFacts`
+   - 서버가 진실로 승인한 장기 사실
+   - 현재는 최초 세계관과 플레이어 설정으로 시작한다.
+   - 향후 Game Engine의 검증된 command/proposal만 변경할 수 있다.
+2. `rollingSummary`
+   - 최근 문맥에서 밀려난 오래된 턴의 압축 기록
+   - 현재는 별도 AI 호출 없이 서버가 결정적으로 누적한다.
+   - 최대 4,000자로 제한한다.
+3. `recentTurns`
+   - 가장 최근 6턴
+   - 플레이어 행동과 결과 본문만 보관한다.
+
+Narrative Engine에는 전체 `game_log` 대신 위 세 계층과 이번 플레이어 행동을 전달한다.
+
+## 메모리 우선순위
+
+충돌 시 다음 순서를 따른다.
+
+`canonicalFacts > rollingSummary > recentTurns > LLM 생성 내용`
+
+LLM 응답 자체는 canonical state 변경 권한이 없다.
+
+## 턴 처리 흐름
+
+1. `expectedTurn`으로 현재 세션과 `GameState.turnNumber`를 검증한다.
+2. 선택지 ID를 서버가 기존 choices에서 실제 행동 문자열로 해석한다.
+3. `GameState`에서 `NarrativeContext`를 구성한다.
+4. Narrative Engine이 이야기와 다음 선택지만 생성한다.
+5. 서버가 다음 `GameState`를 결정적으로 구성한다.
+6. `game_log`, `game_session`, `game_state_snapshot`을 같은 transaction에서 저장한다.
+7. 낙관적 잠금/unique constraint 충돌 시 전체 저장을 롤백한다.
+
+## 기존 세션 호환성
+
+V2 snapshot 도입 전 생성된 세션은 `game_state_snapshot`이 없을 수 있다. 이 경우 저장된 `game_log`를 턴 순서로 replay하여 최소 GameState를 복구한다. 다음 정상 저장부터 snapshot이 생성된다.
+
+## 향후 확장
+
+#7 이후 다음 상태는 `GameState` 내부에서 확장한다.
+
+- 캐릭터 stats와 deterministic Skill Check
+- inventory / equipment
+- HP / status effects
+- combat state
+- XP / level / skills
+- quest flags
+- relationships
+
+이 기능들은 prompt 문자열이나 `GameService` 임시 필드가 아니라 서버 GameState에 구현한다.
+
+## 아직 하지 않는 것
+
+- AI가 상태 변경 command/proposal을 직접 적용하는 기능
+- 세부 전투 공식
+- 아이템 카탈로그
+- 퀘스트 콘텐츠 대량 작성
+- 복잡한 클래스/직업 트리

--- a/src/main/java/com/uctale/uctale/application/game/GamePersistenceService.java
+++ b/src/main/java/com/uctale/uctale/application/game/GamePersistenceService.java
@@ -2,22 +2,36 @@ package com.uctale.uctale.application.game;
 
 import com.uctale.uctale.domain.GameLog;
 import com.uctale.uctale.domain.GameSession;
+import com.uctale.uctale.domain.GameStateSnapshot;
+import com.uctale.uctale.domain.game.GameState;
 import com.uctale.uctale.repository.GameLogRepository;
 import com.uctale.uctale.repository.GameSessionRepository;
+import com.uctale.uctale.repository.GameStateSnapshotRepository;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 public class GamePersistenceService {
 
     private final GameSessionRepository gameSessionRepository;
     private final GameLogRepository gameLogRepository;
+    private final GameStateSnapshotRepository gameStateSnapshotRepository;
+    private final GameStateCodec gameStateCodec;
 
-    public GamePersistenceService(GameSessionRepository gameSessionRepository, GameLogRepository gameLogRepository) {
+    public GamePersistenceService(
+            GameSessionRepository gameSessionRepository,
+            GameLogRepository gameLogRepository,
+            GameStateSnapshotRepository gameStateSnapshotRepository,
+            GameStateCodec gameStateCodec
+    ) {
         this.gameSessionRepository = gameSessionRepository;
         this.gameLogRepository = gameLogRepository;
+        this.gameStateSnapshotRepository = gameStateSnapshotRepository;
+        this.gameStateCodec = gameStateCodec;
     }
 
     @Transactional
@@ -29,6 +43,8 @@ public class GamePersistenceService {
             String imageUrl
     ) {
         GameSession session = gameSessionRepository.save(new GameSession(worldSetting, characterSetting));
+        GameState initialState = GameState.initial(worldSetting, characterSetting, storyText);
+        gameStateSnapshotRepository.save(new GameStateSnapshot(session, gameStateCodec.serialize(initialState)));
         gameLogRepository.save(new GameLog(session, 1, storyText, choicesJson, imageUrl));
         return session;
     }
@@ -49,6 +65,11 @@ public class GamePersistenceService {
             throw new IllegalStateException("세션 턴과 저장된 로그가 일치하지 않습니다.");
         }
 
+        GameState gameState = loadOrRecoverState(session);
+        if (gameState.turnNumber() != expectedTurn) {
+            throw new IllegalStateException("세션 턴과 GameState가 일치하지 않습니다.");
+        }
+
         return new LoadedTurn(
                 session.getId(),
                 session.getCurrentTurn(),
@@ -56,7 +77,8 @@ public class GamePersistenceService {
                 session.getCharacterSetting(),
                 lastLog.getStoryText(),
                 lastLog.getChoicesJson(),
-                lastLog.getImageUrl()
+                lastLog.getImageUrl(),
+                gameState
         );
     }
 
@@ -84,6 +106,12 @@ public class GamePersistenceService {
                 throw new IllegalStateException("세션 턴과 저장된 로그가 일치하지 않습니다.");
             }
 
+            GameState currentState = loadOrRecoverState(session);
+            if (currentState.turnNumber() != expectedTurn) {
+                throw new IllegalStateException("세션 턴과 GameState가 일치하지 않습니다.");
+            }
+            GameState nextState = currentState.advance(userChoice, storyText);
+
             previousLog.updateUserChoice(userChoice);
             session.advanceTurn();
 
@@ -97,12 +125,42 @@ public class GamePersistenceService {
                     imageUrl
             ));
 
+            GameStateSnapshot snapshot = gameStateSnapshotRepository.findById(sessionId)
+                    .orElseGet(() -> new GameStateSnapshot(session, gameStateCodec.serialize(currentState)));
+            snapshot.updateStateJson(gameStateCodec.serialize(nextState));
+            gameStateSnapshotRepository.save(snapshot);
+
             gameLogRepository.flush();
+            gameStateSnapshotRepository.flush();
             gameSessionRepository.flush();
             return session.getCurrentTurn();
         } catch (ObjectOptimisticLockingFailureException | DataIntegrityViolationException exception) {
             throw new TurnConflictException("동시에 처리된 턴 요청과 충돌했습니다.", exception);
         }
+    }
+
+    private GameState loadOrRecoverState(GameSession session) {
+        return gameStateSnapshotRepository.findById(session.getId())
+                .map(snapshot -> gameStateCodec.deserialize(snapshot.getStateJson()))
+                .orElseGet(() -> recoverState(session));
+    }
+
+    private GameState recoverState(GameSession session) {
+        List<GameLog> logs = gameLogRepository.findByGameSessionOrderByTurnNumberAsc(session);
+        if (logs.isEmpty()) {
+            throw new IllegalStateException("GameState를 복구할 게임 로그가 없습니다.");
+        }
+
+        GameState state = GameState.initial(
+                session.getWorldSetting(),
+                session.getCharacterSetting(),
+                logs.get(0).getStoryText()
+        );
+        for (int i = 1; i < logs.size(); i++) {
+            String action = logs.get(i - 1).getUserChoice();
+            state = state.advance(action, logs.get(i).getStoryText());
+        }
+        return state;
     }
 
     public record LoadedTurn(
@@ -112,6 +170,7 @@ public class GamePersistenceService {
             String characterSetting,
             String storyText,
             String choicesJson,
-            String imageUrl
+            String imageUrl,
+            GameState gameState
     ) {}
 }

--- a/src/main/java/com/uctale/uctale/application/game/GameStateCodec.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameStateCodec.java
@@ -1,0 +1,32 @@
+package com.uctale.uctale.application.game;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.uctale.uctale.domain.game.GameState;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GameStateCodec {
+
+    private final ObjectMapper objectMapper;
+
+    public GameStateCodec(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public String serialize(GameState state) {
+        try {
+            return objectMapper.writeValueAsString(state);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("GameState 직렬화에 실패했습니다.", e);
+        }
+    }
+
+    public GameState deserialize(String json) {
+        try {
+            return objectMapper.readValue(json, GameState.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("GameState 역직렬화에 실패했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/uctale/uctale/application/narrative/NarrativeContext.java
+++ b/src/main/java/com/uctale/uctale/application/narrative/NarrativeContext.java
@@ -1,0 +1,34 @@
+package com.uctale.uctale.application.narrative;
+
+import com.uctale.uctale.domain.game.CanonicalFact;
+import com.uctale.uctale.domain.game.GameState;
+import com.uctale.uctale.domain.game.GameTurn;
+
+import java.util.List;
+
+public record NarrativeContext(
+        String worldPremise,
+        String playerDescription,
+        List<CanonicalFact> canonicalFacts,
+        String rollingSummary,
+        List<GameTurn> recentTurns,
+        String playerAction
+) {
+    public NarrativeContext {
+        canonicalFacts = canonicalFacts == null ? List.of() : List.copyOf(canonicalFacts);
+        rollingSummary = rollingSummary == null ? "" : rollingSummary;
+        recentTurns = recentTurns == null ? List.of() : List.copyOf(recentTurns);
+        playerAction = playerAction == null ? "" : playerAction;
+    }
+
+    public static NarrativeContext from(GameState state, String playerAction) {
+        return new NarrativeContext(
+                state.worldState().premise(),
+                state.playerCharacter().description(),
+                state.storyMemory().canonicalFacts(),
+                state.storyMemory().rollingSummary(),
+                state.storyMemory().recentTurns(),
+                playerAction
+        );
+    }
+}

--- a/src/main/java/com/uctale/uctale/application/narrative/NarrativeGenerator.java
+++ b/src/main/java/com/uctale/uctale/application/narrative/NarrativeGenerator.java
@@ -4,5 +4,5 @@ public interface NarrativeGenerator {
 
     NarrativeTurn createOpening(String worldSetting, String characterSetting);
 
-    NarrativeTurn createNextTurn(String worldSetting, String characterSetting, String previousStory, String userChoice);
+    NarrativeTurn createNextTurn(NarrativeContext context);
 }

--- a/src/main/java/com/uctale/uctale/domain/GameStateSnapshot.java
+++ b/src/main/java/com/uctale/uctale/domain/GameStateSnapshot.java
@@ -5,7 +5,9 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -14,6 +16,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 @Entity
+@Table(name = "game_state_snapshot")
 @Getter
 @NoArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
@@ -23,8 +26,9 @@ public class GameStateSnapshot {
     @Column(name = "session_id")
     private Long sessionId;
 
+    @MapsId
     @OneToOne(optional = false)
-    @JoinColumn(name = "session_id", insertable = false, updatable = false)
+    @JoinColumn(name = "session_id")
     private GameSession gameSession;
 
     @Column(name = "state_json", nullable = false, columnDefinition = "text")
@@ -35,7 +39,6 @@ public class GameStateSnapshot {
     private LocalDateTime updatedAt;
 
     public GameStateSnapshot(GameSession gameSession, String stateJson) {
-        this.sessionId = gameSession.getId();
         this.gameSession = gameSession;
         this.stateJson = stateJson;
     }

--- a/src/main/java/com/uctale/uctale/domain/GameStateSnapshot.java
+++ b/src/main/java/com/uctale/uctale/domain/GameStateSnapshot.java
@@ -1,0 +1,46 @@
+package com.uctale.uctale.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class GameStateSnapshot {
+
+    @Id
+    @Column(name = "session_id")
+    private Long sessionId;
+
+    @OneToOne(optional = false)
+    @JoinColumn(name = "session_id", insertable = false, updatable = false)
+    private GameSession gameSession;
+
+    @Column(name = "state_json", nullable = false, columnDefinition = "text")
+    private String stateJson;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public GameStateSnapshot(GameSession gameSession, String stateJson) {
+        this.sessionId = gameSession.getId();
+        this.gameSession = gameSession;
+        this.stateJson = stateJson;
+    }
+
+    public void updateStateJson(String stateJson) {
+        this.stateJson = stateJson;
+    }
+}

--- a/src/main/java/com/uctale/uctale/domain/game/CanonicalFact.java
+++ b/src/main/java/com/uctale/uctale/domain/game/CanonicalFact.java
@@ -1,0 +1,19 @@
+package com.uctale.uctale.domain.game;
+
+import java.util.Objects;
+
+public record CanonicalFact(String key, String value) {
+
+    public CanonicalFact {
+        if (key == null || key.isBlank()) {
+            throw new IllegalArgumentException("canonical fact key는 비어 있을 수 없습니다.");
+        }
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("canonical fact value는 비어 있을 수 없습니다.");
+        }
+        key = key.trim();
+        value = value.trim();
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(value);
+    }
+}

--- a/src/main/java/com/uctale/uctale/domain/game/GameState.java
+++ b/src/main/java/com/uctale/uctale/domain/game/GameState.java
@@ -1,0 +1,36 @@
+package com.uctale.uctale.domain.game;
+
+public record GameState(
+        int turnNumber,
+        PlayerCharacter playerCharacter,
+        WorldState worldState,
+        StoryMemory storyMemory
+) {
+    public GameState {
+        if (turnNumber < 1) {
+            throw new IllegalArgumentException("turnNumber는 1 이상이어야 합니다.");
+        }
+        if (playerCharacter == null || worldState == null || storyMemory == null) {
+            throw new IllegalArgumentException("GameState 구성 요소는 null일 수 없습니다.");
+        }
+    }
+
+    public static GameState initial(String worldSetting, String characterSetting, String openingStory) {
+        return new GameState(
+                1,
+                PlayerCharacter.initial(characterSetting),
+                WorldState.initial(worldSetting),
+                StoryMemory.initial(worldSetting, characterSetting, openingStory)
+        );
+    }
+
+    public GameState advance(String playerAction, String storyText) {
+        int nextTurn = turnNumber + 1;
+        return new GameState(
+                nextTurn,
+                playerCharacter,
+                worldState,
+                storyMemory.append(new GameTurn(nextTurn, playerAction, storyText))
+        );
+    }
+}

--- a/src/main/java/com/uctale/uctale/domain/game/GameTurn.java
+++ b/src/main/java/com/uctale/uctale/domain/game/GameTurn.java
@@ -1,0 +1,19 @@
+package com.uctale.uctale.domain.game;
+
+public record GameTurn(
+        int turnNumber,
+        String playerAction,
+        String storyText
+) {
+    public GameTurn {
+        if (turnNumber < 1) {
+            throw new IllegalArgumentException("turnNumber는 1 이상이어야 합니다.");
+        }
+        playerAction = playerAction == null ? "" : playerAction.trim();
+        storyText = storyText == null ? "" : storyText.trim();
+    }
+
+    public static GameTurn opening(String storyText) {
+        return new GameTurn(1, "", storyText);
+    }
+}

--- a/src/main/java/com/uctale/uctale/domain/game/PlayerCharacter.java
+++ b/src/main/java/com/uctale/uctale/domain/game/PlayerCharacter.java
@@ -1,0 +1,17 @@
+package com.uctale.uctale.domain.game;
+
+import java.util.Map;
+
+public record PlayerCharacter(
+        String description,
+        Map<String, Integer> stats
+) {
+    public PlayerCharacter {
+        description = description == null ? "" : description.trim();
+        stats = stats == null ? Map.of() : Map.copyOf(stats);
+    }
+
+    public static PlayerCharacter initial(String characterSetting) {
+        return new PlayerCharacter(characterSetting, Map.of());
+    }
+}

--- a/src/main/java/com/uctale/uctale/domain/game/StoryMemory.java
+++ b/src/main/java/com/uctale/uctale/domain/game/StoryMemory.java
@@ -1,0 +1,55 @@
+package com.uctale.uctale.domain.game;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public record StoryMemory(
+        List<CanonicalFact> canonicalFacts,
+        String rollingSummary,
+        List<GameTurn> recentTurns
+) {
+    public static final int RECENT_TURN_LIMIT = 6;
+    private static final int SUMMARY_LIMIT = 4000;
+
+    public StoryMemory {
+        canonicalFacts = canonicalFacts == null ? List.of() : List.copyOf(canonicalFacts);
+        rollingSummary = rollingSummary == null ? "" : rollingSummary.trim();
+        recentTurns = recentTurns == null ? List.of() : List.copyOf(recentTurns);
+    }
+
+    public static StoryMemory initial(String worldSetting, String characterSetting, String openingStory) {
+        return new StoryMemory(
+                List.of(
+                        new CanonicalFact("world.premise", worldSetting),
+                        new CanonicalFact("player.description", characterSetting)
+                ),
+                "",
+                List.of(GameTurn.opening(openingStory))
+        );
+    }
+
+    public StoryMemory append(GameTurn turn) {
+        List<GameTurn> turns = new ArrayList<>(recentTurns);
+        turns.add(turn);
+        String summary = rollingSummary;
+
+        while (turns.size() > RECENT_TURN_LIMIT) {
+            GameTurn removed = turns.remove(0);
+            summary = appendSummary(summary, removed);
+        }
+        return new StoryMemory(canonicalFacts, summary, turns);
+    }
+
+    private static String appendSummary(String current, GameTurn turn) {
+        String entry = "T%d: %s%s".formatted(
+                turn.turnNumber(),
+                turn.playerAction().isBlank() ? "" : turn.playerAction() + " -> ",
+                turn.storyText()
+        );
+        String combined = current.isBlank() ? entry : current + "\n" + entry;
+        if (combined.length() <= SUMMARY_LIMIT) {
+            return combined;
+        }
+        return combined.substring(combined.length() - SUMMARY_LIMIT);
+    }
+}

--- a/src/main/java/com/uctale/uctale/domain/game/WorldState.java
+++ b/src/main/java/com/uctale/uctale/domain/game/WorldState.java
@@ -1,0 +1,17 @@
+package com.uctale.uctale.domain.game;
+
+import java.util.Map;
+
+public record WorldState(
+        String premise,
+        Map<String, String> flags
+) {
+    public WorldState {
+        premise = premise == null ? "" : premise.trim();
+        flags = flags == null ? Map.of() : Map.copyOf(flags);
+    }
+
+    public static WorldState initial(String worldSetting) {
+        return new WorldState(worldSetting, Map.of());
+    }
+}

--- a/src/main/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapter.java
+++ b/src/main/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapter.java
@@ -3,6 +3,7 @@ package com.uctale.uctale.provider.gemini;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.uctale.uctale.application.narrative.NarrativeContext;
 import com.uctale.uctale.application.narrative.NarrativeGenerator;
 import com.uctale.uctale.application.narrative.NarrativeTurn;
 import lombok.extern.slf4j.Slf4j;
@@ -21,16 +22,18 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
 
     private static final String GEMINI_API_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent";
     private static final String SYSTEM_INSTRUCTION = """
-            당신은 텍스트 어드벤처 게임 마스터(GM)입니다.
-            사용자가 입력한 [세계관]과 [캐릭터] 설정을 절대적인 진실로 받아들이고, 이를 바탕으로 일관성 있는 스토리를 진행하세요.
+            당신은 UCTale의 Narrative Engine입니다.
+            게임의 결정적 상태와 사실은 서버가 소유하며, 당신은 전달받은 상태를 바탕으로 서사를 표현합니다.
 
             [핵심 원칙]
-            1. **세계관 준수:** 현실/판타지/SF 등 사용자가 설정한 장르를 엄격히 따르십시오.
-            2. **개연성:** 사건은 인과관계에 맞게 발생해야 합니다.
+            1. **캐논 우선:** [캐논 사실]과 [현재 게임 상태]에 반하는 내용을 진실로 확정하지 마십시오.
+            2. **상태 비소유:** 능력치, 아이템, 생사, 위치 등 결정적 게임 상태를 임의로 변경했다고 확정하지 마십시오.
+            3. **개연성:** 사건은 전달받은 과거 문맥과 사용자 행동에 맞는 인과관계를 가져야 합니다.
+            4. **메모리 우선순위:** 캐논 사실 > 누적 요약 > 최근 턴 순으로 충돌을 해결하십시오.
 
             [시각적 요소(visual_assets) 작성 규칙 - 매우 중요]
             1. **이미지 생성 판단:** 직전 턴과 비교하여 **시각적으로 명확한 변화**가 있을 때만 작성하세요.
-               - (O) 장소 이동, 새로운 적/NPC 등장, 중요한 아이템 획득
+               - (O) 장소 이동, 새로운 적/NPC 등장, 중요한 아이템 등장
                - (X) 단순 대화, 생각, 시각적 변화가 없는 행동
             2. **변화가 없다면:** `background`, `characters`, `assets` 모든 필드를 비워두세요 (빈 문자열 "" 또는 빈 리스트 []).
             3. **작성 내용:**
@@ -84,17 +87,36 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
     }
 
     @Override
-    public NarrativeTurn createNextTurn(String worldSetting, String characterSetting, String previousStory, String userChoice) {
+    public NarrativeTurn createNextTurn(NarrativeContext context) {
         try {
             String prompt = String.format("""
-                    [세계관]: %s
-                    [캐릭터]: %s
-                    [직전 상황]: %s
-                    [사용자 행동]: %s
+                    [현재 게임 상태]
+                    세계관: %s
+                    플레이어: %s
 
-                    1. 행동에 대한 결과를 서술하고 다음 상황을 제시하세요.
-                    2. 시각적 변화가 없다면 visual_assets를 비워두어 불필요한 이미지 생성을 막으세요.
-                    """, worldSetting, characterSetting, previousStory, userChoice);
+                    [캐논 사실]
+                    %s
+
+                    [누적 요약]
+                    %s
+
+                    [최근 턴]
+                    %s
+
+                    [이번 사용자 행동]
+                    %s
+
+                    행동의 결과와 다음 상황을 서술하세요.
+                    서버가 전달하지 않은 결정적 상태 변화는 임의로 확정하지 마세요.
+                    시각적 변화가 없다면 visual_assets를 비워두세요.
+                    """,
+                    context.worldPremise(),
+                    context.playerDescription(),
+                    objectMapper.writeValueAsString(context.canonicalFacts()),
+                    context.rollingSummary().isBlank() ? "(없음)" : context.rollingSummary(),
+                    objectMapper.writeValueAsString(context.recentTurns()),
+                    context.playerAction()
+            );
             return generate(prompt, "Gemini API Progress Error");
         } catch (Exception e) {
             log.error("Gemini 다음 턴 생성 실패: {}", e.getClass().getSimpleName());

--- a/src/main/java/com/uctale/uctale/repository/GameLogRepository.java
+++ b/src/main/java/com/uctale/uctale/repository/GameLogRepository.java
@@ -4,8 +4,11 @@ import com.uctale.uctale.domain.GameLog;
 import com.uctale.uctale.domain.GameSession;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface GameLogRepository extends JpaRepository<GameLog, Long> {
     Optional<GameLog> findTopByGameSessionOrderByTurnNumberDesc(GameSession gameSession);
+
+    List<GameLog> findByGameSessionOrderByTurnNumberAsc(GameSession gameSession);
 }

--- a/src/main/java/com/uctale/uctale/repository/GameStateSnapshotRepository.java
+++ b/src/main/java/com/uctale/uctale/repository/GameStateSnapshotRepository.java
@@ -1,0 +1,7 @@
+package com.uctale.uctale.repository;
+
+import com.uctale.uctale.domain.GameStateSnapshot;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GameStateSnapshotRepository extends JpaRepository<GameStateSnapshot, Long> {
+}

--- a/src/main/java/com/uctale/uctale/service/GameService.java
+++ b/src/main/java/com/uctale/uctale/service/GameService.java
@@ -4,6 +4,7 @@ import com.uctale.uctale.application.game.ChoiceCodec;
 import com.uctale.uctale.application.game.GamePersistenceService;
 import com.uctale.uctale.application.game.ImagePromptComposer;
 import com.uctale.uctale.application.image.ImageGenerator;
+import com.uctale.uctale.application.narrative.NarrativeContext;
 import com.uctale.uctale.application.narrative.NarrativeGenerator;
 import com.uctale.uctale.application.narrative.NarrativeTurn;
 import com.uctale.uctale.dto.GameChoice;
@@ -55,12 +56,8 @@ public class GameService {
         );
 
         String userChoiceText = choiceCodec.findText(loadedTurn.choicesJson(), request.choiceId());
-        NarrativeTurn nextTurn = narrativeGenerator.createNextTurn(
-                loadedTurn.worldSetting(),
-                loadedTurn.characterSetting(),
-                loadedTurn.storyText(),
-                userChoiceText
-        );
+        NarrativeContext narrativeContext = NarrativeContext.from(loadedTurn.gameState(), userChoiceText);
+        NarrativeTurn nextTurn = narrativeGenerator.createNextTurn(narrativeContext);
         List<GameChoice> choices = toGameChoices(nextTurn.choices());
 
         String imageUrl = loadedTurn.imageUrl();

--- a/src/main/resources/db/migration/V2__create_game_state_snapshot.sql
+++ b/src/main/resources/db/migration/V2__create_game_state_snapshot.sql
@@ -1,0 +1,7 @@
+create table game_state_snapshot (
+    session_id bigint primary key,
+    state_json text not null,
+    updated_at timestamp,
+    constraint fk_game_state_snapshot_session
+        foreign key (session_id) references game_session(id) on delete cascade
+);

--- a/src/test/java/com/uctale/uctale/application/game/GamePersistenceServiceTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/GamePersistenceServiceTest.java
@@ -3,6 +3,7 @@ package com.uctale.uctale.application.game;
 import com.uctale.uctale.domain.GameSession;
 import com.uctale.uctale.repository.GameLogRepository;
 import com.uctale.uctale.repository.GameSessionRepository;
+import com.uctale.uctale.repository.GameStateSnapshotRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,10 +20,11 @@ class GamePersistenceServiceTest {
     @Autowired private GamePersistenceService gamePersistenceService;
     @Autowired private GameSessionRepository gameSessionRepository;
     @Autowired private GameLogRepository gameLogRepository;
+    @Autowired private GameStateSnapshotRepository gameStateSnapshotRepository;
 
     @Test
-    @DisplayName("턴 저장 후 동일 expectedTurn 재요청은 거부한다")
-    void saveNextTurn_RejectsStaleRetry() {
+    @DisplayName("턴 저장 후 동일 expectedTurn 재요청은 거부하고 GameState도 함께 진행한다")
+    void saveNextTurn_RejectsStaleRetryAndAdvancesState() {
         GameSession session = gamePersistenceService.saveOpening(
                 "세계관",
                 "캐릭터",
@@ -42,10 +44,44 @@ class GamePersistenceServiceTest {
 
         assertThat(savedTurn).isEqualTo(2);
         assertThat(gameLogRepository.count()).isEqualTo(2);
+        assertThat(gameStateSnapshotRepository.findById(session.getId())).isPresent();
         assertThat(gameSessionRepository.findById(session.getId()).orElseThrow().getCurrentTurn()).isEqualTo(2);
+
+        GamePersistenceService.LoadedTurn loaded = gamePersistenceService.loadLatestTurn(session.getId(), 2);
+        assertThat(loaded.gameState().turnNumber()).isEqualTo(2);
+        assertThat(loaded.gameState().storyMemory().recentTurns()).hasSize(2);
+        assertThat(loaded.gameState().storyMemory().recentTurns().get(1).playerAction()).isEqualTo("진행");
 
         assertThatThrownBy(() -> gamePersistenceService.loadLatestTurn(session.getId(), 1))
                 .isInstanceOf(TurnConflictException.class);
+    }
+
+    @Test
+    @DisplayName("스냅샷이 없는 기존 세션은 저장된 로그에서 GameState를 복구한다")
+    void loadLatestTurn_RecoversLegacySessionWithoutSnapshot() {
+        GameSession session = gamePersistenceService.saveOpening(
+                "세계관",
+                "캐릭터",
+                "첫 이야기",
+                "[]",
+                "/image"
+        );
+        gamePersistenceService.saveNextTurn(
+                session.getId(),
+                1,
+                "진행",
+                "두 번째 이야기",
+                "[]",
+                "/image"
+        );
+        gameStateSnapshotRepository.deleteById(session.getId());
+        gameStateSnapshotRepository.flush();
+
+        GamePersistenceService.LoadedTurn loaded = gamePersistenceService.loadLatestTurn(session.getId(), 2);
+
+        assertThat(loaded.gameState().turnNumber()).isEqualTo(2);
+        assertThat(loaded.gameState().storyMemory().recentTurns()).hasSize(2);
+        assertThat(loaded.gameState().storyMemory().recentTurns().get(1).playerAction()).isEqualTo("진행");
     }
 
     @Test
@@ -65,5 +101,6 @@ class GamePersistenceServiceTest {
         assertThat(loaded.turnNumber()).isEqualTo(1);
         assertThat(loaded.storyText()).isEqualTo("첫 이야기");
         assertThat(loaded.imageUrl()).isEqualTo("/image");
+        assertThat(loaded.gameState().storyMemory().canonicalFacts()).hasSize(2);
     }
 }

--- a/src/test/java/com/uctale/uctale/domain/game/StoryMemoryTest.java
+++ b/src/test/java/com/uctale/uctale/domain/game/StoryMemoryTest.java
@@ -1,0 +1,27 @@
+package com.uctale.uctale.domain.game;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StoryMemoryTest {
+
+    @Test
+    @DisplayName("최근 턴은 6개만 유지하고 오래된 턴은 rolling summary로 이동한다")
+    void append_KeepsSixRecentTurnsAndRollsOlderTurnIntoSummary() {
+        GameState state = GameState.initial("세계관", "캐릭터", "1턴");
+
+        for (int turn = 2; turn <= 8; turn++) {
+            state = state.advance("행동 " + turn, turn + "턴");
+        }
+
+        StoryMemory memory = state.storyMemory();
+        assertThat(memory.recentTurns()).hasSize(StoryMemory.RECENT_TURN_LIMIT);
+        assertThat(memory.recentTurns()).extracting(GameTurn::turnNumber)
+                .containsExactly(3, 4, 5, 6, 7, 8);
+        assertThat(memory.rollingSummary()).contains("T1: 1턴");
+        assertThat(memory.rollingSummary()).contains("T2: 행동 2 -> 2턴");
+        assertThat(memory.canonicalFacts()).hasSize(2);
+    }
+}

--- a/src/test/java/com/uctale/uctale/service/GameServiceTest.java
+++ b/src/test/java/com/uctale/uctale/service/GameServiceTest.java
@@ -6,9 +6,11 @@ import com.uctale.uctale.application.game.GamePersistenceService;
 import com.uctale.uctale.application.game.ImagePromptComposer;
 import com.uctale.uctale.application.game.TurnConflictException;
 import com.uctale.uctale.application.image.ImageGenerator;
+import com.uctale.uctale.application.narrative.NarrativeContext;
 import com.uctale.uctale.application.narrative.NarrativeGenerator;
 import com.uctale.uctale.application.narrative.NarrativeTurn;
 import com.uctale.uctale.domain.GameSession;
+import com.uctale.uctale.domain.game.GameState;
 import com.uctale.uctale.dto.GameChoice;
 import com.uctale.uctale.dto.GameInitRequest;
 import com.uctale.uctale.dto.GameProgressRequest;
@@ -17,6 +19,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -79,8 +82,8 @@ class GameServiceTest {
     }
 
     @Test
-    @DisplayName("게임 진행은 기대 턴을 검증하고 다음 턴을 저장한다")
-    void progressGame_UsesExpectedTurn() {
+    @DisplayName("게임 진행은 GameState에서 Narrative Context를 구성한다")
+    void progressGame_UsesCanonicalGameState() {
         String choicesJson = choiceCodec.serialize(List.of(new GameChoice(1, "문을 잠근다")));
         GamePersistenceService.LoadedTurn loadedTurn = loadedTurn(choicesJson);
         NarrativeTurn nextTurn = new NarrativeTurn(
@@ -91,9 +94,7 @@ class GameServiceTest {
         );
 
         given(gamePersistenceService.loadLatestTurn(42L, 1)).willReturn(loadedTurn);
-        given(narrativeGenerator.createNextTurn(
-                "좀비 아포칼립스", "김대리", "직전 스토리", "문을 잠근다"
-        )).willReturn(nextTurn);
+        given(narrativeGenerator.createNextTurn(any(NarrativeContext.class))).willReturn(nextTurn);
         given(gamePersistenceService.saveNextTurn(
                 42L,
                 1,
@@ -106,15 +107,14 @@ class GameServiceTest {
         GameResponse response = gameService.progressGame(new GameProgressRequest(42L, 1, 1));
 
         assertThat(response.turnNumber()).isEqualTo(2);
-        assertThat(response.storyText()).isEqualTo("다음 스토리");
-        verify(gamePersistenceService).saveNextTurn(
-                42L,
-                1,
-                "문을 잠근다",
-                "다음 스토리",
-                "[{\"id\":1,\"text\":\"기다린다\"}]",
-                "/api/game/image?prompt=old&aspectRatio=16%3A9"
-        );
+        ArgumentCaptor<NarrativeContext> contextCaptor = ArgumentCaptor.forClass(NarrativeContext.class);
+        verify(narrativeGenerator).createNextTurn(contextCaptor.capture());
+        NarrativeContext context = contextCaptor.getValue();
+        assertThat(context.worldPremise()).isEqualTo("좀비 아포칼립스");
+        assertThat(context.playerDescription()).isEqualTo("김대리");
+        assertThat(context.playerAction()).isEqualTo("문을 잠근다");
+        assertThat(context.canonicalFacts()).hasSize(2);
+        assertThat(context.recentTurns()).hasSize(1);
     }
 
     @Test
@@ -126,7 +126,7 @@ class GameServiceTest {
         assertThatThrownBy(() -> gameService.progressGame(new GameProgressRequest(42L, 1, 1)))
                 .isInstanceOf(TurnConflictException.class);
 
-        verify(narrativeGenerator, never()).createNextTurn(any(), any(), any(), any());
+        verify(narrativeGenerator, never()).createNextTurn(any(NarrativeContext.class));
         verify(gamePersistenceService, never()).saveNextTurn(any(), anyInt(), any(), any(), any(), any());
     }
 
@@ -135,9 +135,8 @@ class GameServiceTest {
     void progressGame_DoesNotPersistWhenNarrativeFails() {
         String choicesJson = choiceCodec.serialize(List.of(new GameChoice(1, "문을 잠근다")));
         given(gamePersistenceService.loadLatestTurn(42L, 1)).willReturn(loadedTurn(choicesJson));
-        given(narrativeGenerator.createNextTurn(
-                "좀비 아포칼립스", "김대리", "직전 스토리", "문을 잠근다"
-        )).willThrow(new RuntimeException("AI 호출 실패"));
+        given(narrativeGenerator.createNextTurn(any(NarrativeContext.class)))
+                .willThrow(new RuntimeException("AI 호출 실패"));
 
         assertThatThrownBy(() -> gameService.progressGame(new GameProgressRequest(42L, 1, 1)))
                 .isInstanceOf(RuntimeException.class)
@@ -154,7 +153,8 @@ class GameServiceTest {
                 "김대리",
                 "직전 스토리",
                 choicesJson,
-                "/api/game/image?prompt=old&aspectRatio=16%3A9"
+                "/api/game/image?prompt=old&aspectRatio=16%3A9",
+                GameState.initial("좀비 아포칼립스", "김대리", "직전 스토리")
         );
     }
 }


### PR DESCRIPTION
## 변경 이유

UCTale의 결정적 상태를 서버가 소유하고, Gemini는 그 상태를 서사로 표현하는 Narrative Engine으로 제한하기 위한 기반을 마련합니다.

## 변경 내용

- `PlayerCharacter`, `WorldState`, `GameTurn`, `StoryMemory`, `GameState` 도메인 모델 추가
- 세션별 `game_state_snapshot` 영속화 및 Flyway V2 migration 추가
- canonical facts + rolling summary + 최근 6턴 정책 도입
- 기존 세션은 `game_log`에서 GameState 복구 지원
- Narrative Engine 입력을 `NarrativeContext`로 분리
- Gemini가 결정적 상태를 임의 확정하지 않도록 시스템 지침 강화
- GameState/Story Memory 설계 문서 추가
- 스냅샷 저장·복구 및 메모리 롤링 테스트 추가

## 검증

- [x] `Backend test and build`
- [x] `Frontend lint and build`

Resolves #6