### PR TITLE
chore(vercel): 프론트 변경에만 프로덕션 배포

### DIFF
--- a/.github/workflows/vercel-production.yml
+++ b/.github/workflows/vercel-production.yml
@@ -19,6 +19,7 @@ jobs:
     name: Deploy frontend to Vercel
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    environment: production
     defaults:
       run:
         working-directory: frontend

--- a/.github/workflows/vercel-production.yml
+++ b/.github/workflows/vercel-production.yml
@@ -28,23 +28,34 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '22'
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
-      - name: Install dependencies
+      - name: Install frontend dependencies
         run: npm ci
 
+      - name: Install pinned Vercel CLI
+        run: npm install --global vercel@59.5.0
+
       - name: Pull Vercel production settings
-        run: npx vercel@latest pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=production
 
       - name: Build frontend
-        run: npx vercel@latest build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: vercel build --prod
 
       - name: Deploy frontend to production
-        run: npx vercel@latest deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: vercel deploy --prebuilt --prod

--- a/.github/workflows/vercel-production.yml
+++ b/.github/workflows/vercel-production.yml
@@ -1,0 +1,50 @@
+name: Vercel Production
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/vercel-production.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: vercel-production
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy frontend to Vercel
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: frontend
+    env:
+      VERCEL_ORG_ID: team_AZeQdHarbvM8rt8bXC3JfkPy
+      VERCEL_PROJECT_ID: prj_VLiMAOC7vmahUHpeo4Eu0I3RX3cw
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Pull Vercel production settings
+        run: npx vercel@latest pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build frontend
+        run: npx vercel@latest build --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy frontend to production
+        run: npx vercel@latest deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": false
+  }
+}


### PR DESCRIPTION
## 변경 이유

백엔드 중심 작업과 PR 커밋마다 Vercel Preview/Production 배포가 반복되어 Hobby deployment rate limit을 소모하는 문제를 막습니다.

## 변경 내용

- Vercel Git 자동 배포 비활성화
- PR/feature branch Preview 배포 제거
- `main`의 `frontend/**` 변경에만 Production 배포 실행
- GitHub Actions에서 Vercel CLI로 production build/deploy 수행
- Vercel CLI를 `59.5.0`으로 고정
- `actions/checkout`, `actions/setup-node`를 full commit SHA로 고정
- checkout credential persistence 비활성화
- `VERCEL_TOKEN`을 command argument가 아닌 배포 단계 환경변수로만 주입
- 배포 job을 GitHub `Production` Environment에 한정

## 사전 설정

- [x] GitHub `Production` Environment의 Environment secret에 `VERCEL_TOKEN` 설정
- [x] 사용하지 않는 `Preview` Environment 제거

## 검증

- [x] `Backend test and build`
- [x] `Frontend lint and build`
- backend-only 변경은 Vercel Production workflow 미실행
- PR/feature branch에서는 Vercel Preview 미생성
- frontend 변경이 main에 병합될 때만 Vercel Production workflow 실행