### PR TITLE
feat(security): 공유 접근 세션과 CORS allowlist 적용

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,25 @@ UCTale은 사용자가 직접 입력한 세계관과 주인공 설정을 바탕�
 
 ## 플레이 방식
 
-1. 원하는 세계관과 주인공을 입력합니다.
-2. 서버가 입력 내용을 바탕으로 첫 장면과 선택지를 생성합니다.
-3. 플레이어가 선택지를 고르면 다음 턴이 진행됩니다.
-4. 서버는 현재 턴과 게임 상태를 저장하고, 필요한 문맥만 Narrative Engine에 전달합니다.
-5. 시각적으로 표현할 장면이 있으면 별도의 이미지 생성 경로를 통해 삽화를 제공합니다.
+1. 공유 베타 접근 비밀번호를 확인해 단기 접근 세션을 발급받습니다.
+2. 원하는 세계관과 주인공을 입력합니다.
+3. 서버가 입력 내용을 바탕으로 첫 장면과 선택지를 생성합니다.
+4. 플레이어가 선택지를 고르면 다음 턴이 진행됩니다.
+5. 서버는 현재 턴과 게임 상태를 저장하고, 필요한 문맥만 Narrative Engine에 전달합니다.
+6. 시각적으로 표현할 장면이 있으면 별도의 이미지 생성 경로를 통해 삽화를 제공합니다.
 
 현재 플레이는 AI가 모든 게임 상태를 임의로 결정하는 방식이 아니라, 장기적으로 서버가 게임의 사실과 규칙을 소유하고 LLM은 그 결과를 이야기로 표현하는 구조를 목표로 개발하고 있습니다.
 
 ---
 
 ## 현재 구현된 내용
+
+### 공유 베타 접근 제어
+
+- 비밀번호 검증 성공 시 서버가 서명한 단기 접근 세션을 HttpOnly 쿠키로 발급합니다.
+- 게임 시작, 턴 진행, 이미지 생성 API는 유효한 접근 세션이 있어야 호출할 수 있습니다.
+- 운영 기본 CORS origin은 `https://uctale.vercel.app`만 허용하며, 허용 origin은 환경변수로 명시적으로 관리합니다.
+- 접근 세션이 만료되거나 유효하지 않으면 프론트엔드가 재인증 화면으로 전환합니다.
 
 ### 이야기 생성과 선택지 진행
 
@@ -139,10 +147,15 @@ uctale/
 GOOGLE_AI_API_KEY=...
 POLLINATIONS_TOKEN=...
 GAME_ACCESS_PASSWORD=...
+GAME_ACCESS_SESSION_SECRET=32자 이상의 충분히 긴 임의 문자열
+GAME_ACCESS_COOKIE_SECURE=false
+GAME_CORS_ALLOWED_ORIGINS=http://localhost:5173
 DATABASE_URL=jdbc:postgresql://localhost:5432/uctale
 DATABASE_USERNAME=...
 DATABASE_PASSWORD=...
 ```
+
+`GAME_ACCESS_COOKIE_SECURE=false`는 로컬 HTTP 개발용입니다. 운영에서는 기본값 `true`를 사용해 `Secure; SameSite=None` HttpOnly 쿠키를 발급합니다. 운영 CORS 기본값은 `https://uctale.vercel.app`이며, 다른 origin을 허용해야 할 때만 `GAME_CORS_ALLOWED_ORIGINS`를 쉼표로 구분해 명시합니다.
 
 ### 백엔드 실행
 
@@ -192,6 +205,7 @@ VITE_API_URL=https://example.com/api/game
 ```bash
 cd frontend
 npm ci
+npm test
 npm run lint
 npm run build
 ```
@@ -204,8 +218,7 @@ npm run build
 
 진행 중인 주요 작업은 다음과 같습니다.
 
