### PR TITLE
fix(api): 비용 요청의 validation과 오류 계약 강화

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: ./gradlew build -x test
 
   frontend:
-    name: Frontend lint and build
+    name: Frontend test, lint and build
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:
@@ -60,6 +60,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Run frontend tests
+        run: npm test
 
       - name: Run ESLint
         run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: ./gradlew build -x test
 
   frontend:
-    name: Frontend test, lint and build
+    name: Frontend lint and build
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "test": "node --test",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { initGame, progressGame, resolveGameAssetUrl } from './api/gameApi'
+import { getApiErrorMessage } from './api/apiError'
 import GameImage from './components/GameImage'
 import TypewriterText from './components/TypewriterText'
 import './App.css'
@@ -27,7 +28,7 @@ function App() {
             setIsTypingComplete(false);
         } catch (error) {
             console.error(error);
-            alert("오류가 발생했습니다.");
+            alert(getApiErrorMessage(error));
         } finally {
             setIsLoading(false);
         }
@@ -43,7 +44,7 @@ function App() {
             window.scrollTo(0, 0);
         } catch (error) {
             console.error(error);
-            alert(error?.response?.status === 409 ? "이미 처리된 선택입니다." : "오류가 발생했습니다.");
+            alert(getApiErrorMessage(error));
         } finally {
             setIsLoading(false);
         }

--- a/frontend/src/api/apiError.js
+++ b/frontend/src/api/apiError.js
@@ -1,0 +1,15 @@
+const ERROR_MESSAGES = {
+  SESSION_NOT_FOUND: '게임 세션을 찾을 수 없습니다.',
+  TURN_CONFLICT: '이미 처리되었거나 오래된 선택입니다. 최신 상태에서 다시 시도해주세요.',
+  INVALID_CHOICE: '현재 턴에서 선택할 수 없는 선택지입니다.',
+  PROVIDER_RESPONSE_INVALID: '이야기 생성 응답이 올바르지 않습니다. 다시 시도해주세요.',
+  PERSISTENCE_FAILURE: '게임 상태 저장 중 오류가 발생했습니다. 다시 시도해주세요.',
+}
+
+export const getApiErrorMessage = (error, fallback = '오류가 발생했습니다.') => {
+  const code = error?.response?.data?.code
+  if (code === 'VALIDATION_ERROR' || code === 'INVALID_REQUEST') {
+    return error?.response?.data?.message || fallback
+  }
+  return ERROR_MESSAGES[code] || fallback
+}

--- a/frontend/src/api/apiError.test.js
+++ b/frontend/src/api/apiError.test.js
@@ -1,0 +1,22 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { getApiErrorMessage } from './apiError.js'
+
+test('validation 오류는 서버의 안전한 사용자 메시지를 표시한다', () => {
+  const error = { response: { data: { code: 'VALIDATION_ERROR', message: '세계관 설정은 255자 이하여야 합니다.' } } }
+  assert.equal(getApiErrorMessage(error), '세계관 설정은 255자 이하여야 합니다.')
+})
+
+test('충돌 오류는 안정적인 사용자 메시지로 변환한다', () => {
+  const error = { response: { data: { code: 'TURN_CONFLICT', message: 'internal detail' } } }
+  assert.equal(
+    getApiErrorMessage(error),
+    '이미 처리되었거나 오래된 선택입니다. 최신 상태에서 다시 시도해주세요.'
+  )
+})
+
+test('알 수 없는 서버 오류는 내부 메시지를 노출하지 않는다', () => {
+  const error = { response: { data: { code: 'UNKNOWN', message: 'database internal detail' } } }
+  assert.equal(getApiErrorMessage(error), '오류가 발생했습니다.')
+})

--- a/src/main/java/com/uctale/uctale/application/game/ChoiceCodec.java
+++ b/src/main/java/com/uctale/uctale/application/game/ChoiceCodec.java
@@ -37,6 +37,6 @@ public class ChoiceCodec {
                 .filter(choice -> choice.id() == choiceId)
                 .findFirst()
                 .map(GameChoice::text)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 선택지입니다."));
+                .orElseThrow(() -> new InvalidChoiceException("현재 턴에서 선택할 수 없는 선택지입니다."));
     }
 }

