### PR TITLE
build(deps): Spring Boot 4.1과 Jackson 3으로 마이그레이션

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.7'
+    id 'org.springframework.boot' version '4.1.1'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -26,10 +26,12 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    implementation 'org.springframework.boot:spring-boot-starter-restclient'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.flywaydb:flyway-core'
-    implementation 'me.paulschwarz:spring-dotenv:4.0.0'
+    implementation 'org.springframework.boot:spring-boot-starter-flyway'
+    implementation platform('me.paulschwarz:spring-dotenv-bom:5.1.0')
+    developmentOnly 'me.paulschwarz:springboot4-dotenv'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-restclient'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-flyway'
-    implementation platform('me.paulschwarz:spring-dotenv-bom:5.1.0')
+    developmentOnly platform('me.paulschwarz:spring-dotenv-bom:5.1.0')
     developmentOnly 'me.paulschwarz:springboot4-dotenv'
 
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/uctale/uctale/application/game/ChoiceCodec.java
+++ b/src/main/java/com/uctale/uctale/application/game/ChoiceCodec.java
@@ -1,8 +1,8 @@
 package com.uctale.uctale.application.game;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 import com.uctale.uctale.dto.GameChoice;
 import org.springframework.stereotype.Component;
 
@@ -20,7 +20,7 @@ public class ChoiceCodec {
     public String serialize(List<GameChoice> choices) {
         try {
             return objectMapper.writeValueAsString(choices);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new IllegalStateException("선택지 JSON 변환에 실패했습니다.", e);
         }
     }
@@ -29,7 +29,7 @@ public class ChoiceCodec {
         final List<GameChoice> choices;
         try {
             choices = objectMapper.readValue(json, new TypeReference<>() {});
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new IllegalStateException("저장된 선택지를 읽을 수 없습니다.", e);
         }
 

--- a/src/main/java/com/uctale/uctale/application/game/GameStateCodec.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameStateCodec.java
@@ -1,7 +1,7 @@
 package com.uctale.uctale.application.game;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import com.uctale.uctale.domain.game.GameState;
 import org.springframework.stereotype.Component;
 
@@ -17,7 +17,7 @@ public class GameStateCodec {
     public String serialize(GameState state) {
         try {
             return objectMapper.writeValueAsString(state);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new IllegalStateException("GameState 직렬화에 실패했습니다.", e);
         }
     }
@@ -25,7 +25,7 @@ public class GameStateCodec {
     public GameState deserialize(String json) {
         try {
             return objectMapper.readValue(json, GameState.class);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new IllegalStateException("GameState 역직렬화에 실패했습니다.", e);
         }
     }

--- a/src/main/java/com/uctale/uctale/config/RestClientConfig.java
+++ b/src/main/java/com/uctale/uctale/config/RestClientConfig.java
@@ -1,6 +1,6 @@
 package com.uctale.uctale.config;
 
-import org.springframework.boot.web.client.RestClientCustomizer;
+import org.springframework.boot.restclient.RestClientCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;

--- a/src/main/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapter.java
+++ b/src/main/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapter.java
@@ -1,8 +1,8 @@
 package com.uctale.uctale.provider.gemini;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 import com.uctale.uctale.application.narrative.NarrativeContext;
 import com.uctale.uctale.application.narrative.NarrativeGenerator;
 import com.uctale.uctale.application.narrative.NarrativeTurn;
@@ -124,7 +124,7 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
         }
     }
 
-    private NarrativeTurn generate(String prompt, String errorContext) throws JsonProcessingException {
+    private NarrativeTurn generate(String prompt, String errorContext) throws JacksonException {
         String requestBody = createRequestBody(prompt);
         String response = restClient.post()
                 .uri(GEMINI_API_URL + "?key=" + apiKey)
@@ -138,7 +138,7 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
         return parseResponse(response);
     }
 
-    private String createRequestBody(String userPrompt) throws JsonProcessingException {
+    private String createRequestBody(String userPrompt) throws JacksonException {
         Map<String, Object> requestMap = Map.of(
                 "contents", List.of(Map.of("parts", List.of(Map.of("text", SYSTEM_INSTRUCTION + "\n\n" + userPrompt)))),
                 "generationConfig", Map.of("response_mime_type", "application/json")
@@ -146,7 +146,7 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
         return objectMapper.writeValueAsString(requestMap);
     }
 
-    private NarrativeTurn parseResponse(String rawResponse) throws JsonProcessingException {
+    private NarrativeTurn parseResponse(String rawResponse) throws JacksonException {
         GeminiApiResponse apiResponse = objectMapper.readValue(rawResponse, GeminiApiResponse.class);
         if (apiResponse.candidates() == null || apiResponse.candidates().isEmpty()) {
             throw new IllegalStateException("AI 응답이 비어있습니다.");
@@ -160,11 +160,11 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
         if (choicesNode.isArray()) {
             int index = 1;
             for (JsonNode node : choicesNode) {
-                if (node.isTextual()) {
-                    choices.add(new NarrativeTurn.Choice(index++, node.asText()));
+                if (node.isString()) {
+                    choices.add(new NarrativeTurn.Choice(index++, node.asString()));
                 } else if (node.isObject()) {
                     int id = node.has("id") ? node.get("id").asInt() : index++;
-                    String text = node.has("text") ? node.get("text").asText() : "내용 없음";
+                    String text = node.has("text") ? node.get("text").asString() : "내용 없음";
                     choices.add(new NarrativeTurn.Choice(id, text));
                 }
             }
@@ -172,11 +172,11 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
 
         JsonNode visualNode = rootNode.path("visual_assets");
         return new NarrativeTurn(
-                rootNode.path("title").asText("제목 없음"),
-                rootNode.path("story_text").asText("스토리가 없습니다."),
+                rootNode.path("title").asString("제목 없음"),
+                rootNode.path("story_text").asString("스토리가 없습니다."),
                 choices,
                 new NarrativeTurn.VisualAssets(
-                        visualNode.path("background").asText(""),
+                        visualNode.path("background").asString(""),
                         readNonBlankStrings(visualNode.path("characters")),
                         readNonBlankStrings(visualNode.path("assets"))
                 )
@@ -187,7 +187,7 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
         List<String> values = new ArrayList<>();
         if (node.isArray()) {
             for (JsonNode item : node) {
-                String value = item.asText();
+                String value = item.asString();
                 if (value != null && !value.isBlank()) {
                     values.add(value);
                 }

--- a/src/test/java/com/uctale/uctale/controller/GameControllerTest.java
+++ b/src/test/java/com/uctale/uctale/controller/GameControllerTest.java
@@ -1,6 +1,6 @@
 package com.uctale.uctale.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import com.uctale.uctale.application.game.TurnConflictException;
 import com.uctale.uctale.dto.GameChoice;
 import com.uctale.uctale.dto.GameInitRequest;

--- a/src/test/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapterTest.java
+++ b/src/test/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapterTest.java
@@ -1,6 +1,6 @@
 package com.uctale.uctale.provider.gemini;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import com.uctale.uctale.application.narrative.NarrativeTurn;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/uctale/uctale/service/GameServiceTest.java
+++ b/src/test/java/com/uctale/uctale/service/GameServiceTest.java
@@ -1,6 +1,6 @@
 package com.uctale.uctale.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import com.uctale.uctale.application.game.ChoiceCodec;
 import com.uctale.uctale.application.game.GamePersistenceService;
 import com.uctale.uctale.application.game.ImagePromptComposer;


### PR DESCRIPTION
## 변경 사항

- Spring Boot 3.5.7을 4.1.1로 업그레이드
- Boot 4 모듈 구조에 맞춰 Web MVC, RestClient, Flyway starter 분리
- Jackson 2 API를 Jackson 3(`tools.jackson`) API로 마이그레이션
- `spring-dotenv` 5.1 BOM과 Boot 4 전용 artifact를 `developmentOnly`로 적용

Dependabot PR #10과 #11을 완전한 마이그레이션으로 대체합니다.

## 검증

- Java 17 환경에서 `./gradlew clean test` 통과
- deprecated Jackson 3 API 제거
- Java 21 기준 최종 검증은 이 PR의 GitHub Actions에서 수행