-- API 입력 검증과 오류 응답 정리
-- 공유 베타용 접근 제어와 세션 소유권
+- 공유 베타 게임 세션 소유권
 - AI 및 이미지 호출에 대한 비용 보호와 관측성
 - 턴 idempotency와 동시 요청 처리 강화
 - GameState snapshot 버전 관리

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -125,7 +125,12 @@ function App() {
                 <h1>📖 {gameData.title}</h1>
 
                 <div className="image-container">
-                    <GameImage key={mainImageUrl} src={mainImageUrl} alt="Game Scene" />
+                    <GameImage
+                        key={mainImageUrl}
+                        src={mainImageUrl}
+                        alt="Game Scene"
+                        onAuthError={requireReauthentication}
+                    />
                 </div>
 
                 <div className="story-box">

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,6 @@
-import { useState } from 'react'
-import { initGame, progressGame, resolveGameAssetUrl } from './api/gameApi'
-import { getApiErrorMessage } from './api/apiError'
+import { useEffect, useState } from 'react'
+import { checkAccessSession, initGame, progressGame, resolveGameAssetUrl, verifyPassword } from './api/gameApi'
+import { getApiErrorMessage, isAccessAuthError } from './api/apiError'
 import GameImage from './components/GameImage'
 import TypewriterText from './components/TypewriterText'
 import './App.css'
@@ -11,10 +11,44 @@ function App() {
     const [isLoading, setIsLoading] = useState(false);
     const [gameData, setGameData] = useState(null);
     const [isTypingComplete, setIsTypingComplete] = useState(false);
+    const [authState, setAuthState] = useState('checking');
+    const [password, setPassword] = useState('');
+    const [authMessage, setAuthMessage] = useState('');
 
     const sessionId = gameData?.sessionId;
     const turnNumber = gameData?.turnNumber;
     const mainImageUrl = resolveGameAssetUrl(gameData?.mainImageUrl);
+
+    useEffect(() => {
+        checkAccessSession()
+            .then(() => setAuthState('authenticated'))
+            .catch(() => setAuthState('login'));
+    }, []);
+
+    const requireReauthentication = (error) => {
+        if (!isAccessAuthError(error)) return false;
+        setAuthMessage(getApiErrorMessage(error));
+        setAuthState('login');
+        return true;
+    };
+
+    const handleLogin = async () => {
+        if (!password) {
+            setAuthMessage('비밀번호를 입력해주세요.');
+            return;
+        }
+        setIsLoading(true);
+        setAuthMessage('');
+        try {
+            await verifyPassword(password);
+            setPassword('');
+            setAuthState('authenticated');
+        } catch (error) {
+            setAuthMessage(getApiErrorMessage(error, '로그인에 실패했습니다.'));
+        } finally {
+            setIsLoading(false);
+        }
+    };
 
     const handleStartGame = async () => {
         if (!world || !character) {
@@ -27,8 +61,10 @@ function App() {
             setGameData(data);
             setIsTypingComplete(false);
         } catch (error) {
-            console.error(error);
-            alert(getApiErrorMessage(error));
+            if (!requireReauthentication(error)) {
+                console.error(error);
+                alert(getApiErrorMessage(error));
+            }
         } finally {
             setIsLoading(false);
         }
@@ -43,12 +79,45 @@ function App() {
             setIsTypingComplete(false);
             window.scrollTo(0, 0);
         } catch (error) {
-            console.error(error);
-            alert(getApiErrorMessage(error));
+            if (!requireReauthentication(error)) {
+                console.error(error);
+                alert(getApiErrorMessage(error));
+            }
         } finally {
             setIsLoading(false);
         }
     };
+
+    if (authState === 'checking') {
+        return (
+            <div className="container">
+                <h1>UCTale<span className="subtitle">접근 세션 확인 중...</span></h1>
+            </div>
+        );
+    }
+
+    if (authState === 'login') {
+        return (
+            <div className="container">
+                <h1>UCTale<span className="subtitle">공유 베타 접근</span></h1>
+                <div className="input-group">
+                    <label htmlFor="access-password">🔐 접근 비밀번호</label>
+                    <input
+                        id="access-password"
+                        type="password"
+                        autoComplete="current-password"
+                        value={password}
+                        onChange={(event) => setPassword(event.target.value)}
+                        onKeyDown={(event) => event.key === 'Enter' && handleLogin()}
+                    />
+                </div>
+                {authMessage && <p role="alert">{authMessage}</p>}
+                <button className="start-btn" onClick={handleLogin} disabled={isLoading}>
+                    {isLoading ? '확인 중...' : '입장하기'}
+                </button>
+            </div>
+        );
+    }
 
     if (gameData) {
         return (

--- a/frontend/src/api/apiError.js
+++ b/frontend/src/api/apiError.js
@@ -8,6 +8,7 @@ const ERROR_MESSAGES = {
   ACCESS_SESSION_REQUIRED: '접근 인증이 필요합니다.',
   ACCESS_SESSION_INVALID: '접근 세션이 올바르지 않습니다. 다시 로그인해주세요.',
   ACCESS_SESSION_EXPIRED: '접근 세션이 만료되었습니다. 다시 로그인해주세요.',
+  ACCESS_REQUEST_FORBIDDEN: '요청 출처를 확인할 수 없습니다. 페이지를 새로고침해주세요.',
 }
 
 const AUTH_ERROR_CODES = new Set([

--- a/frontend/src/api/apiError.js
+++ b/frontend/src/api/apiError.js
@@ -4,10 +4,25 @@ const ERROR_MESSAGES = {
   INVALID_CHOICE: '현재 턴에서 선택할 수 없는 선택지입니다.',
   PROVIDER_RESPONSE_INVALID: '이야기 생성 응답이 올바르지 않습니다. 다시 시도해주세요.',
   PERSISTENCE_FAILURE: '게임 상태 저장 중 오류가 발생했습니다. 다시 시도해주세요.',
+  INVALID_CREDENTIALS: '비밀번호가 올바르지 않습니다.',
+  ACCESS_SESSION_REQUIRED: '접근 인증이 필요합니다.',
+  ACCESS_SESSION_INVALID: '접근 세션이 올바르지 않습니다. 다시 로그인해주세요.',
+  ACCESS_SESSION_EXPIRED: '접근 세션이 만료되었습니다. 다시 로그인해주세요.',
 }
 
+const AUTH_ERROR_CODES = new Set([
+  'INVALID_CREDENTIALS',
+  'ACCESS_SESSION_REQUIRED',
+  'ACCESS_SESSION_INVALID',
+  'ACCESS_SESSION_EXPIRED',
+])
+
+export const getApiErrorCode = (error) => error?.response?.data?.code
+
+export const isAccessAuthError = (error) => AUTH_ERROR_CODES.has(getApiErrorCode(error))
+
 export const getApiErrorMessage = (error, fallback = '오류가 발생했습니다.') => {
-  const code = error?.response?.data?.code
+  const code = getApiErrorCode(error)
   if (code === 'VALIDATION_ERROR' || code === 'INVALID_REQUEST') {
     return error?.response?.data?.message || fallback
   }

--- a/frontend/src/api/apiError.test.js
+++ b/frontend/src/api/apiError.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { getApiErrorMessage } from './apiError.js'
+import { getApiErrorMessage, isAccessAuthError } from './apiError.js'
 
 test('validation 오류는 서버의 안전한 사용자 메시지를 표시한다', () => {
   const error = { response: { data: { code: 'VALIDATION_ERROR', message: '세계관 설정은 255자 이하여야 합니다.' } } }
@@ -14,6 +14,12 @@ test('충돌 오류는 안정적인 사용자 메시지로 변환한다', () => 
     getApiErrorMessage(error),
     '이미 처리되었거나 오래된 선택입니다. 최신 상태에서 다시 시도해주세요.'
   )
+})
+
+test('접근 세션 만료는 재인증 대상으로 판별한다', () => {
+  const error = { response: { data: { code: 'ACCESS_SESSION_EXPIRED' } } }
+  assert.equal(isAccessAuthError(error), true)
+  assert.equal(getApiErrorMessage(error), '접근 세션이 만료되었습니다. 다시 로그인해주세요.')
 })
 
 test('알 수 없는 서버 오류는 내부 메시지를 노출하지 않는다', () => {

--- a/frontend/src/api/gameApi.js
+++ b/frontend/src/api/gameApi.js
@@ -2,7 +2,10 @@ import axios from 'axios';
 
 const BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080/api/game';
 const API_ORIGIN = new URL(BASE_URL).origin;
-const apiClient = axios.create({ withCredentials: true });
+const apiClient = axios.create({
+    withCredentials: true,
+    headers: { 'X-UCTale-Client': 'web' }
+});
 
 export const initGame = async (worldSetting, characterSetting) => {
     const response = await apiClient.post(`${BASE_URL}/init`, {
@@ -26,6 +29,13 @@ export const resolveGameAssetUrl = (assetUrl) => {
         return assetUrl;
     }
     return new URL(assetUrl, API_ORIGIN).toString();
+};
+
+export const fetchGameImage = async (assetUrl) => {
+    const response = await apiClient.get(resolveGameAssetUrl(assetUrl), {
+        responseType: 'blob'
+    });
+    return response.data;
 };
 
 export const verifyPassword = async (password) => {

--- a/frontend/src/api/gameApi.js
+++ b/frontend/src/api/gameApi.js
@@ -2,9 +2,10 @@ import axios from 'axios';
 
 const BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080/api/game';
 const API_ORIGIN = new URL(BASE_URL).origin;
+const apiClient = axios.create({ withCredentials: true });
 
 export const initGame = async (worldSetting, characterSetting) => {
-    const response = await axios.post(`${BASE_URL}/init`, {
+    const response = await apiClient.post(`${BASE_URL}/init`, {
         worldSetting,
         characterSetting
     });
@@ -12,7 +13,7 @@ export const initGame = async (worldSetting, characterSetting) => {
 };
 
 export const progressGame = async (sessionId, choiceId, expectedTurn) => {
-    const response = await axios.post(`${BASE_URL}/progress`, {
+    const response = await apiClient.post(`${BASE_URL}/progress`, {
         sessionId,
         choiceId,
         expectedTurn
@@ -28,8 +29,9 @@ export const resolveGameAssetUrl = (assetUrl) => {
 };
 
 export const verifyPassword = async (password) => {
-    await axios.post(`${BASE_URL}/verify-password`, {
-        password
-    });
-    return true;
+    await apiClient.post(`${BASE_URL}/verify-password`, { password });
+};
+
+export const checkAccessSession = async () => {
+    await apiClient.get(`${BASE_URL}/access-session`);
 };

--- a/frontend/src/components/GameImage.jsx
+++ b/frontend/src/components/GameImage.jsx
@@ -16,16 +16,7 @@ const GameImage = ({ src, alt, onAuthError }) => {
         let cancelled = false;
         let objectUrl = null;
 
-        if (!src) {
-            setImageSrc(null);
-            setIsLoading(false);
-            setHasError(false);
-            return undefined;
-        }
-
-        setIsLoading(true);
-        setHasError(false);
-        setImageSrc(null);
+        if (!src) return undefined;
 
         fetchGameImage(src)
             .then((blob) => {

--- a/frontend/src/components/GameImage.jsx
+++ b/frontend/src/components/GameImage.jsx
@@ -1,7 +1,55 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { fetchGameImage } from '../api/gameApi';
+import { isAccessAuthError } from '../api/apiError';
 
-const GameImage = ({ src, alt }) => {
-    const [isLoading, setIsLoading] = useState(true);
+const GameImage = ({ src, alt, onAuthError }) => {
+    const [imageSrc, setImageSrc] = useState(null);
+    const [isLoading, setIsLoading] = useState(Boolean(src));
+    const [hasError, setHasError] = useState(false);
+    const onAuthErrorRef = useRef(onAuthError);
+
+    useEffect(() => {
+        onAuthErrorRef.current = onAuthError;
+    }, [onAuthError]);
+
+    useEffect(() => {
+        let cancelled = false;
+        let objectUrl = null;
+
+        if (!src) {
+            setImageSrc(null);
+            setIsLoading(false);
+            setHasError(false);
+            return undefined;
+        }
+
+        setIsLoading(true);
+        setHasError(false);
+        setImageSrc(null);
+
+        fetchGameImage(src)
+            .then((blob) => {
+                if (cancelled) return;
+                objectUrl = URL.createObjectURL(blob);
+                setImageSrc(objectUrl);
+            })
+            .catch((error) => {
+                if (cancelled) return;
+                if (isAccessAuthError(error) && onAuthErrorRef.current) {
+                    onAuthErrorRef.current(error);
+                    return;
+                }
+                setHasError(true);
+            })
+            .finally(() => {
+                if (!cancelled) setIsLoading(false);
+            });
+
+        return () => {
+            cancelled = true;
+            if (objectUrl) URL.revokeObjectURL(objectUrl);
+        };
+    }, [src]);
 
     return (
         <div style={{
@@ -36,17 +84,17 @@ const GameImage = ({ src, alt }) => {
                 </div>
             )}
 
-            <img
-                src={src}
-                alt={alt}
-                onLoad={() => setIsLoading(false)}
-                style={{
-                    width: '100%',
-                    display: 'block',
-                    opacity: isLoading ? 0 : 1,
-                    transition: 'opacity 0.5s ease-in-out'
-                }}
-            />
+            {hasError && !isLoading && (
+                <p style={{ color: '#aaa', textAlign: 'center' }}>이미지를 불러오지 못했습니다.</p>
+            )}
+
+            {imageSrc && (
+                <img
+                    src={imageSrc}
+                    alt={alt}
+                    style={{ width: '100%', display: 'block' }}
+                />
+            )}
 
             <style>{`
         @keyframes spin {

--- a/src/main/java/com/uctale/uctale/controller/AccessController.java
+++ b/src/main/java/com/uctale/uctale/controller/AccessController.java
@@ -1,0 +1,45 @@
+package com.uctale.uctale.controller;
+
+import com.uctale.uctale.dto.AccessPasswordRequest;
+import com.uctale.uctale.security.AccessSessionService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/game")
+public class AccessController {
+
+    private final AccessSessionService accessSessionService;
+
+    public AccessController(AccessSessionService accessSessionService) {
+        this.accessSessionService = accessSessionService;
+    }
+
+    @PostMapping("/verify-password")
+    public ResponseEntity<Void> verifyPassword(@Valid @RequestBody AccessPasswordRequest request) {
+        String token = accessSessionService.authenticate(request.password());
+        ResponseCookie cookie = ResponseCookie.from(AccessSessionService.COOKIE_NAME, token)
+                .httpOnly(true)
+                .secure(accessSessionService.secureCookie())
+                .sameSite(accessSessionService.sameSite())
+                .path("/api/game")
+                .maxAge(accessSessionService.ttl())
+                .build();
+
+        return ResponseEntity.noContent()
+                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .build();
+    }
+
+    @GetMapping("/access-session")
+    public ResponseEntity<Void> accessSession() {
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/uctale/uctale/controller/ApiExceptionHandler.java
+++ b/src/main/java/com/uctale/uctale/controller/ApiExceptionHandler.java
@@ -5,6 +5,7 @@ import com.uctale.uctale.application.game.InvalidChoiceException;
 import com.uctale.uctale.application.game.PersistenceOperationException;
 import com.uctale.uctale.application.game.TurnConflictException;
 import com.uctale.uctale.application.narrative.InvalidNarrativeResponseException;
+import com.uctale.uctale.security.AccessSessionException;
 import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +15,11 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class ApiExceptionHandler {
+
+    @ExceptionHandler(AccessSessionException.class)
+    public ResponseEntity<ApiError> handleAccessSession(AccessSessionException exception) {
+        return error(HttpStatus.UNAUTHORIZED, exception.code(), exception.getMessage());
+    }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ApiError> handleIllegalArgument(IllegalArgumentException exception) {

--- a/src/main/java/com/uctale/uctale/controller/ApiExceptionHandler.java
+++ b/src/main/java/com/uctale/uctale/controller/ApiExceptionHandler.java
@@ -5,6 +5,7 @@ import com.uctale.uctale.application.game.InvalidChoiceException;
 import com.uctale.uctale.application.game.PersistenceOperationException;
 import com.uctale.uctale.application.game.TurnConflictException;
 import com.uctale.uctale.application.narrative.InvalidNarrativeResponseException;
+import com.uctale.uctale.security.AccessRequestForbiddenException;
 import com.uctale.uctale.security.AccessSessionException;
 import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
@@ -19,6 +20,11 @@ public class ApiExceptionHandler {
     @ExceptionHandler(AccessSessionException.class)
     public ResponseEntity<ApiError> handleAccessSession(AccessSessionException exception) {
         return error(HttpStatus.UNAUTHORIZED, exception.code(), exception.getMessage());
+    }
+
+    @ExceptionHandler(AccessRequestForbiddenException.class)
+    public ResponseEntity<ApiError> handleAccessRequestForbidden(AccessRequestForbiddenException exception) {
+        return error(HttpStatus.FORBIDDEN, "ACCESS_REQUEST_FORBIDDEN", exception.getMessage());
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/src/main/java/com/uctale/uctale/controller/GameController.java
+++ b/src/main/java/com/uctale/uctale/controller/GameController.java
@@ -7,32 +7,19 @@ import com.uctale.uctale.service.GameService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.Map;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
 @RequestMapping("/api/game")
 @RequiredArgsConstructor
-@CrossOrigin(origins = "*")
 public class GameController {
 
     private final GameService gameService;
-
-    @Value("${game.access.password}")
-    private String accessPassword;
-
-    @PostMapping("/verify-password")
-    public ResponseEntity<?> verifyPassword(@RequestBody Map<String, String> payload) {
-        String inputPassword = payload.get("password");
-        if (accessPassword.equals(inputPassword)) {
-            return ResponseEntity.ok().build();
-        }
-        return ResponseEntity.status(401).body("비밀번호가 틀렸습니다.");
-    }
 
     @PostMapping("/init")
     public ResponseEntity<GameResponse> initGame(@Valid @RequestBody GameInitRequest request) {

--- a/src/main/java/com/uctale/uctale/controller/ImageController.java
+++ b/src/main/java/com/uctale/uctale/controller/ImageController.java
@@ -44,7 +44,7 @@ public class ImageController {
 
         return ResponseEntity.ok()
                 .contentType(generatedImage.contentType())
-                .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic())
+                .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePrivate())
                 .body(generatedImage.bytes());
     }
 

--- a/src/main/java/com/uctale/uctale/controller/ImageController.java
+++ b/src/main/java/com/uctale/uctale/controller/ImageController.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -20,7 +19,6 @@ import java.util.concurrent.TimeUnit;
 @RestController
 @RequestMapping("/api/game")
 @RequiredArgsConstructor
-@CrossOrigin(origins = "*")
 public class ImageController {
 
     private static final int MAX_PROMPT_LENGTH = 2000;

--- a/src/main/java/com/uctale/uctale/dto/AccessPasswordRequest.java
+++ b/src/main/java/com/uctale/uctale/dto/AccessPasswordRequest.java
@@ -1,0 +1,10 @@
+package com.uctale.uctale.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AccessPasswordRequest(
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Size(max = 128, message = "비밀번호가 너무 깁니다.")
+        String password
+) {}

--- a/src/main/java/com/uctale/uctale/security/AccessRequestForbiddenException.java
+++ b/src/main/java/com/uctale/uctale/security/AccessRequestForbiddenException.java
@@ -1,0 +1,7 @@
+package com.uctale.uctale.security;
+
+public class AccessRequestForbiddenException extends RuntimeException {
+    public AccessRequestForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/uctale/uctale/security/AccessSessionException.java
+++ b/src/main/java/com/uctale/uctale/security/AccessSessionException.java
@@ -1,0 +1,14 @@
+package com.uctale.uctale.security;
+
+public class AccessSessionException extends RuntimeException {
+    private final String code;
+
+    public AccessSessionException(String code, String message) {
+        super(message);
+        this.code = code;
+    }
+
+    public String code() {
+        return code;
+    }
+}

--- a/src/main/java/com/uctale/uctale/security/AccessSessionInterceptor.java
+++ b/src/main/java/com/uctale/uctale/security/AccessSessionInterceptor.java
@@ -1,0 +1,37 @@
+package com.uctale.uctale.security;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.Arrays;
+
+@Component
+public class AccessSessionInterceptor implements HandlerInterceptor {
+
+    private final AccessSessionService accessSessionService;
+
+    public AccessSessionInterceptor(AccessSessionService accessSessionService) {
+        this.accessSessionService = accessSessionService;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+            return true;
+        }
+
+        String token = request.getCookies() == null
+                ? null
+                : Arrays.stream(request.getCookies())
+                .filter(cookie -> AccessSessionService.COOKIE_NAME.equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
+
+        accessSessionService.validate(token);
+        return true;
+    }
+}

--- a/src/main/java/com/uctale/uctale/security/AccessSessionInterceptor.java
+++ b/src/main/java/com/uctale/uctale/security/AccessSessionInterceptor.java
@@ -11,6 +11,9 @@ import java.util.Arrays;
 @Component
 public class AccessSessionInterceptor implements HandlerInterceptor {
 
+    public static final String CLIENT_HEADER = "X-UCTale-Client";
+    public static final String CLIENT_HEADER_VALUE = "web";
+
     private final AccessSessionService accessSessionService;
 
     public AccessSessionInterceptor(AccessSessionService accessSessionService) {
@@ -32,6 +35,10 @@ public class AccessSessionInterceptor implements HandlerInterceptor {
                 .orElse(null);
 
         accessSessionService.validate(token);
+
+        if (!CLIENT_HEADER_VALUE.equals(request.getHeader(CLIENT_HEADER))) {
+            throw new AccessRequestForbiddenException("허용된 클라이언트 요청이 아닙니다.");
+        }
         return true;
     }
 }

--- a/src/main/java/com/uctale/uctale/security/AccessSessionService.java
+++ b/src/main/java/com/uctale/uctale/security/AccessSessionService.java
@@ -1,5 +1,6 @@
 package com.uctale.uctale.security;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -26,6 +27,7 @@ public class AccessSessionService {
     private final boolean secureCookie;
     private final Clock clock;
 
+    @Autowired
     public AccessSessionService(
             @Value("${game.access.password}") String accessPassword,
             @Value("${game.access.session-secret}") String sessionSecret,

--- a/src/main/java/com/uctale/uctale/security/AccessSessionService.java
+++ b/src/main/java/com/uctale/uctale/security/AccessSessionService.java
@@ -1,0 +1,124 @@
+package com.uctale.uctale.security;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+
+@Service
+public class AccessSessionService {
+
+    public static final String COOKIE_NAME = "uctale_access";
+    private static final String HMAC_ALGORITHM = "HmacSHA256";
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private final byte[] signingSecret;
+    private final byte[] accessPassword;
+    private final Duration ttl;
+    private final boolean secureCookie;
+    private final Clock clock;
+
+    public AccessSessionService(
+            @Value("${game.access.password}") String accessPassword,
+            @Value("${game.access.session-secret}") String sessionSecret,
+            @Value("${game.access.session-ttl-seconds:3600}") long ttlSeconds,
+            @Value("${game.access.cookie-secure:true}") boolean secureCookie
+    ) {
+        this(accessPassword, sessionSecret, Duration.ofSeconds(ttlSeconds), secureCookie, Clock.systemUTC());
+    }
+
+    AccessSessionService(String accessPassword, String sessionSecret, Duration ttl, boolean secureCookie, Clock clock) {
+        if (sessionSecret == null || sessionSecret.length() < 32) {
+            throw new IllegalArgumentException("game.access.session-secret은 32자 이상이어야 합니다.");
+        }
+        this.accessPassword = accessPassword.getBytes(StandardCharsets.UTF_8);
+        this.signingSecret = sessionSecret.getBytes(StandardCharsets.UTF_8);
+        this.ttl = ttl;
+        this.secureCookie = secureCookie;
+        this.clock = clock;
+    }
+
+    public String authenticate(String candidatePassword) {
+        byte[] candidate = candidatePassword == null
+                ? new byte[0]
+                : candidatePassword.getBytes(StandardCharsets.UTF_8);
+        if (!MessageDigest.isEqual(accessPassword, candidate)) {
+            throw new AccessSessionException("INVALID_CREDENTIALS", "비밀번호가 올바르지 않습니다.");
+        }
+        return issueToken();
+    }
+
+    public void validate(String token) {
+        if (token == null || token.isBlank()) {
+            throw new AccessSessionException("ACCESS_SESSION_REQUIRED", "접근 인증이 필요합니다.");
+        }
+        String[] parts = token.split("\\.");
+        if (parts.length != 4 || !"v1".equals(parts[0])) {
+            throw invalid();
+        }
+
+        long expiresAt;
+        try {
+            expiresAt = Long.parseLong(parts[1]);
+        } catch (NumberFormatException exception) {
+            throw invalid();
+        }
+
+        String payload = String.join(".", parts[0], parts[1], parts[2]);
+        byte[] expected = sign(payload);
+        byte[] actual;
+        try {
+            actual = Base64.getUrlDecoder().decode(parts[3]);
+        } catch (IllegalArgumentException exception) {
+            throw invalid();
+        }
+        if (!MessageDigest.isEqual(expected, actual)) {
+            throw invalid();
+        }
+        if (!Instant.ofEpochSecond(expiresAt).isAfter(clock.instant())) {
+            throw new AccessSessionException("ACCESS_SESSION_EXPIRED", "접근 세션이 만료되었습니다.");
+        }
+    }
+
+    public Duration ttl() {
+        return ttl;
+    }
+
+    public boolean secureCookie() {
+        return secureCookie;
+    }
+
+    public String sameSite() {
+        return secureCookie ? "None" : "Lax";
+    }
+
+    private String issueToken() {
+        long expiresAt = clock.instant().plus(ttl).getEpochSecond();
+        byte[] nonce = new byte[18];
+        SECURE_RANDOM.nextBytes(nonce);
+        String payload = "v1." + expiresAt + "." + Base64.getUrlEncoder().withoutPadding().encodeToString(nonce);
+        return payload + "." + Base64.getUrlEncoder().withoutPadding().encodeToString(sign(payload));
+    }
+
+    private byte[] sign(String payload) {
+        try {
+            Mac mac = Mac.getInstance(HMAC_ALGORITHM);
+            mac.init(new SecretKeySpec(signingSecret, HMAC_ALGORITHM));
+            return mac.doFinal(payload.getBytes(StandardCharsets.UTF_8));
+        } catch (Exception exception) {
+            throw new IllegalStateException("접근 세션 서명에 실패했습니다.", exception);
+        }
+    }
+
+    private AccessSessionException invalid() {
+        return new AccessSessionException("ACCESS_SESSION_INVALID", "접근 세션이 올바르지 않습니다.");
+    }
+}

--- a/src/main/java/com/uctale/uctale/security/SecurityWebConfig.java
+++ b/src/main/java/com/uctale/uctale/security/SecurityWebConfig.java
@@ -1,0 +1,56 @@
+package com.uctale.uctale.security;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Configuration
+public class SecurityWebConfig implements WebMvcConfigurer {
+
+    private final AccessSessionInterceptor accessSessionInterceptor;
+
+    public SecurityWebConfig(AccessSessionInterceptor accessSessionInterceptor) {
+        this.accessSessionInterceptor = accessSessionInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(accessSessionInterceptor)
+                .addPathPatterns(
+                        "/api/game/init",
+                        "/api/game/progress",
+                        "/api/game/image",
+                        "/api/game/access-session"
+                );
+    }
+
+    @Bean
+    CorsFilter corsFilter(@Value("${game.cors.allowed-origins}") String configuredOrigins) {
+        List<String> origins = Arrays.stream(configuredOrigins.split(","))
+                .map(String::trim)
+                .filter(value -> !value.isBlank())
+                .toList();
+        if (origins.isEmpty() || origins.stream().anyMatch("*"::equals)) {
+            throw new IllegalArgumentException("game.cors.allowed-origins는 명시적 origin allowlist여야 합니다.");
+        }
+
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(origins);
+        configuration.setAllowedMethods(List.of("GET", "POST", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("Content-Type"));
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/api/**", configuration);
+        return new CorsFilter(source);
+    }
+}

--- a/src/main/java/com/uctale/uctale/security/SecurityWebConfig.java
+++ b/src/main/java/com/uctale/uctale/security/SecurityWebConfig.java
@@ -45,7 +45,7 @@ public class SecurityWebConfig implements WebMvcConfigurer {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(origins);
         configuration.setAllowedMethods(List.of("GET", "POST", "OPTIONS"));
-        configuration.setAllowedHeaders(List.of("Content-Type"));
+        configuration.setAllowedHeaders(List.of("Content-Type", AccessSessionInterceptor.CLIENT_HEADER));
         configuration.setAllowCredentials(true);
         configuration.setMaxAge(3600L);
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,6 +3,10 @@ spring.application.name=uctale
 google.ai.api-key=${GOOGLE_AI_API_KEY}
 pollinations.token=${POLLINATIONS_TOKEN}
 game.access.password=${GAME_ACCESS_PASSWORD}
+game.access.session-secret=${GAME_ACCESS_SESSION_SECRET}
+game.access.session-ttl-seconds=${GAME_ACCESS_SESSION_TTL_SECONDS:3600}
+game.access.cookie-secure=${GAME_ACCESS_COOKIE_SECURE:true}
+game.cors.allowed-origins=${GAME_CORS_ALLOWED_ORIGINS:https://uctale.vercel.app}
 
 spring.datasource.url=${DATABASE_URL}
 spring.datasource.username=${DATABASE_USERNAME}

--- a/src/test/java/com/uctale/uctale/controller/AccessControllerTest.java
+++ b/src/test/java/com/uctale/uctale/controller/AccessControllerTest.java
@@ -1,0 +1,84 @@
+package com.uctale.uctale.controller;
+
+import com.uctale.uctale.security.AccessSessionInterceptor;
+import com.uctale.uctale.security.AccessSessionService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class AccessControllerTest {
+
+    private static final String SECRET = "0123456789abcdef0123456789abcdef";
+
+    @Test
+    @DisplayName("올바른 비밀번호는 HttpOnly 접근 쿠키를 발급한다")
+    void verifyPassword_IssuesHttpOnlyCookie() throws Exception {
+        AccessSessionService service = new AccessSessionService("TEST_PASSWORD", SECRET, 3600, false);
+        MockMvc mockMvc = MockMvcBuilders.standaloneSetup(new AccessController(service))
+                .setControllerAdvice(new ApiExceptionHandler())
+                .build();
+
+        mockMvc.perform(post("/api/game/verify-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"password\":\"TEST_PASSWORD\"}"))
+                .andExpect(status().isNoContent())
+                .andExpect(header().string("Set-Cookie", containsString("uctale_access=")))
+                .andExpect(header().string("Set-Cookie", containsString("HttpOnly")))
+                .andExpect(header().string("Set-Cookie", containsString("SameSite=Lax")));
+    }
+
+    @Test
+    @DisplayName("잘못된 비밀번호는 안정적인 401 오류를 반환한다")
+    void verifyPassword_RejectsWrongPassword() throws Exception {
+        AccessSessionService service = new AccessSessionService("TEST_PASSWORD", SECRET, 3600, false);
+        MockMvc mockMvc = MockMvcBuilders.standaloneSetup(new AccessController(service))
+                .setControllerAdvice(new ApiExceptionHandler())
+                .build();
+
+        mockMvc.perform(post("/api/game/verify-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"password\":\"wrong\"}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("INVALID_CREDENTIALS"));
+    }
+
+    @Test
+    @DisplayName("만료된 접근 쿠키는 보호 API에서 401로 거부한다")
+    void protectedEndpoint_RejectsExpiredSession() throws Exception {
+        AccessSessionService service = new AccessSessionService("TEST_PASSWORD", SECRET, -1, false);
+        String expiredToken = service.authenticate("TEST_PASSWORD");
+        AccessSessionInterceptor interceptor = new AccessSessionInterceptor(service);
+        MockMvc mockMvc = MockMvcBuilders.standaloneSetup(new AccessController(service))
+                .setControllerAdvice(new ApiExceptionHandler())
+                .addInterceptors(interceptor)
+                .build();
+
+        mockMvc.perform(get("/api/game/access-session")
+                        .cookie(new jakarta.servlet.http.Cookie(AccessSessionService.COOKIE_NAME, expiredToken)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("ACCESS_SESSION_EXPIRED"));
+    }
+
+    @Test
+    @DisplayName("접근 쿠키가 없으면 보호 API에서 401로 거부한다")
+    void protectedEndpoint_RejectsMissingSession() throws Exception {
+        AccessSessionService service = new AccessSessionService("TEST_PASSWORD", SECRET, 3600, false);
+        MockMvc mockMvc = MockMvcBuilders.standaloneSetup(new AccessController(service))
+                .setControllerAdvice(new ApiExceptionHandler())
+                .addInterceptors(new AccessSessionInterceptor(service))
+                .build();
+
+        mockMvc.perform(get("/api/game/access-session"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("ACCESS_SESSION_REQUIRED"));
+    }
+}

--- a/src/test/java/com/uctale/uctale/controller/AccessControllerTest.java
+++ b/src/test/java/com/uctale/uctale/controller/AccessControllerTest.java
@@ -20,9 +20,9 @@ class AccessControllerTest {
     private static final String SECRET = "0123456789abcdef0123456789abcdef";
 
     @Test
-    @DisplayName("올바른 비밀번호는 HttpOnly 접근 쿠키를 발급한다")
-    void verifyPassword_IssuesHttpOnlyCookie() throws Exception {
-        AccessSessionService service = new AccessSessionService("TEST_PASSWORD", SECRET, 3600, false);
+    @DisplayName("올바른 비밀번호는 운영용 HttpOnly Secure 접근 쿠키를 발급한다")
+    void verifyPassword_IssuesSecureHttpOnlyCookie() throws Exception {
+        AccessSessionService service = new AccessSessionService("TEST_PASSWORD", SECRET, 3600, true);
         MockMvc mockMvc = MockMvcBuilders.standaloneSetup(new AccessController(service))
                 .setControllerAdvice(new ApiExceptionHandler())
                 .build();
@@ -33,7 +33,8 @@ class AccessControllerTest {
                 .andExpect(status().isNoContent())
                 .andExpect(header().string("Set-Cookie", containsString("uctale_access=")))
                 .andExpect(header().string("Set-Cookie", containsString("HttpOnly")))
-                .andExpect(header().string("Set-Cookie", containsString("SameSite=Lax")));
+                .andExpect(header().string("Set-Cookie", containsString("Secure")))
+                .andExpect(header().string("Set-Cookie", containsString("SameSite=None")));
     }
 
     @Test

--- a/src/test/java/com/uctale/uctale/controller/AccessControllerTest.java
+++ b/src/test/java/com/uctale/uctale/controller/AccessControllerTest.java
@@ -2,6 +2,7 @@ package com.uctale.uctale.controller;
 
 import com.uctale.uctale.security.AccessSessionInterceptor;
 import com.uctale.uctale.security.AccessSessionService;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -58,13 +59,10 @@ class AccessControllerTest {
         AccessSessionService service = new AccessSessionService("TEST_PASSWORD", SECRET, -1, false);
         String expiredToken = service.authenticate("TEST_PASSWORD");
         AccessSessionInterceptor interceptor = new AccessSessionInterceptor(service);
-        MockMvc mockMvc = MockMvcBuilders.standaloneSetup(new AccessController(service))
-                .setControllerAdvice(new ApiExceptionHandler())
-                .addInterceptors(interceptor)
-                .build();
+        MockMvc mockMvc = protectedMockMvc(service, interceptor);
 
         mockMvc.perform(get("/api/game/access-session")
-                        .cookie(new jakarta.servlet.http.Cookie(AccessSessionService.COOKIE_NAME, expiredToken)))
+                        .cookie(new Cookie(AccessSessionService.COOKIE_NAME, expiredToken)))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value("ACCESS_SESSION_EXPIRED"));
     }
@@ -73,13 +71,43 @@ class AccessControllerTest {
     @DisplayName("접근 쿠키가 없으면 보호 API에서 401로 거부한다")
     void protectedEndpoint_RejectsMissingSession() throws Exception {
         AccessSessionService service = new AccessSessionService("TEST_PASSWORD", SECRET, 3600, false);
-        MockMvc mockMvc = MockMvcBuilders.standaloneSetup(new AccessController(service))
-                .setControllerAdvice(new ApiExceptionHandler())
-                .addInterceptors(new AccessSessionInterceptor(service))
-                .build();
+        MockMvc mockMvc = protectedMockMvc(service, new AccessSessionInterceptor(service));
 
         mockMvc.perform(get("/api/game/access-session"))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value("ACCESS_SESSION_REQUIRED"));
+    }
+
+    @Test
+    @DisplayName("유효한 쿠키가 있어도 client header가 없으면 403으로 거부한다")
+    void protectedEndpoint_RejectsMissingClientHeader() throws Exception {
+        AccessSessionService service = new AccessSessionService("TEST_PASSWORD", SECRET, 3600, false);
+        String token = service.authenticate("TEST_PASSWORD");
+        MockMvc mockMvc = protectedMockMvc(service, new AccessSessionInterceptor(service));
+
+        mockMvc.perform(get("/api/game/access-session")
+                        .cookie(new Cookie(AccessSessionService.COOKIE_NAME, token)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("ACCESS_REQUEST_FORBIDDEN"));
+    }
+
+    @Test
+    @DisplayName("유효한 쿠키와 client header가 있으면 보호 API를 호출한다")
+    void protectedEndpoint_AcceptsSessionAndClientHeader() throws Exception {
+        AccessSessionService service = new AccessSessionService("TEST_PASSWORD", SECRET, 3600, false);
+        String token = service.authenticate("TEST_PASSWORD");
+        MockMvc mockMvc = protectedMockMvc(service, new AccessSessionInterceptor(service));
+
+        mockMvc.perform(get("/api/game/access-session")
+                        .cookie(new Cookie(AccessSessionService.COOKIE_NAME, token))
+                        .header(AccessSessionInterceptor.CLIENT_HEADER, AccessSessionInterceptor.CLIENT_HEADER_VALUE))
+                .andExpect(status().isNoContent());
+    }
+
+    private MockMvc protectedMockMvc(AccessSessionService service, AccessSessionInterceptor interceptor) {
+        return MockMvcBuilders.standaloneSetup(new AccessController(service))
+                .setControllerAdvice(new ApiExceptionHandler())
+                .addInterceptors(interceptor)
+                .build();
     }
 }

--- a/src/test/java/com/uctale/uctale/controller/ImageControllerTest.java
+++ b/src/test/java/com/uctale/uctale/controller/ImageControllerTest.java
@@ -58,8 +58,8 @@ class ImageControllerTest {
     }
 
     @Test
-    @DisplayName("이미지 provider 성공 시 이미지 바이트와 콘텐츠 타입을 반환한다")
-    void image_ReturnsGeneratedImage() {
+    @DisplayName("이미지 provider 성공 시 private cache 이미지 응답을 반환한다")
+    void image_ReturnsGeneratedImageWithPrivateCache() {
         ImageController controller = new ImageController(imageGenerator);
         byte[] bytes = new byte[]{1, 2, 3};
         given(imageGenerator.fetchImage("zombie", "16:9"))
@@ -69,6 +69,7 @@ class ImageControllerTest {
 
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getHeaders().getContentType()).isEqualTo(MediaType.IMAGE_PNG);
+        assertThat(response.getHeaders().getCacheControl()).contains("private");
         assertThat(response.getBody()).containsExactly(bytes);
     }
 }

--- a/src/test/java/com/uctale/uctale/security/SecurityWebConfigTest.java
+++ b/src/test/java/com/uctale/uctale/security/SecurityWebConfigTest.java
@@ -15,7 +15,7 @@ class SecurityWebConfigTest {
     private static final String SECRET = "0123456789abcdef0123456789abcdef";
 
     @Test
-    @DisplayName("명시된 Vercel origin만 credential CORS 응답을 받는다")
+    @DisplayName("명시된 Vercel origin만 보호 client header credential CORS 응답을 받는다")
     void cors_AllowsConfiguredOriginOnly() throws Exception {
         AccessSessionService service = new AccessSessionService("pw", SECRET, 3600, true);
         SecurityWebConfig config = new SecurityWebConfig(new AccessSessionInterceptor(service));
@@ -26,6 +26,7 @@ class SecurityWebConfigTest {
         filter.doFilter(allowed, allowedResponse, new MockFilterChain());
         assertThat(allowedResponse.getHeader("Access-Control-Allow-Origin")).isEqualTo("https://uctale.vercel.app");
         assertThat(allowedResponse.getHeader("Access-Control-Allow-Credentials")).isEqualTo("true");
+        assertThat(allowedResponse.getHeader("Access-Control-Allow-Headers")).containsIgnoringCase(AccessSessionInterceptor.CLIENT_HEADER);
 
         MockHttpServletRequest denied = preflight("https://evil.example");
         MockHttpServletResponse deniedResponse = new MockHttpServletResponse();
@@ -59,6 +60,7 @@ class SecurityWebConfigTest {
         MockHttpServletRequest request = new MockHttpServletRequest("OPTIONS", "/api/game/init");
         request.addHeader("Origin", origin);
         request.addHeader("Access-Control-Request-Method", "POST");
+        request.addHeader("Access-Control-Request-Headers", "Content-Type, " + AccessSessionInterceptor.CLIENT_HEADER);
         return request;
     }
 }

--- a/src/test/java/com/uctale/uctale/security/SecurityWebConfigTest.java
+++ b/src/test/java/com/uctale/uctale/security/SecurityWebConfigTest.java
@@ -1,0 +1,64 @@
+package com.uctale.uctale.security;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.filter.CorsFilter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SecurityWebConfigTest {
+
+    private static final String SECRET = "0123456789abcdef0123456789abcdef";
+
+    @Test
+    @DisplayName("명시된 Vercel origin만 credential CORS 응답을 받는다")
+    void cors_AllowsConfiguredOriginOnly() throws Exception {
+        AccessSessionService service = new AccessSessionService("pw", SECRET, 3600, true);
+        SecurityWebConfig config = new SecurityWebConfig(new AccessSessionInterceptor(service));
+        CorsFilter filter = config.corsFilter("https://uctale.vercel.app");
+
+        MockHttpServletRequest allowed = preflight("https://uctale.vercel.app");
+        MockHttpServletResponse allowedResponse = new MockHttpServletResponse();
+        filter.doFilter(allowed, allowedResponse, new MockFilterChain());
+        assertThat(allowedResponse.getHeader("Access-Control-Allow-Origin")).isEqualTo("https://uctale.vercel.app");
+        assertThat(allowedResponse.getHeader("Access-Control-Allow-Credentials")).isEqualTo("true");
+
+        MockHttpServletRequest denied = preflight("https://evil.example");
+        MockHttpServletResponse deniedResponse = new MockHttpServletResponse();
+        filter.doFilter(denied, deniedResponse, new MockFilterChain());
+        assertThat(deniedResponse.getHeader("Access-Control-Allow-Origin")).isNull();
+    }
+
+    @Test
+    @DisplayName("와일드카드 CORS 설정은 시작 단계에서 거부한다")
+    void cors_RejectsWildcard() {
+        AccessSessionService service = new AccessSessionService("pw", SECRET, 3600, true);
+        SecurityWebConfig config = new SecurityWebConfig(new AccessSessionInterceptor(service));
+        assertThatThrownBy(() -> config.corsFilter("*"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("서명된 접근 토큰은 변조되면 거부된다")
+    void session_RejectsTamperedToken() {
+        AccessSessionService service = new AccessSessionService("pw", SECRET, 3600, true);
+        String token = service.authenticate("pw");
+        String tampered = token.substring(0, token.length() - 1) + (token.endsWith("A") ? "B" : "A");
+
+        assertThatThrownBy(() -> service.validate(tampered))
+                .isInstanceOf(AccessSessionException.class)
+                .extracting("code")
+                .isEqualTo("ACCESS_SESSION_INVALID");
+    }
+
+    private MockHttpServletRequest preflight(String origin) {
+        MockHttpServletRequest request = new MockHttpServletRequest("OPTIONS", "/api/game/init");
+        request.addHeader("Origin", origin);
+        request.addHeader("Access-Control-Request-Method", "POST");
+        return request;
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,6 +1,10 @@
 google.ai.api-key=TEST_API_KEY
 pollinations.token=TEST_TOKEN
 game.access.password=TEST_PASSWORD
+game.access.session-secret=TEST_SESSION_SECRET_0123456789_0123456789
+game.access.session-ttl-seconds=3600
+game.access.cookie-secure=false
+game.cors.allowed-origins=http://localhost:5173
 
 spring.datasource.url=jdbc:h2:mem:uctaledb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE
 spring.datasource.driver-class-name=org.h2.Driver


### PR DESCRIPTION
## 왜 필요한가요?

공유 베타 비밀번호 확인이 실제 비용 API 보호로 이어지지 않고, `@CrossOrigin("*")`로 CORS가 넓게 열려 있던 문제를 해결합니다.

- Closes #24

## 무엇이 바뀌나요?

- 게임 규칙·상태: 게임 세션 소유권이나 게임 규칙은 변경하지 않습니다.
- Backend / API / DB: 비밀번호 검증 성공 시 HMAC-SHA256으로 서명한 단기 접근 세션을 HttpOnly 쿠키로 발급합니다. `/init`, `/progress`, `/image`, `/access-session`은 유효한 접근 쿠키와 보호 client header를 요구합니다.
- AI narrative / prompt: 변경 없음.
- Image generation: 이미지 생성 endpoint도 접근 세션으로 보호하고, 응답 캐시는 shared cache가 아닌 `private`로 제한합니다.
- Frontend / UX: 앱 진입 시 접근 세션을 확인하고, 미인증/만료/변조 상태에서는 비밀번호 화면으로 전환합니다. 이미지는 인증 Axios 요청으로 Blob을 받아 렌더링합니다. 토큰은 JavaScript나 Web Storage에 저장하지 않습니다.
- Build / deploy / docs: 운영 CORS 기본 allowlist를 `https://uctale.vercel.app`로 제한하고 새 환경변수를 README에 문서화합니다.

## 접근 세션 정책

- 쿠키: `HttpOnly`, path `/api/game`
- 운영 기본: `Secure; SameSite=None`
- 로컬 HTTP: `GAME_ACCESS_COOKIE_SECURE=false`일 때 `SameSite=Lax`
- 기본 TTL: 3600초
- 서명 secret: `GAME_ACCESS_SESSION_SECRET` 32자 이상 필수
- 세션 없음/만료/변조: 401 (`ACCESS_SESSION_REQUIRED`, `ACCESS_SESSION_EXPIRED`, `ACCESS_SESSION_INVALID`)
- 잘못된 공유 비밀번호: 401 (`INVALID_CREDENTIALS`)
- 유효한 세션이지만 보호 client header가 없는 요청: 403 (`ACCESS_REQUEST_FORBIDDEN`)

## CORS / cross-site 비용 보호

- 운영 기본 허용 origin: `https://uctale.vercel.app`
- 환경변수 `GAME_CORS_ALLOWED_ORIGINS`로 명시적 allowlist 설정
- wildcard `*`는 구성 단계에서 거부
- credentials 허용
- `GET`, `POST`, `OPTIONS`만 허용
- 보호 API는 `X-UCTale-Client: web`을 요구합니다. 브라우저 JS 요청이 CORS preflight를 거치게 하여 단순 `<img>` 등으로 인증 쿠키만 재사용하는 cross-site 비용 호출을 차단합니다.

## 어떻게 검증했나요?

- [x] `./gradlew clean test`
- [x] `./gradlew build`
- [x] `cd frontend && npm ci && npm test && npm run lint && npm run build`
- [x] 인증 성공/실패/누락/만료 API 테스트
- [x] 변조된 서명 토큰 거부 테스트
- [x] 유효한 쿠키 + client header 누락 시 403 테스트
- [x] Vercel allowlist 및 임의 origin 차단 테스트
- [x] custom client header CORS preflight 테스트
- [x] 운영 쿠키의 HttpOnly/Secure/SameSite=None 속성 테스트
- [x] 보호 이미지 응답의 private cache 테스트

최종 GitHub Actions CI #70에서 Backend test/build와 Frontend test/lint/build가 모두 성공했습니다.

## 추가 리뷰 후 보완

CI 통과 후 PR 전체 diff를 별도로 다시 검토했습니다.

1. **이미지 GET의 cross-site 비용 유발 가능성 발견 및 보완**
   - `SameSite=None` 쿠키는 Vercel → Render cross-site 구성에 필요하지만, 그대로 두면 외부 사이트의 `<img src=".../api/game/image">` 요청에도 쿠키가 실릴 수 있습니다.
   - CORS만으로는 단순 이미지 GET의 서버 실행 자체를 막지 못하므로, 보호 client header를 추가하고 프론트 이미지 로딩을 authenticated Axios Blob fetch로 변경했습니다.
2. **인증 이미지의 shared cache 노출 가능성 발견 및 보완**
   - 기존 `Cache-Control: public`은 인증된 이미지 응답에 부적절합니다.
   - `private` cache로 변경해 shared cache/CDN 재사용 가능성을 차단했습니다.
3. **CI 회귀 확인**
   - 보완 후 Backend/Frontend 전체 CI를 다시 실행해 최종 성공을 확인했습니다.

현재 코드 기준으로 merge를 막아야 할 추가 결함은 발견하지 못했습니다.

## 게임 상태·AI 안전성

- [x] 인증 실패는 Narrative/Image provider 호출 전에 거부됩니다.
- [x] 게임 결정적 상태와 Narrative 계약은 변경하지 않습니다.
- [x] 기존 GameState/DB schema 변경이 없습니다.

## 보안·비용

- [x] 비밀번호는 요청 검증에만 사용하고 로그에 남기지 않습니다.
- [x] 접근 토큰은 HttpOnly 쿠키로만 전달하며 프론트 코드/Web Storage에 저장하지 않습니다.
- [x] 서명 검증은 상수 시간 비교를 사용합니다.
- [x] 비용 발생 API와 이미지 endpoint를 미인증 사용자에게 차단합니다.
- [x] wildcard CORS를 제거했습니다.
- [x] 단순 cross-site 이미지 요청을 통한 비용 API 호출을 차단했습니다.

## API·DB·운영 영향

- [x] 새 환경변수: `GAME_ACCESS_SESSION_SECRET`
- [x] 선택 환경변수: `GAME_ACCESS_SESSION_TTL_SECONDS`, `GAME_ACCESS_COOKIE_SECURE`, `GAME_CORS_ALLOWED_ORIGINS`
- [x] 운영 기본 CORS origin은 `https://uctale.vercel.app`
- [x] DB migration 없음
- [x] **머지/배포 전 Render에 32자 이상 `GAME_ACCESS_SESSION_SECRET` 설정 완료**

## 운영 확인 항목

Render 환경변수에 `GAME_ACCESS_SESSION_SECRET` 설정을 완료했습니다. 머지 후 자동 배포가 끝나면 Vercel에서 로그인 → 게임 시작 → 진행 → 이미지 로딩 → 재인증 흐름을 smoke test해야 합니다.

Vercel과 Render가 서로 다른 site이므로 브라우저의 third-party cookie 정책에 따라 쿠키 전달이 제한될 가능성은 배포 smoke test에서 확인해야 합니다. 문제가 발생하면 same-site reverse proxy 또는 custom domain 구성이 후속 대안입니다.