--- a/src/main/java/com/uctale/uctale/application/game/GamePersistenceService.java
+++ b/src/main/java/com/uctale/uctale/application/game/GamePersistenceService.java
@@ -17,6 +17,8 @@ import java.util.List;
 @Service
 public class GamePersistenceService {
 
+    private static final String TURN_UNIQUE_CONSTRAINT = "uk_game_log_session_turn";
+
     private final GameSessionRepository gameSessionRepository;
     private final GameLogRepository gameLogRepository;
     private final GameStateSnapshotRepository gameStateSnapshotRepository;
@@ -42,17 +44,24 @@ public class GamePersistenceService {
             String choicesJson,
             String imageUrl
     ) {
-        GameSession session = gameSessionRepository.save(new GameSession(worldSetting, characterSetting));
-        GameState initialState = GameState.initial(worldSetting, characterSetting, storyText);
-        gameStateSnapshotRepository.save(new GameStateSnapshot(session, gameStateCodec.serialize(initialState)));
-        gameLogRepository.save(new GameLog(session, 1, storyText, choicesJson, imageUrl));
-        return session;
+        try {
+            GameSession session = gameSessionRepository.save(new GameSession(worldSetting, characterSetting));
+            GameState initialState = GameState.initial(worldSetting, characterSetting, storyText);
+            gameStateSnapshotRepository.save(new GameStateSnapshot(session, gameStateCodec.serialize(initialState)));
+            gameLogRepository.save(new GameLog(session, 1, storyText, choicesJson, imageUrl));
+            gameLogRepository.flush();
+            gameStateSnapshotRepository.flush();
+            gameSessionRepository.flush();
+            return session;
+        } catch (DataIntegrityViolationException exception) {
+            throw new PersistenceOperationException("게임 시작 상태를 저장할 수 없습니다.", exception);
+        }
     }
 
     @Transactional(readOnly = true)
     public LoadedTurn loadLatestTurn(Long sessionId, int expectedTurn) {
         GameSession session = gameSessionRepository.findById(sessionId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 세션입니다."));
+                .orElseThrow(() -> new GameSessionNotFoundException("존재하지 않는 세션입니다."));
 
         if (session.getCurrentTurn() != expectedTurn) {
             throw new TurnConflictException("이미 처리되었거나 오래된 턴 요청입니다.");
@@ -93,7 +102,7 @@ public class GamePersistenceService {
     ) {
         try {
             GameSession session = gameSessionRepository.findById(sessionId)
-                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 세션입니다."));
+                    .orElseThrow(() -> new GameSessionNotFoundException("존재하지 않는 세션입니다."));
 
             if (session.getCurrentTurn() != expectedTurn) {
                 throw new TurnConflictException("이미 처리되었거나 오래된 턴 요청입니다.");
@@ -134,9 +143,20 @@ public class GamePersistenceService {
             gameStateSnapshotRepository.flush();
             gameSessionRepository.flush();
             return session.getCurrentTurn();
-        } catch (ObjectOptimisticLockingFailureException | DataIntegrityViolationException exception) {
+        } catch (ObjectOptimisticLockingFailureException exception) {
             throw new TurnConflictException("동시에 처리된 턴 요청과 충돌했습니다.", exception);
+        } catch (DataIntegrityViolationException exception) {
+            if (isTurnUniqueConstraintViolation(exception)) {
+                throw new TurnConflictException("동시에 처리된 턴 요청과 충돌했습니다.", exception);
+            }
+            throw new PersistenceOperationException("게임 진행 상태를 저장할 수 없습니다.", exception);
         }
+    }
+
+    private boolean isTurnUniqueConstraintViolation(DataIntegrityViolationException exception) {
+        Throwable cause = exception.getMostSpecificCause();
+        String message = cause == null ? exception.getMessage() : cause.getMessage();
+        return message != null && message.toLowerCase().contains(TURN_UNIQUE_CONSTRAINT);
     }
 
     private GameState loadOrRecoverState(GameSession session) {

--- a/src/main/java/com/uctale/uctale/application/game/GameSessionNotFoundException.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameSessionNotFoundException.java
@@ -1,0 +1,7 @@
+package com.uctale.uctale.application.game;
+
+public class GameSessionNotFoundException extends RuntimeException {
+    public GameSessionNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/uctale/uctale/application/game/InvalidChoiceException.java
+++ b/src/main/java/com/uctale/uctale/application/game/InvalidChoiceException.java
@@ -1,0 +1,7 @@
+package com.uctale.uctale.application.game;
+
+public class InvalidChoiceException extends RuntimeException {
+    public InvalidChoiceException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/uctale/uctale/application/game/PersistenceOperationException.java
+++ b/src/main/java/com/uctale/uctale/application/game/PersistenceOperationException.java
@@ -1,0 +1,7 @@
+package com.uctale.uctale.application.game;
+
+public class PersistenceOperationException extends RuntimeException {
+    public PersistenceOperationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/uctale/uctale/application/narrative/InvalidNarrativeResponseException.java
+++ b/src/main/java/com/uctale/uctale/application/narrative/InvalidNarrativeResponseException.java
@@ -1,0 +1,7 @@
+package com.uctale.uctale.application.narrative;
+
+public class InvalidNarrativeResponseException extends RuntimeException {
+    public InvalidNarrativeResponseException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/uctale/uctale/controller/ApiError.java
+++ b/src/main/java/com/uctale/uctale/controller/ApiError.java
@@ -1,0 +1,6 @@
+package com.uctale.uctale.controller;
+
+public record ApiError(
+        String code,
+        String message
+) {}

--- a/src/main/java/com/uctale/uctale/controller/ApiExceptionHandler.java
+++ b/src/main/java/com/uctale/uctale/controller/ApiExceptionHandler.java
@@ -1,34 +1,69 @@
 package com.uctale.uctale.controller;
 
+import com.uctale.uctale.application.game.GameSessionNotFoundException;
+import com.uctale.uctale.application.game.InvalidChoiceException;
+import com.uctale.uctale.application.game.PersistenceOperationException;
 import com.uctale.uctale.application.game.TurnConflictException;
+import com.uctale.uctale.application.narrative.InvalidNarrativeResponseException;
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.util.Map;
-
 @RestControllerAdvice
 public class ApiExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<Map<String, String>> handleIllegalArgument(IllegalArgumentException exception) {
-        return ResponseEntity.badRequest().body(Map.of("message", exception.getMessage()));
+    public ResponseEntity<ApiError> handleIllegalArgument(IllegalArgumentException exception) {
+        return error(HttpStatus.BAD_REQUEST, "INVALID_REQUEST", exception.getMessage());
+    }
+
+    @ExceptionHandler(GameSessionNotFoundException.class)
+    public ResponseEntity<ApiError> handleSessionNotFound(GameSessionNotFoundException exception) {
+        return error(HttpStatus.NOT_FOUND, "SESSION_NOT_FOUND", exception.getMessage());
     }
 
     @ExceptionHandler(TurnConflictException.class)
-    public ResponseEntity<Map<String, String>> handleTurnConflict(TurnConflictException exception) {
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("message", exception.getMessage()));
+    public ResponseEntity<ApiError> handleTurnConflict(TurnConflictException exception) {
+        return error(HttpStatus.CONFLICT, "TURN_CONFLICT", exception.getMessage());
+    }
+
+    @ExceptionHandler(InvalidChoiceException.class)
+    public ResponseEntity<ApiError> handleInvalidChoice(InvalidChoiceException exception) {
+        return error(HttpStatus.UNPROCESSABLE_ENTITY, "INVALID_CHOICE", exception.getMessage());
+    }
+
+    @ExceptionHandler(InvalidNarrativeResponseException.class)
+    public ResponseEntity<ApiError> handleInvalidNarrativeResponse(InvalidNarrativeResponseException exception) {
+        return error(HttpStatus.BAD_GATEWAY, "PROVIDER_RESPONSE_INVALID", "Narrative provider 응답이 올바르지 않습니다.");
+    }
+
+    @ExceptionHandler(PersistenceOperationException.class)
+    public ResponseEntity<ApiError> handlePersistenceFailure(PersistenceOperationException exception) {
+        return error(HttpStatus.INTERNAL_SERVER_ERROR, "PERSISTENCE_FAILURE", "게임 상태 저장 중 오류가 발생했습니다.");
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<Map<String, String>> handleValidation(MethodArgumentNotValidException exception) {
+    public ResponseEntity<ApiError> handleValidation(MethodArgumentNotValidException exception) {
         String message = exception.getBindingResult().getFieldErrors().stream()
                 .findFirst()
                 .map(error -> error.getDefaultMessage())
                 .orElse("요청값이 올바르지 않습니다.");
+        return error(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", message);
+    }
 
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("message", message));
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiError> handleConstraintViolation(ConstraintViolationException exception) {
+        String message = exception.getConstraintViolations().stream()
+                .findFirst()
+                .map(violation -> violation.getMessage())
+                .orElse("요청값이 올바르지 않습니다.");
+        return error(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", message);
+    }
+
+    private ResponseEntity<ApiError> error(HttpStatus status, String code, String message) {
+        return ResponseEntity.status(status).body(new ApiError(code, message));
     }
 }

--- a/src/main/java/com/uctale/uctale/controller/GameController.java
+++ b/src/main/java/com/uctale/uctale/controller/GameController.java
@@ -36,13 +36,13 @@ public class GameController {
 
     @PostMapping("/init")
     public ResponseEntity<GameResponse> initGame(@Valid @RequestBody GameInitRequest request) {
-        log.info("게임 초기화 요청: 세계관={}, 사용자={}", request.worldSetting(), request.characterSetting());
+        log.info("게임 초기화 요청 수신");
         return ResponseEntity.ok(gameService.initGame(request));
     }
 
     @PostMapping("/progress")
     public ResponseEntity<GameResponse> progressGame(@Valid @RequestBody GameProgressRequest request) {
-        log.info("게임 진행: 세션ID={}, 선택지={}", request.sessionId(), request.choiceId());
+        log.info("게임 진행 요청: 세션ID={}, 기대턴={}", request.sessionId(), request.expectedTurn());
         return ResponseEntity.ok(gameService.progressGame(request));
     }
 }

--- a/src/main/java/com/uctale/uctale/controller/ImageController.java
+++ b/src/main/java/com/uctale/uctale/controller/ImageController.java
@@ -1,9 +1,13 @@
 package com.uctale.uctale.controller;
 
 import com.uctale.uctale.application.image.ImageGenerator;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.concurrent.TimeUnit;
 
+@Validated
 @RestController
 @RequestMapping("/api/game")
 @RequiredArgsConstructor
@@ -22,13 +27,14 @@ public class ImageController {
 
     @GetMapping("/image")
     public ResponseEntity<byte[]> image(
-            @RequestParam String prompt,
-            @RequestParam(defaultValue = "16:9") String aspectRatio
+            @RequestParam
+            @NotBlank(message = "이미지 prompt는 필수입니다.")
+            @Size(max = 2000, message = "이미지 prompt는 2000자 이하여야 합니다.")
+            String prompt,
+            @RequestParam(defaultValue = "16:9")
+            @Pattern(regexp = "^(16:9|1:1)$", message = "지원하지 않는 이미지 비율입니다.")
+            String aspectRatio
     ) {
-        if (prompt == null || prompt.isBlank()) {
-            return ResponseEntity.badRequest().build();
-        }
-
         ImageGenerator.GeneratedImage generatedImage = imageGenerator.fetchImage(prompt, aspectRatio);
         if (generatedImage == null || generatedImage.bytes() == null || generatedImage.bytes().length == 0) {
             return ResponseEntity.status(502).build();

--- a/src/main/java/com/uctale/uctale/controller/ImageController.java
+++ b/src/main/java/com/uctale/uctale/controller/ImageController.java
@@ -23,18 +23,22 @@ import java.util.concurrent.TimeUnit;
 @CrossOrigin(origins = "*")
 public class ImageController {
 
+    private static final int MAX_PROMPT_LENGTH = 2000;
+
     private final ImageGenerator imageGenerator;
 
     @GetMapping("/image")
     public ResponseEntity<byte[]> image(
             @RequestParam
             @NotBlank(message = "이미지 prompt는 필수입니다.")
-            @Size(max = 2000, message = "이미지 prompt는 2000자 이하여야 합니다.")
+            @Size(max = MAX_PROMPT_LENGTH, message = "이미지 prompt는 2000자 이하여야 합니다.")
             String prompt,
             @RequestParam(defaultValue = "16:9")
             @Pattern(regexp = "^(16:9|1:1)$", message = "지원하지 않는 이미지 비율입니다.")
             String aspectRatio
     ) {
+        validateRequest(prompt, aspectRatio);
+
         ImageGenerator.GeneratedImage generatedImage = imageGenerator.fetchImage(prompt, aspectRatio);
         if (generatedImage == null || generatedImage.bytes() == null || generatedImage.bytes().length == 0) {
             return ResponseEntity.status(502).build();
@@ -44,5 +48,17 @@ public class ImageController {
                 .contentType(generatedImage.contentType())
                 .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic())
                 .body(generatedImage.bytes());
+    }
+
+    private void validateRequest(String prompt, String aspectRatio) {
+        if (prompt == null || prompt.isBlank()) {
+            throw new IllegalArgumentException("이미지 prompt는 필수입니다.");
+        }
+        if (prompt.length() > MAX_PROMPT_LENGTH) {
+            throw new IllegalArgumentException("이미지 prompt는 2000자 이하여야 합니다.");
+        }
+        if (!"16:9".equals(aspectRatio) && !"1:1".equals(aspectRatio)) {
+            throw new IllegalArgumentException("지원하지 않는 이미지 비율입니다.");
+        }
     }
 }

--- a/src/main/java/com/uctale/uctale/dto/GameInitRequest.java
+++ b/src/main/java/com/uctale/uctale/dto/GameInitRequest.java
@@ -1,11 +1,14 @@
 package com.uctale.uctale.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record GameInitRequest(
         @NotBlank(message = "세계관 설정은 필수입니다.")
+        @Size(max = 255, message = "세계관 설정은 255자 이하여야 합니다.")
         String worldSetting,
 
         @NotBlank(message = "캐릭터 설정은 필수입니다.")
+        @Size(max = 255, message = "캐릭터 설정은 255자 이하여야 합니다.")
         String characterSetting
 ) {}

--- a/src/main/java/com/uctale/uctale/service/GameService.java
+++ b/src/main/java/com/uctale/uctale/service/GameService.java
@@ -4,6 +4,7 @@ import com.uctale.uctale.application.game.ChoiceCodec;
 import com.uctale.uctale.application.game.GamePersistenceService;
 import com.uctale.uctale.application.game.ImagePromptComposer;
 import com.uctale.uctale.application.image.ImageGenerator;
+import com.uctale.uctale.application.narrative.InvalidNarrativeResponseException;
 import com.uctale.uctale.application.narrative.NarrativeContext;
 import com.uctale.uctale.application.narrative.NarrativeGenerator;
 import com.uctale.uctale.application.narrative.NarrativeTurn;
@@ -15,12 +16,20 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class GameService {
+
+    private static final int MAX_TITLE_LENGTH = 200;
+    private static final int MAX_STORY_LENGTH = 50_000;
+    private static final int MAX_CHOICE_TEXT_LENGTH = 255;
+    private static final int MAX_CHOICES = 8;
+    private static final int MAX_IMAGE_PROMPT_LENGTH = 2_000;
 
     private final NarrativeGenerator narrativeGenerator;
     private final ImageGenerator imageGenerator;
@@ -30,12 +39,14 @@ public class GameService {
 
     public GameResponse initGame(GameInitRequest request) {
         NarrativeTurn opening = narrativeGenerator.createOpening(request.worldSetting(), request.characterSetting());
+        validateNarrativeTurn(opening);
         List<GameChoice> choices = toGameChoices(opening.choices());
 
         String imagePrompt = imagePromptComposer.compose(opening.visualAssets());
         if (imagePrompt == null || imagePrompt.isBlank()) {
             imagePrompt = "mysterious atmosphere, " + request.worldSetting();
         }
+        validateImagePrompt(imagePrompt);
         String imageUrl = imageGenerator.createPublicUrl(imagePrompt, "16:9");
 
         var session = gamePersistenceService.saveOpening(
@@ -58,11 +69,13 @@ public class GameService {
         String userChoiceText = choiceCodec.findText(loadedTurn.choicesJson(), request.choiceId());
         NarrativeContext narrativeContext = NarrativeContext.from(loadedTurn.gameState(), userChoiceText);
         NarrativeTurn nextTurn = narrativeGenerator.createNextTurn(narrativeContext);
+        validateNarrativeTurn(nextTurn);
         List<GameChoice> choices = toGameChoices(nextTurn.choices());
 
         String imageUrl = loadedTurn.imageUrl();
         String imagePrompt = imagePromptComposer.compose(nextTurn.visualAssets());
         if (imagePrompt != null && !imagePrompt.isBlank()) {
+            validateImagePrompt(imagePrompt);
             log.info("새로운 이미지 생성 요청");
             String newImageUrl = imageGenerator.createPublicUrl(imagePrompt, "16:9");
             if (newImageUrl != null) {
@@ -84,6 +97,37 @@ public class GameService {
         return toResponse(loadedTurn.sessionId(), savedTurn, nextTurn, choices, imageUrl);
     }
 
+    private void validateNarrativeTurn(NarrativeTurn turn) {
+        if (turn == null) {
+            throw new InvalidNarrativeResponseException("Narrative 응답이 없습니다.");
+        }
+        if (turn.title() == null || turn.title().isBlank() || turn.title().length() > MAX_TITLE_LENGTH) {
+            throw new InvalidNarrativeResponseException("Narrative 제목이 올바르지 않습니다.");
+        }
+        if (turn.storyText() == null || turn.storyText().isBlank() || turn.storyText().length() > MAX_STORY_LENGTH) {
+            throw new InvalidNarrativeResponseException("Narrative 본문이 올바르지 않습니다.");
+        }
+        if (turn.choices() == null || turn.choices().isEmpty() || turn.choices().size() > MAX_CHOICES) {
+            throw new InvalidNarrativeResponseException("Narrative 선택지 수가 올바르지 않습니다.");
+        }
+
+        Set<Integer> choiceIds = new HashSet<>();
+        for (NarrativeTurn.Choice choice : turn.choices()) {
+            if (choice == null || choice.id() <= 0 || !choiceIds.add(choice.id())) {
+                throw new InvalidNarrativeResponseException("Narrative 선택지 ID가 올바르지 않습니다.");
+            }
+            if (choice.text() == null || choice.text().isBlank() || choice.text().length() > MAX_CHOICE_TEXT_LENGTH) {
+                throw new InvalidNarrativeResponseException("Narrative 선택지 문구가 올바르지 않습니다.");
+            }
+        }
+    }
+
+    private void validateImagePrompt(String imagePrompt) {
+        if (imagePrompt != null && imagePrompt.length() > MAX_IMAGE_PROMPT_LENGTH) {
+            throw new InvalidNarrativeResponseException("이미지 prompt가 너무 깁니다.");
+        }
+    }
+
     private GameResponse toResponse(
             Long sessionId,
             int turnNumber,
@@ -95,9 +139,6 @@ public class GameService {
     }
 
     private List<GameChoice> toGameChoices(List<NarrativeTurn.Choice> choices) {
-        if (choices == null) {
-            return List.of();
-        }
         return choices.stream()
                 .map(choice -> new GameChoice(choice.id(), choice.text()))
                 .toList();

--- a/src/test/java/com/uctale/uctale/application/game/GamePersistenceIntegrityTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/GamePersistenceIntegrityTest.java
@@ -1,0 +1,57 @@
+package com.uctale.uctale.application.game;
+
+import com.uctale.uctale.repository.GameLogRepository;
+import com.uctale.uctale.repository.GameSessionRepository;
+import com.uctale.uctale.repository.GameStateSnapshotRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class GamePersistenceIntegrityTest {
+
+    @Mock private GameSessionRepository gameSessionRepository;
+    @Mock private GameLogRepository gameLogRepository;
+    @Mock private GameStateSnapshotRepository gameStateSnapshotRepository;
+    @Mock private GameStateCodec gameStateCodec;
+
+    private GamePersistenceService persistenceService;
+
+    @BeforeEach
+    void setUp() {
+        persistenceService = new GamePersistenceService(
+                gameSessionRepository,
+                gameLogRepository,
+                gameStateSnapshotRepository,
+                gameStateCodec
+        );
+    }
+
+    @Test
+    @DisplayName("일반 DataIntegrityViolationException은 턴 충돌 409로 오인하지 않는다")
+    void saveNextTurn_DoesNotMapEveryIntegrityFailureToTurnConflict() {
+        given(gameSessionRepository.findById(42L))
+                .willThrow(new DataIntegrityViolationException("not-null constraint violation"));
+
+        assertThatThrownBy(() -> persistenceService.saveNextTurn(42L, 1, "선택", "본문", "[]", null))
+                .isInstanceOf(PersistenceOperationException.class)
+                .isNotInstanceOf(TurnConflictException.class);
+    }
+
+    @Test
+    @DisplayName("턴 unique constraint 위반만 턴 충돌로 분류한다")
+    void saveNextTurn_MapsTurnUniqueConstraintToConflict() {
+        given(gameSessionRepository.findById(42L))
+                .willThrow(new DataIntegrityViolationException("constraint uk_game_log_session_turn violated"));
+
+        assertThatThrownBy(() -> persistenceService.saveNextTurn(42L, 1, "선택", "본문", "[]", null))
+                .isInstanceOf(TurnConflictException.class);
+    }
+}

--- a/src/test/java/com/uctale/uctale/controller/GameControllerTest.java
+++ b/src/test/java/com/uctale/uctale/controller/GameControllerTest.java
@@ -1,6 +1,8 @@
 package com.uctale.uctale.controller;
 
 import tools.jackson.databind.ObjectMapper;
+import com.uctale.uctale.application.game.GameSessionNotFoundException;
+import com.uctale.uctale.application.game.InvalidChoiceException;
 import com.uctale.uctale.application.game.TurnConflictException;
 import com.uctale.uctale.dto.GameChoice;
 import com.uctale.uctale.dto.GameInitRequest;
@@ -21,6 +23,8 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -84,7 +88,7 @@ class GameControllerTest {
     }
 
     @Test
-    @DisplayName("오래된 턴 요청은 409로 반환한다")
+    @DisplayName("오래된 턴 요청은 안정적인 409 오류 코드로 반환한다")
     void progressGame_MapsTurnConflict() throws Exception {
         given(gameService.progressGame(any(GameProgressRequest.class)))
                 .willThrow(new TurnConflictException("이미 처리되었거나 오래된 턴 요청입니다."));
@@ -93,15 +97,57 @@ class GameControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new GameProgressRequest(42L, 1, 1))))
                 .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("TURN_CONFLICT"))
                 .andExpect(jsonPath("$.message").value("이미 처리되었거나 오래된 턴 요청입니다."));
     }
 
     @Test
-    @DisplayName("빈 세계관 설정은 400으로 거부한다")
+    @DisplayName("존재하지 않는 세션은 404 오류 코드로 반환한다")
+    void progressGame_MapsSessionNotFound() throws Exception {
+        given(gameService.progressGame(any(GameProgressRequest.class)))
+                .willThrow(new GameSessionNotFoundException("존재하지 않는 세션입니다."));
+
+        mockMvc.perform(post("/api/game/progress")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new GameProgressRequest(42L, 1, 1))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("SESSION_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("현재 턴에 없는 선택지는 422 오류 코드로 반환한다")
+    void progressGame_MapsInvalidChoice() throws Exception {
+        given(gameService.progressGame(any(GameProgressRequest.class)))
+                .willThrow(new InvalidChoiceException("현재 턴에서 선택할 수 없는 선택지입니다."));
+
+        mockMvc.perform(post("/api/game/progress")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new GameProgressRequest(42L, 99, 1))))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.code").value("INVALID_CHOICE"));
+    }
+
+    @Test
+    @DisplayName("빈 세계관 설정은 provider 호출 전에 400으로 거부한다")
     void initGame_RejectsBlankWorldSetting() throws Exception {
         mockMvc.perform(post("/api/game/init")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new GameInitRequest("", "김대리"))))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+
+        verify(gameService, never()).initGame(any(GameInitRequest.class));
+    }
+
+    @Test
+    @DisplayName("DB varchar 한계를 넘는 세계관 설정은 provider 호출 전에 거부한다")
+    void initGame_RejectsWorldSettingLongerThanDatabaseLimit() throws Exception {
+        mockMvc.perform(post("/api/game/init")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new GameInitRequest("가".repeat(256), "김대리"))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+
+        verify(gameService, never()).initGame(any(GameInitRequest.class));
     }
 }

--- a/src/test/java/com/uctale/uctale/controller/ImageControllerTest.java
+++ b/src/test/java/com/uctale/uctale/controller/ImageControllerTest.java
@@ -10,13 +10,40 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class ImageControllerTest {
 
     @Mock
     private ImageGenerator imageGenerator;
+
+    @Test
+    @DisplayName("빈 이미지 prompt는 provider 호출 전에 거부한다")
+    void image_RejectsBlankPromptBeforeProviderCall() {
+        ImageController controller = new ImageController(imageGenerator);
+
+        assertThatThrownBy(() -> controller.image(" ", "16:9"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미지 prompt는 필수입니다.");
+
+        verify(imageGenerator, never()).fetchImage(" ", "16:9");
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 이미지 비율은 provider 호출 전에 거부한다")
+    void image_RejectsUnsupportedAspectRatioBeforeProviderCall() {
+        ImageController controller = new ImageController(imageGenerator);
+
+        assertThatThrownBy(() -> controller.image("zombie", "4:3"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("지원하지 않는 이미지 비율입니다.");
+
+        verify(imageGenerator, never()).fetchImage("zombie", "4:3");
+    }
 
     @Test
     @DisplayName("이미지 provider 실패 시 502를 반환한다")

--- a/src/test/java/com/uctale/uctale/service/GameServiceValidationTest.java
+++ b/src/test/java/com/uctale/uctale/service/GameServiceValidationTest.java
@@ -1,0 +1,86 @@
+package com.uctale.uctale.service;
+
+import tools.jackson.databind.ObjectMapper;
+import com.uctale.uctale.application.game.ChoiceCodec;
+import com.uctale.uctale.application.game.GamePersistenceService;
+import com.uctale.uctale.application.game.ImagePromptComposer;
+import com.uctale.uctale.application.image.ImageGenerator;
+import com.uctale.uctale.application.narrative.InvalidNarrativeResponseException;
+import com.uctale.uctale.application.narrative.NarrativeGenerator;
+import com.uctale.uctale.application.narrative.NarrativeTurn;
+import com.uctale.uctale.dto.GameInitRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+class GameServiceValidationTest {
+
+    @Mock private NarrativeGenerator narrativeGenerator;
+    @Mock private ImageGenerator imageGenerator;
+    @Mock private GamePersistenceService gamePersistenceService;
+
+    private GameService gameService;
+
+    @BeforeEach
+    void setUp() {
+        gameService = new GameService(
+                narrativeGenerator,
+                imageGenerator,
+                gamePersistenceService,
+                new ChoiceCodec(new ObjectMapper()),
+                new ImagePromptComposer()
+        );
+    }
+
+    @Test
+    @DisplayName("DB user_choice 한계를 넘는 provider 선택지는 이미지 생성과 저장 전에 거부한다")
+    void initGame_RejectsOversizedProviderChoiceBeforeSideEffects() {
+        GameInitRequest request = new GameInitRequest("세계관", "캐릭터");
+        NarrativeTurn invalidTurn = new NarrativeTurn(
+                "제목",
+                "본문",
+                List.of(new NarrativeTurn.Choice(1, "가".repeat(256))),
+                new NarrativeTurn.VisualAssets("street", List.of(), List.of())
+        );
+        given(narrativeGenerator.createOpening("세계관", "캐릭터")).willReturn(invalidTurn);
+
+        assertThatThrownBy(() -> gameService.initGame(request))
+                .isInstanceOf(InvalidNarrativeResponseException.class);
+
+        verify(imageGenerator, never()).createPublicUrl(any(), any());
+        verify(gamePersistenceService, never()).saveOpening(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("중복 선택지 ID가 있는 provider 응답은 저장 전에 거부한다")
+    void initGame_RejectsDuplicateProviderChoiceIds() {
+        GameInitRequest request = new GameInitRequest("세계관", "캐릭터");
+        NarrativeTurn invalidTurn = new NarrativeTurn(
+                "제목",
+                "본문",
+                List.of(
+                        new NarrativeTurn.Choice(1, "간다"),
+                        new NarrativeTurn.Choice(1, "멈춘다")
+                ),
+                new NarrativeTurn.VisualAssets("", List.of(), List.of())
+        );
+        given(narrativeGenerator.createOpening("세계관", "캐릭터")).willReturn(invalidTurn);
+
+        assertThatThrownBy(() -> gameService.initGame(request))
+                .isInstanceOf(InvalidNarrativeResponseException.class);
+
+        verify(gamePersistenceService, never()).saveOpening(any(), any(), any(), any(), any());
+    }
+}


### PR DESCRIPTION
## 왜 필요한가요?

공유 베타에서 잘못된 게임 생성·진행·이미지 요청이 외부 Narrative/Image provider 호출까지 도달해 비용을 발생시키거나, 서로 다른 영속성 실패가 모두 턴 충돌 409로 처리되는 문제를 막습니다.

- Closes #23

## 무엇이 바뀌나요?

- 게임 규칙·상태: 현재 턴에 없는 선택지를 `INVALID_CHOICE` 422로 분리하고 기존 턴 충돌은 `TURN_CONFLICT` 409로 유지합니다.
- Backend / API / DB: `{code, message}` 오류 응답을 도입하고 validation 400, session not found 404, turn conflict 409, invalid choice 422, persistence failure 500을 구분합니다. `worldSetting`/`characterSetting`을 DB varchar(255)와 맞추고, 일반 `DataIntegrityViolationException`을 더 이상 모두 409로 처리하지 않습니다.
- AI narrative / prompt: Narrative 응답의 title/story/choice 필수값, 길이, choice ID 중복을 저장 및 이미지 생성 전에 검증합니다.
- Image generation: 빈/과도하게 긴 prompt와 지원하지 않는 aspect ratio를 provider 호출 전에 거부합니다.
- Frontend / UX: 서버 error code를 사용자 메시지로 변환하는 얇은 매퍼와 테스트를 추가합니다. 화면 구조와 `alert()` 제거는 #48 범위로 남깁니다.
- Build / deploy / docs: CI에서 Node 내장 테스트 러너로 frontend 오류 계약 테스트를 실행합니다.

## 책임 경계

- **서버가 결정하는 사실:** 요청 유효성, 세션 존재 여부, 현재 턴 충돌, 현재 선택지 유효성, 저장 가능 여부
- **LLM이 서술하는 내용:** 제목, 본문, 다음 선택지와 시각적 힌트
- **LLM이 변경하면 안 되는 사실:** API 오류 상태, 세션/턴 무결성, 영속성 충돌 분류

## 어떻게 검증했나요?

- [x] `./gradlew clean test`
- [x] `./gradlew build`
- [x] `cd frontend && npm ci && npm run test && npm run lint && npm run build`
- [x] 정상 흐름을 자동 테스트로 확인했습니다.
- [x] 잘못된 입력/실패 흐름을 테스트로 추가했습니다.
- [x] 중복 요청 또는 상태 전이가 관련되면 이를 검증했습니다.

GitHub Actions CI #53에서 Java 21 backend test/build와 Node 22 frontend test/lint/build가 모두 성공했습니다.

## 게임 상태·AI 안전성

- [x] 게임의 결정적 상태는 서버에서 검증·저장됩니다.
- [x] LLM 출력만으로 HP, 보상, 성공/실패 등 결정적 상태가 임의 변경되지 않습니다.
- [x] AI 요청에 필요한 최소 문맥만 전달합니다.
- [x] AI 응답 검증 실패 시 다음 턴을 저장하거나 이미지 생성하지 않습니다.
- [x] DB schema 변경 없이 기존 저장 데이터와 호환됩니다.

## 보안·비용

- [x] API Key, 토큰, 비밀번호가 코드·로그·URL·클라이언트 응답에 새로 노출되지 않습니다.
- [x] 잘못된 입력과 잘못된 provider 응답에서 불필요한 외부 호출을 줄입니다.
- [x] 사용자 입력 길이와 외부 API 비용 증가 가능성을 검토했습니다.
- [x] CORS 정책은 변경하지 않습니다. CORS 제한은 #24에서 처리합니다.

## API·DB·운영 영향

- [x] API 오류 계약 변경에 맞춰 Frontend 호출부를 함께 갱신했습니다.
- [x] DB schema 변경은 없습니다.
- [x] 새 환경변수나 Secret은 없습니다.
- [x] CI에서 정상 init/progress와 400/404/409/422 실패 계약을 검증했습니다.

## 화면 / 응답 예시

```json
{
  "code": "TURN_CONFLICT",
  "message": "이미 처리되었거나 오래된 턴 요청입니다."
}
```
