### PR TITLE
feat(security): 게임 세션 소유권 검증 적용

### DIFF
--- a/docs/architecture/session-ownership.md
+++ b/docs/architecture/session-ownership.md
@@ -1,0 +1,52 @@
+# 게임 세션 소유권 정책
+
+## 목적
+
+공유 베타의 접근 비밀번호는 애플리케이션 진입을 제한할 뿐, 개별 `GameSession`의 소유자를 구분하지 못합니다. 이 문서는 접근 세션에서 파생한 owner key를 게임 세션에 연결하고, session ID를 아는 다른 접근 주체가 조회·진행하지 못하도록 하는 정책을 정의합니다.
+
+## Owner key
+
+- 공유 비밀번호 인증과 사용자 계정은 동일한 개념이 아닙니다.
+- 비밀번호 인증 성공 시 브라우저별 랜덤 owner key를 발급합니다.
+- owner key는 `uctale_owner` HttpOnly 쿠키에 HMAC 서명된 형태로 저장합니다.
+- 단기 `uctale_access` 쿠키에도 같은 owner key를 포함합니다.
+- 접근 쿠키는 기본 1시간, owner 쿠키는 기본 180일 유지합니다.
+- 재인증 시 유효한 owner 쿠키가 있으면 같은 owner key를 재사용합니다.
+- #24에서 발급된 기존 access 쿠키만 있는 경우 보호 API 첫 요청에서 access token의 nonce를 owner key로 승격해 owner 쿠키를 발급합니다.
+
+owner key 자체는 API 응답, URL, Web Storage에 노출하지 않습니다.
+
+## GameSession 소유권
+
+새 `GameSession`은 생성 시 `owner_key`를 반드시 저장합니다. session-scoped persistence 조회는 `sessionId` 단독 조회를 사용하지 않고 `sessionId + ownerKey` 조건을 사용합니다.
+
+진행 요청은 다음 두 시점 모두 소유권을 검사합니다.
+
+1. Narrative 호출 전 최신 턴을 불러올 때
+2. Narrative 호출 후 다음 턴을 저장하기 직전 세션을 다시 읽을 때
+
+따라서 service 단계에서 확인한 소유권이 persistence 저장 단계에서 누락되지 않습니다.
+
+## 404 / 403 정책
+
+- 유효한 접근 세션이 없으면 기존 접근 제어 정책대로 401을 반환합니다.
+- 유효한 접근 세션이지만 보호 client header가 없으면 403을 반환합니다.
+- session ID가 존재하지 않는 경우와 다른 owner의 session ID인 경우는 모두 `SESSION_NOT_FOUND` 404로 반환합니다.
+
+다른 사용자가 session ID의 존재 여부를 구분할 수 없도록 소유권 불일치를 별도 403으로 노출하지 않습니다.
+
+## 기존 익명 세션 migration
+
+V3 migration은 기존 `game_session` 행에 `legacy-{id}` owner key를 백필한 뒤 `owner_key`를 NOT NULL로 고정합니다.
+
+이 값은 실제 owner cookie가 허용하는 랜덤 Base64URL 형식과 의도적으로 호환되지 않습니다. 따라서 기존 익명 세션은 배포 후 누구도 새 owner identity로 선점할 수 없으며 읽기/진행이 차단됩니다.
+
+공유 베타 단계에서 영구 사용자 계정이나 세션 복구 UI가 없으므로, 보안상 기존 익명 세션의 접근을 끊는 것을 안전한 migration 정책으로 선택합니다.
+
+## 테스트 기준
+
+- 새 세션에 생성 owner가 저장되는지 persistence integration test로 검증합니다.
+- 같은 owner는 최신 턴을 조회·진행할 수 있는지 검증합니다.
+- 다른 owner는 동일 session ID에 대해 404를 받는지 API/persistence 양쪽에서 검증합니다.
+- 저장 직전 owner 재검증이 누락되지 않는지 service/persistence 테스트로 검증합니다.
+- 기존 access token에서 owner 쿠키를 승격하는 호환 경로와 재로그인 시 owner 유지 동작을 검증합니다.

--- a/src/main/java/com/uctale/uctale/application/game/GamePersistenceService.java
+++ b/src/main/java/com/uctale/uctale/application/game/GamePersistenceService.java
@@ -38,6 +38,7 @@ public class GamePersistenceService {
 
     @Transactional
     public GameSession saveOpening(
+            String ownerKey,
             String worldSetting,
             String characterSetting,
             String storyText,
@@ -45,7 +46,7 @@ public class GamePersistenceService {
             String imageUrl
     ) {
         try {
-            GameSession session = gameSessionRepository.save(new GameSession(worldSetting, characterSetting));
+            GameSession session = gameSessionRepository.save(new GameSession(ownerKey, worldSetting, characterSetting));
             GameState initialState = GameState.initial(worldSetting, characterSetting, storyText);
             gameStateSnapshotRepository.save(new GameStateSnapshot(session, gameStateCodec.serialize(initialState)));
             gameLogRepository.save(new GameLog(session, 1, storyText, choicesJson, imageUrl));
@@ -59,9 +60,8 @@ public class GamePersistenceService {
     }
 
     @Transactional(readOnly = true)
-    public LoadedTurn loadLatestTurn(Long sessionId, int expectedTurn) {
-        GameSession session = gameSessionRepository.findById(sessionId)
-                .orElseThrow(() -> new GameSessionNotFoundException("존재하지 않는 세션입니다."));
+    public LoadedTurn loadLatestTurn(String ownerKey, Long sessionId, int expectedTurn) {
+        GameSession session = findOwnedSession(ownerKey, sessionId);
 
         if (session.getCurrentTurn() != expectedTurn) {
             throw new TurnConflictException("이미 처리되었거나 오래된 턴 요청입니다.");
@@ -93,6 +93,7 @@ public class GamePersistenceService {
 
     @Transactional
     public int saveNextTurn(
+            String ownerKey,
             Long sessionId,
             int expectedTurn,
             String userChoice,
@@ -101,8 +102,7 @@ public class GamePersistenceService {
             String imageUrl
     ) {
         try {
-            GameSession session = gameSessionRepository.findById(sessionId)
-                    .orElseThrow(() -> new GameSessionNotFoundException("존재하지 않는 세션입니다."));
+            GameSession session = findOwnedSession(ownerKey, sessionId);
 
             if (session.getCurrentTurn() != expectedTurn) {
                 throw new TurnConflictException("이미 처리되었거나 오래된 턴 요청입니다.");
@@ -151,6 +151,11 @@ public class GamePersistenceService {
             }
             throw new PersistenceOperationException("게임 진행 상태를 저장할 수 없습니다.", exception);
         }
+    }
+
+    private GameSession findOwnedSession(String ownerKey, Long sessionId) {
+        return gameSessionRepository.findByIdAndOwnerKey(sessionId, ownerKey)
+                .orElseThrow(() -> new GameSessionNotFoundException("존재하지 않는 세션입니다."));
     }
 
     private boolean isTurnUniqueConstraintViolation(DataIntegrityViolationException exception) {

--- a/src/main/java/com/uctale/uctale/controller/AccessController.java
+++ b/src/main/java/com/uctale/uctale/controller/AccessController.java
@@ -2,6 +2,8 @@ package com.uctale.uctale.controller;
 
 import com.uctale.uctale.dto.AccessPasswordRequest;
 import com.uctale.uctale.security.AccessSessionService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
@@ -11,6 +13,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Arrays;
 
 @RestController
 @RequestMapping("/api/game")
@@ -23,23 +27,49 @@ public class AccessController {
     }
 
     @PostMapping("/verify-password")
-    public ResponseEntity<Void> verifyPassword(@Valid @RequestBody AccessPasswordRequest request) {
-        String token = accessSessionService.authenticate(request.password());
-        ResponseCookie cookie = ResponseCookie.from(AccessSessionService.COOKIE_NAME, token)
+    public ResponseEntity<Void> verifyPassword(
+            @Valid @RequestBody AccessPasswordRequest request,
+            HttpServletRequest servletRequest
+    ) {
+        String existingOwnerToken = findCookie(servletRequest, AccessSessionService.OWNER_COOKIE_NAME);
+        AccessSessionService.IssuedSession session = accessSessionService.authenticate(
+                request.password(),
+                existingOwnerToken
+        );
+
+        ResponseCookie accessCookie = ResponseCookie.from(AccessSessionService.COOKIE_NAME, session.accessToken())
                 .httpOnly(true)
                 .secure(accessSessionService.secureCookie())
                 .sameSite(accessSessionService.sameSite())
                 .path("/api/game")
                 .maxAge(accessSessionService.ttl())
                 .build();
+        ResponseCookie ownerCookie = ResponseCookie.from(AccessSessionService.OWNER_COOKIE_NAME, session.ownerToken())
+                .httpOnly(true)
+                .secure(accessSessionService.secureCookie())
+                .sameSite(accessSessionService.sameSite())
+                .path("/api/game")
+                .maxAge(accessSessionService.ownerTtl())
+                .build();
 
         return ResponseEntity.noContent()
-                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .header(HttpHeaders.SET_COOKIE, accessCookie.toString(), ownerCookie.toString())
                 .build();
     }
 
     @GetMapping("/access-session")
     public ResponseEntity<Void> accessSession() {
         return ResponseEntity.noContent().build();
+    }
+
+    private String findCookie(HttpServletRequest request, String name) {
+        if (request.getCookies() == null) {
+            return null;
+        }
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> name.equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/src/main/java/com/uctale/uctale/controller/GameController.java
+++ b/src/main/java/com/uctale/uctale/controller/GameController.java
@@ -3,12 +3,14 @@ package com.uctale.uctale.controller;
 import com.uctale.uctale.dto.GameInitRequest;
 import com.uctale.uctale.dto.GameProgressRequest;
 import com.uctale.uctale.dto.GameResponse;
+import com.uctale.uctale.security.AccessSessionInterceptor;
 import com.uctale.uctale.service.GameService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,14 +24,20 @@ public class GameController {
     private final GameService gameService;
 
     @PostMapping("/init")
-    public ResponseEntity<GameResponse> initGame(@Valid @RequestBody GameInitRequest request) {
+    public ResponseEntity<GameResponse> initGame(
+            @RequestAttribute(AccessSessionInterceptor.OWNER_KEY_ATTRIBUTE) String ownerKey,
+            @Valid @RequestBody GameInitRequest request
+    ) {
         log.info("게임 초기화 요청 수신");
-        return ResponseEntity.ok(gameService.initGame(request));
+        return ResponseEntity.ok(gameService.initGame(ownerKey, request));
     }
 
     @PostMapping("/progress")
-    public ResponseEntity<GameResponse> progressGame(@Valid @RequestBody GameProgressRequest request) {
+    public ResponseEntity<GameResponse> progressGame(
+            @RequestAttribute(AccessSessionInterceptor.OWNER_KEY_ATTRIBUTE) String ownerKey,
+            @Valid @RequestBody GameProgressRequest request
+    ) {
         log.info("게임 진행 요청: 세션ID={}, 기대턴={}", request.sessionId(), request.expectedTurn());
-        return ResponseEntity.ok(gameService.progressGame(request));
+        return ResponseEntity.ok(gameService.progressGame(ownerKey, request));
     }
 }

--- a/src/main/java/com/uctale/uctale/domain/GameSession.java
+++ b/src/main/java/com/uctale/uctale/domain/GameSession.java
@@ -28,6 +28,9 @@ public class GameSession {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false, length = 64)
+    private String ownerKey;
+
     @Column(nullable = false)
     private String worldSetting;
 
@@ -53,7 +56,8 @@ public class GameSession {
     @OneToMany(mappedBy = "gameSession", cascade = jakarta.persistence.CascadeType.ALL, orphanRemoval = true)
     private List<GameLog> logs = new ArrayList<>();
 
-    public GameSession(String worldSetting, String characterSetting) {
+    public GameSession(String ownerKey, String worldSetting, String characterSetting) {
+        this.ownerKey = ownerKey;
         this.worldSetting = worldSetting;
         this.characterSetting = characterSetting;
     }

--- a/src/main/java/com/uctale/uctale/repository/GameSessionRepository.java
+++ b/src/main/java/com/uctale/uctale/repository/GameSessionRepository.java
@@ -3,5 +3,8 @@ package com.uctale.uctale.repository;
 import com.uctale.uctale.domain.GameSession;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface GameSessionRepository extends JpaRepository<GameSession, Long> {
+    Optional<GameSession> findByIdAndOwnerKey(Long id, String ownerKey);
 }

--- a/src/main/java/com/uctale/uctale/security/AccessSessionInterceptor.java
+++ b/src/main/java/com/uctale/uctale/security/AccessSessionInterceptor.java
@@ -3,6 +3,8 @@ package com.uctale.uctale.security;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -13,6 +15,7 @@ public class AccessSessionInterceptor implements HandlerInterceptor {
 
     public static final String CLIENT_HEADER = "X-UCTale-Client";
     public static final String CLIENT_HEADER_VALUE = "web";
+    public static final String OWNER_KEY_ATTRIBUTE = "uctale.ownerKey";
 
     private final AccessSessionService accessSessionService;
 
@@ -26,19 +29,48 @@ public class AccessSessionInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        String token = request.getCookies() == null
-                ? null
-                : Arrays.stream(request.getCookies())
-                .filter(cookie -> AccessSessionService.COOKIE_NAME.equals(cookie.getName()))
-                .map(Cookie::getValue)
-                .findFirst()
-                .orElse(null);
-
-        accessSessionService.validate(token);
+        String accessToken = findCookie(request, AccessSessionService.COOKIE_NAME);
+        AccessSessionService.AccessPrincipal principal = accessSessionService.validateAndGetPrincipal(accessToken);
 
         if (!CLIENT_HEADER_VALUE.equals(request.getHeader(CLIENT_HEADER))) {
             throw new AccessRequestForbiddenException("허용된 클라이언트 요청이 아닙니다.");
         }
+
+        request.setAttribute(OWNER_KEY_ATTRIBUTE, principal.ownerKey());
+        ensureOwnerCookie(request, response, principal.ownerKey());
         return true;
+    }
+
+    private void ensureOwnerCookie(HttpServletRequest request, HttpServletResponse response, String ownerKey) {
+        String ownerToken = findCookie(request, AccessSessionService.OWNER_COOKIE_NAME);
+        boolean ownerMatches = accessSessionService.ownerKeyFromToken(ownerToken)
+                .filter(ownerKey::equals)
+                .isPresent();
+        if (ownerMatches) {
+            return;
+        }
+
+        ResponseCookie ownerCookie = ResponseCookie.from(
+                        AccessSessionService.OWNER_COOKIE_NAME,
+                        accessSessionService.issueOwnerToken(ownerKey)
+                )
+                .httpOnly(true)
+                .secure(accessSessionService.secureCookie())
+                .sameSite(accessSessionService.sameSite())
+                .path("/api/game")
+                .maxAge(accessSessionService.ownerTtl())
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, ownerCookie.toString());
+    }
+
+    private String findCookie(HttpServletRequest request, String name) {
+        if (request.getCookies() == null) {
+            return null;
+        }
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> name.equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/src/main/java/com/uctale/uctale/security/AccessSessionService.java
+++ b/src/main/java/com/uctale/uctale/security/AccessSessionService.java
@@ -12,18 +12,25 @@ import java.security.SecureRandom;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Base64;
+import java.util.Optional;
 
 @Service
 public class AccessSessionService {
 
     public static final String COOKIE_NAME = "uctale_access";
+    public static final String OWNER_COOKIE_NAME = "uctale_owner";
     private static final String HMAC_ALGORITHM = "HmacSHA256";
+    private static final String ACCESS_VERSION = "v1";
+    private static final String OWNER_VERSION = "o1";
+    private static final Duration DEFAULT_OWNER_TTL = Duration.ofDays(180);
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     private final byte[] signingSecret;
     private final byte[] accessPassword;
     private final Duration ttl;
+    private final Duration ownerTtl;
     private final boolean secureCookie;
     private final Clock clock;
 
@@ -32,38 +39,148 @@ public class AccessSessionService {
             @Value("${game.access.password}") String accessPassword,
             @Value("${game.access.session-secret}") String sessionSecret,
             @Value("${game.access.session-ttl-seconds:3600}") long ttlSeconds,
+            @Value("${game.owner.cookie-ttl-seconds:15552000}") long ownerTtlSeconds,
             @Value("${game.access.cookie-secure:true}") boolean secureCookie
     ) {
-        this(accessPassword, sessionSecret, Duration.ofSeconds(ttlSeconds), secureCookie, Clock.systemUTC());
+        this(
+                accessPassword,
+                sessionSecret,
+                Duration.ofSeconds(ttlSeconds),
+                Duration.ofSeconds(ownerTtlSeconds),
+                secureCookie,
+                Clock.systemUTC()
+        );
     }
 
-    AccessSessionService(String accessPassword, String sessionSecret, Duration ttl, boolean secureCookie, Clock clock) {
+    public AccessSessionService(String accessPassword, String sessionSecret, long ttlSeconds, boolean secureCookie) {
+        this(
+                accessPassword,
+                sessionSecret,
+                Duration.ofSeconds(ttlSeconds),
+                DEFAULT_OWNER_TTL,
+                secureCookie,
+                Clock.systemUTC()
+        );
+    }
+
+    AccessSessionService(
+            String accessPassword,
+            String sessionSecret,
+            Duration ttl,
+            Duration ownerTtl,
+            boolean secureCookie,
+            Clock clock
+    ) {
         if (sessionSecret == null || sessionSecret.length() < 32) {
             throw new IllegalArgumentException("game.access.session-secret은 32자 이상이어야 합니다.");
+        }
+        if (ownerTtl.isNegative() || ownerTtl.isZero()) {
+            throw new IllegalArgumentException("game.owner.cookie-ttl-seconds는 양수여야 합니다.");
         }
         this.accessPassword = accessPassword.getBytes(StandardCharsets.UTF_8);
         this.signingSecret = sessionSecret.getBytes(StandardCharsets.UTF_8);
         this.ttl = ttl;
+        this.ownerTtl = ownerTtl;
         this.secureCookie = secureCookie;
         this.clock = clock;
     }
 
+    public IssuedSession authenticate(String candidatePassword, String ownerToken) {
+        verifyPassword(candidatePassword);
+        String ownerKey = ownerKeyFromToken(ownerToken).orElseGet(this::generateOwnerKey);
+        return new IssuedSession(issueAccessToken(ownerKey), issueOwnerToken(ownerKey), ownerKey);
+    }
+
     public String authenticate(String candidatePassword) {
+        return authenticate(candidatePassword, null).accessToken();
+    }
+
+    public AccessPrincipal validateAndGetPrincipal(String token) {
+        ParsedAccessToken parsed = parseAccessToken(token);
+        if (!Instant.ofEpochSecond(parsed.expiresAt()).isAfter(clock.instant())) {
+            throw new AccessSessionException("ACCESS_SESSION_EXPIRED", "접근 세션이 만료되었습니다.");
+        }
+        return new AccessPrincipal(parsed.ownerKey());
+    }
+
+    public void validate(String token) {
+        validateAndGetPrincipal(token);
+    }
+
+    public Optional<String> ownerKeyFromToken(String token) {
+        if (token == null || token.isBlank()) {
+            return Optional.empty();
+        }
+        String[] parts = token.split("\\.");
+        if (parts.length != 3 || !OWNER_VERSION.equals(parts[0]) || !isValidOwnerKey(parts[1])) {
+            return Optional.empty();
+        }
+
+        String payload = "owner." + parts[0] + "." + parts[1];
+        byte[] actual;
+        try {
+            actual = Base64.getUrlDecoder().decode(parts[2]);
+        } catch (IllegalArgumentException exception) {
+            return Optional.empty();
+        }
+        if (!MessageDigest.isEqual(sign(payload), actual)) {
+            return Optional.empty();
+        }
+        return Optional.of(parts[1]);
+    }
+
+    public String issueOwnerToken(String ownerKey) {
+        if (!isValidOwnerKey(ownerKey)) {
+            throw new IllegalArgumentException("owner key가 올바르지 않습니다.");
+        }
+        String value = OWNER_VERSION + "." + ownerKey;
+        String payload = "owner." + value;
+        return value + "." + Base64.getUrlEncoder().withoutPadding().encodeToString(sign(payload));
+    }
+
+    public Duration ttl() {
+        return ttl;
+    }
+
+    public Duration ownerTtl() {
+        return ownerTtl;
+    }
+
+    public boolean secureCookie() {
+        return secureCookie;
+    }
+
+    public String sameSite() {
+        return secureCookie ? "None" : "Lax";
+    }
+
+    private void verifyPassword(String candidatePassword) {
         byte[] candidate = candidatePassword == null
                 ? new byte[0]
                 : candidatePassword.getBytes(StandardCharsets.UTF_8);
         if (!MessageDigest.isEqual(accessPassword, candidate)) {
             throw new AccessSessionException("INVALID_CREDENTIALS", "비밀번호가 올바르지 않습니다.");
         }
-        return issueToken();
     }
 
-    public void validate(String token) {
+    private String generateOwnerKey() {
+        byte[] random = new byte[24];
+        SECURE_RANDOM.nextBytes(random);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(random);
+    }
+
+    private String issueAccessToken(String ownerKey) {
+        long expiresAt = clock.instant().plus(ttl).getEpochSecond();
+        String payload = ACCESS_VERSION + "." + expiresAt + "." + ownerKey;
+        return payload + "." + Base64.getUrlEncoder().withoutPadding().encodeToString(sign(payload));
+    }
+
+    private ParsedAccessToken parseAccessToken(String token) {
         if (token == null || token.isBlank()) {
             throw new AccessSessionException("ACCESS_SESSION_REQUIRED", "접근 인증이 필요합니다.");
         }
         String[] parts = token.split("\\.");
-        if (parts.length != 4 || !"v1".equals(parts[0])) {
+        if (parts.length != 4 || !ACCESS_VERSION.equals(parts[0]) || !isValidOwnerKey(parts[2])) {
             throw invalid();
         }
 
@@ -75,39 +192,32 @@ public class AccessSessionService {
         }
 
         String payload = String.join(".", parts[0], parts[1], parts[2]);
-        byte[] expected = sign(payload);
         byte[] actual;
         try {
             actual = Base64.getUrlDecoder().decode(parts[3]);
         } catch (IllegalArgumentException exception) {
             throw invalid();
         }
-        if (!MessageDigest.isEqual(expected, actual)) {
+        if (!MessageDigest.isEqual(sign(payload), actual)) {
             throw invalid();
         }
-        if (!Instant.ofEpochSecond(expiresAt).isAfter(clock.instant())) {
-            throw new AccessSessionException("ACCESS_SESSION_EXPIRED", "접근 세션이 만료되었습니다.");
+        return new ParsedAccessToken(expiresAt, parts[2]);
+    }
+
+    private boolean isValidOwnerKey(String ownerKey) {
+        if (ownerKey == null || ownerKey.isBlank() || ownerKey.length() > 64) {
+            return false;
         }
-    }
-
-    public Duration ttl() {
-        return ttl;
-    }
-
-    public boolean secureCookie() {
-        return secureCookie;
-    }
-
-    public String sameSite() {
-        return secureCookie ? "None" : "Lax";
-    }
-
-    private String issueToken() {
-        long expiresAt = clock.instant().plus(ttl).getEpochSecond();
-        byte[] nonce = new byte[18];
-        SECURE_RANDOM.nextBytes(nonce);
-        String payload = "v1." + expiresAt + "." + Base64.getUrlEncoder().withoutPadding().encodeToString(nonce);
-        return payload + "." + Base64.getUrlEncoder().withoutPadding().encodeToString(sign(payload));
+        try {
+            byte[] decoded = Base64.getUrlDecoder().decode(ownerKey);
+            return decoded.length >= 18 && decoded.length <= 32
+                    && Arrays.equals(
+                    Base64.getUrlEncoder().withoutPadding().encode(decoded),
+                    ownerKey.getBytes(StandardCharsets.US_ASCII)
+            );
+        } catch (IllegalArgumentException exception) {
+            return false;
+        }
     }
 
     private byte[] sign(String payload) {
@@ -123,4 +233,10 @@ public class AccessSessionService {
     private AccessSessionException invalid() {
         return new AccessSessionException("ACCESS_SESSION_INVALID", "접근 세션이 올바르지 않습니다.");
     }
+
+    public record IssuedSession(String accessToken, String ownerToken, String ownerKey) {}
+
+    public record AccessPrincipal(String ownerKey) {}
+
+    private record ParsedAccessToken(long expiresAt, String ownerKey) {}
 }

--- a/src/main/java/com/uctale/uctale/service/GameService.java
+++ b/src/main/java/com/uctale/uctale/service/GameService.java
@@ -37,7 +37,7 @@ public class GameService {
     private final ChoiceCodec choiceCodec;
     private final ImagePromptComposer imagePromptComposer;
 
-    public GameResponse initGame(GameInitRequest request) {
+    public GameResponse initGame(String ownerKey, GameInitRequest request) {
         NarrativeTurn opening = narrativeGenerator.createOpening(request.worldSetting(), request.characterSetting());
         validateNarrativeTurn(opening);
         List<GameChoice> choices = toGameChoices(opening.choices());
@@ -50,6 +50,7 @@ public class GameService {
         String imageUrl = imageGenerator.createPublicUrl(imagePrompt, "16:9");
 
         var session = gamePersistenceService.saveOpening(
+                ownerKey,
                 request.worldSetting(),
                 request.characterSetting(),
                 opening.storyText(),
@@ -60,8 +61,9 @@ public class GameService {
         return toResponse(session.getId(), session.getCurrentTurn(), opening, choices, imageUrl);
     }
 
-    public GameResponse progressGame(GameProgressRequest request) {
+    public GameResponse progressGame(String ownerKey, GameProgressRequest request) {
         GamePersistenceService.LoadedTurn loadedTurn = gamePersistenceService.loadLatestTurn(
+                ownerKey,
                 request.sessionId(),
                 request.expectedTurn()
         );
@@ -86,6 +88,7 @@ public class GameService {
         }
 
         int savedTurn = gamePersistenceService.saveNextTurn(
+                ownerKey,
                 loadedTurn.sessionId(),
                 request.expectedTurn(),
                 userChoiceText,

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,6 +5,7 @@ pollinations.token=${POLLINATIONS_TOKEN}
 game.access.password=${GAME_ACCESS_PASSWORD}
 game.access.session-secret=${GAME_ACCESS_SESSION_SECRET}
 game.access.session-ttl-seconds=${GAME_ACCESS_SESSION_TTL_SECONDS:3600}
+game.owner.cookie-ttl-seconds=${GAME_OWNER_COOKIE_TTL_SECONDS:15552000}
 game.access.cookie-secure=${GAME_ACCESS_COOKIE_SECURE:true}
 game.cors.allowed-origins=${GAME_CORS_ALLOWED_ORIGINS:https://uctale.vercel.app}
 

--- a/src/main/resources/db/migration/V3__add_game_session_owner.sql
+++ b/src/main/resources/db/migration/V3__add_game_session_owner.sql
@@ -1,0 +1,12 @@
+alter table game_session
+    add column owner_key varchar(64);
+
+update game_session
+set owner_key = concat('legacy-', id)
+where owner_key is null;
+
+alter table game_session
+    alter column owner_key set not null;
+
+create index idx_game_session_owner_id
+    on game_session(owner_key, id);

--- a/src/test/java/com/uctale/uctale/application/game/GamePersistenceIntegrityTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/GamePersistenceIntegrityTest.java
@@ -17,6 +17,8 @@ import static org.mockito.BDDMockito.given;
 @ExtendWith(MockitoExtension.class)
 class GamePersistenceIntegrityTest {
 
+    private static final String OWNER_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
     @Mock private GameSessionRepository gameSessionRepository;
     @Mock private GameLogRepository gameLogRepository;
     @Mock private GameStateSnapshotRepository gameStateSnapshotRepository;
@@ -37,21 +39,23 @@ class GamePersistenceIntegrityTest {
     @Test
     @DisplayName("일반 DataIntegrityViolationException은 턴 충돌 409로 오인하지 않는다")
     void saveNextTurn_DoesNotMapEveryIntegrityFailureToTurnConflict() {
-        given(gameSessionRepository.findById(42L))
+        given(gameSessionRepository.findByIdAndOwnerKey(42L, OWNER_KEY))
                 .willThrow(new DataIntegrityViolationException("not-null constraint violation"));
 
-        assertThatThrownBy(() -> persistenceService.saveNextTurn(42L, 1, "선택", "본문", "[]", null))
-                .isInstanceOf(PersistenceOperationException.class)
+        assertThatThrownBy(() -> persistenceService.saveNextTurn(
+                OWNER_KEY, 42L, 1, "선택", "본문", "[]", null
+        )).isInstanceOf(PersistenceOperationException.class)
                 .isNotInstanceOf(TurnConflictException.class);
     }
 
     @Test
     @DisplayName("턴 unique constraint 위반만 턴 충돌로 분류한다")
     void saveNextTurn_MapsTurnUniqueConstraintToConflict() {
-        given(gameSessionRepository.findById(42L))
+        given(gameSessionRepository.findByIdAndOwnerKey(42L, OWNER_KEY))
                 .willThrow(new DataIntegrityViolationException("constraint uk_game_log_session_turn violated"));
 
-        assertThatThrownBy(() -> persistenceService.saveNextTurn(42L, 1, "선택", "본문", "[]", null))
-                .isInstanceOf(TurnConflictException.class);
+        assertThatThrownBy(() -> persistenceService.saveNextTurn(
+                OWNER_KEY, 42L, 1, "선택", "본문", "[]", null
+        )).isInstanceOf(TurnConflictException.class);
     }
 }

--- a/src/test/java/com/uctale/uctale/application/game/GamePersistenceServiceTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/GamePersistenceServiceTest.java
@@ -17,15 +17,19 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @Transactional
 class GamePersistenceServiceTest {
 
+    private static final String OWNER_A = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    private static final String OWNER_B = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+
     @Autowired private GamePersistenceService gamePersistenceService;
     @Autowired private GameSessionRepository gameSessionRepository;
     @Autowired private GameLogRepository gameLogRepository;
     @Autowired private GameStateSnapshotRepository gameStateSnapshotRepository;
 
     @Test
-    @DisplayName("턴 저장 후 동일 expectedTurn 재요청은 거부하고 GameState도 함께 진행한다")
-    void saveNextTurn_RejectsStaleRetryAndAdvancesState() {
+    @DisplayName("새 게임 세션은 생성 owner에게 귀속되고 동일 owner만 조회·진행할 수 있다")
+    void sessionOwnership_IsEnforcedAcrossReadAndWrite() {
         GameSession session = gamePersistenceService.saveOpening(
+                OWNER_A,
                 "세계관",
                 "캐릭터",
                 "첫 이야기",
@@ -33,7 +37,17 @@ class GamePersistenceServiceTest {
                 null
         );
 
+        assertThat(gameSessionRepository.findById(session.getId()).orElseThrow().getOwnerKey()).isEqualTo(OWNER_A);
+        assertThat(gamePersistenceService.loadLatestTurn(OWNER_A, session.getId(), 1).sessionId()).isEqualTo(session.getId());
+
+        assertThatThrownBy(() -> gamePersistenceService.loadLatestTurn(OWNER_B, session.getId(), 1))
+                .isInstanceOf(GameSessionNotFoundException.class);
+        assertThatThrownBy(() -> gamePersistenceService.saveNextTurn(
+                OWNER_B, session.getId(), 1, "진행", "침입", "[]", null
+        )).isInstanceOf(GameSessionNotFoundException.class);
+
         int savedTurn = gamePersistenceService.saveNextTurn(
+                OWNER_A,
                 session.getId(),
                 1,
                 "진행",
@@ -44,63 +58,39 @@ class GamePersistenceServiceTest {
 
         assertThat(savedTurn).isEqualTo(2);
         assertThat(gameLogRepository.count()).isEqualTo(2);
-        assertThat(gameStateSnapshotRepository.findById(session.getId())).isPresent();
         assertThat(gameSessionRepository.findById(session.getId()).orElseThrow().getCurrentTurn()).isEqualTo(2);
-
-        GamePersistenceService.LoadedTurn loaded = gamePersistenceService.loadLatestTurn(session.getId(), 2);
-        assertThat(loaded.gameState().turnNumber()).isEqualTo(2);
-        assertThat(loaded.gameState().storyMemory().recentTurns()).hasSize(2);
-        assertThat(loaded.gameState().storyMemory().recentTurns().get(1).playerAction()).isEqualTo("진행");
-
-        assertThatThrownBy(() -> gamePersistenceService.loadLatestTurn(session.getId(), 1))
-                .isInstanceOf(TurnConflictException.class);
     }
 
     @Test
-    @DisplayName("스냅샷이 없는 기존 세션은 저장된 로그에서 GameState를 복구한다")
-    void loadLatestTurn_RecoversLegacySessionWithoutSnapshot() {
+    @DisplayName("스냅샷이 없는 동일 owner 세션은 저장된 로그에서 GameState를 복구한다")
+    void loadLatestTurn_RecoversLegacySnapshotForOwnedSession() {
         GameSession session = gamePersistenceService.saveOpening(
-                "세계관",
-                "캐릭터",
-                "첫 이야기",
-                "[]",
-                "/image"
+                OWNER_A, "세계관", "캐릭터", "첫 이야기", "[]", "/image"
         );
         gamePersistenceService.saveNextTurn(
-                session.getId(),
-                1,
-                "진행",
-                "두 번째 이야기",
-                "[]",
-                "/image"
+                OWNER_A, session.getId(), 1, "진행", "두 번째 이야기", "[]", "/image"
         );
         gameStateSnapshotRepository.deleteById(session.getId());
         gameStateSnapshotRepository.flush();
 
-        GamePersistenceService.LoadedTurn loaded = gamePersistenceService.loadLatestTurn(session.getId(), 2);
+        GamePersistenceService.LoadedTurn loaded = gamePersistenceService.loadLatestTurn(OWNER_A, session.getId(), 2);
 
         assertThat(loaded.gameState().turnNumber()).isEqualTo(2);
         assertThat(loaded.gameState().storyMemory().recentTurns()).hasSize(2);
-        assertThat(loaded.gameState().storyMemory().recentTurns().get(1).playerAction()).isEqualTo("진행");
     }
 
     @Test
-    @DisplayName("최신 턴 snapshot은 세션과 로그 상태가 일치한다")
+    @DisplayName("동일 owner의 최신 턴 snapshot은 세션과 로그 상태가 일치한다")
     void loadLatestTurn_ReturnsConsistentSnapshot() {
         GameSession session = gamePersistenceService.saveOpening(
-                "세계관",
-                "캐릭터",
-                "첫 이야기",
-                "[]",
-                "/image"
+                OWNER_A, "세계관", "캐릭터", "첫 이야기", "[]", "/image"
         );
 
-        GamePersistenceService.LoadedTurn loaded = gamePersistenceService.loadLatestTurn(session.getId(), 1);
+        GamePersistenceService.LoadedTurn loaded = gamePersistenceService.loadLatestTurn(OWNER_A, session.getId(), 1);
 
         assertThat(loaded.sessionId()).isEqualTo(session.getId());
         assertThat(loaded.turnNumber()).isEqualTo(1);
         assertThat(loaded.storyText()).isEqualTo("첫 이야기");
-        assertThat(loaded.imageUrl()).isEqualTo("/image");
         assertThat(loaded.gameState().storyMemory().canonicalFacts()).hasSize(2);
     }
 }

--- a/src/test/java/com/uctale/uctale/application/game/GameSessionOwnershipMigrationTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/GameSessionOwnershipMigrationTest.java
@@ -1,0 +1,54 @@
+package com.uctale.uctale.application.game;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.datasource.init.ScriptUtils;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GameSessionOwnershipMigrationTest {
+
+    @Test
+    @DisplayName("기존 익명 세션은 V3 migration에서 선점 불가능한 legacy owner로 백필된다")
+    void migration_BackfillsLegacyOwnerAndMakesColumnNotNull() throws Exception {
+        String url = "jdbc:h2:mem:ownership_migration;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE";
+
+        try (Connection connection = DriverManager.getConnection(url, "sa", "")) {
+            ScriptUtils.executeSqlScript(connection, new ClassPathResource("db/migration/V1__create_game_tables.sql"));
+            ScriptUtils.executeSqlScript(connection, new ClassPathResource("db/migration/V2__create_game_state_snapshot.sql"));
+
+            try (Statement statement = connection.createStatement()) {
+                statement.executeUpdate("""
+                        insert into game_session (
+                            world_setting, character_setting, is_game_over, current_turn, version
+                        ) values ('기존 세계관', '기존 캐릭터', false, 1, 0)
+                        """);
+            }
+
+            ScriptUtils.executeSqlScript(connection, new ClassPathResource("db/migration/V3__add_game_session_owner.sql"));
+
+            try (Statement statement = connection.createStatement();
+                 ResultSet resultSet = statement.executeQuery("select id, owner_key from game_session")) {
+                assertThat(resultSet.next()).isTrue();
+                long id = resultSet.getLong("id");
+                assertThat(resultSet.getString("owner_key")).isEqualTo("legacy-" + id);
+                assertThat(resultSet.next()).isFalse();
+            }
+
+            try (Statement statement = connection.createStatement()) {
+                org.assertj.core.api.Assertions.assertThatThrownBy(() -> statement.executeUpdate("""
+                                insert into game_session (
+                                    owner_key, world_setting, character_setting, is_game_over, current_turn, version
+                                ) values (null, '새 세계관', '새 캐릭터', false, 1, 0)
+                                """))
+                        .isInstanceOf(java.sql.SQLException.class);
+            }
+        }
+    }
+}

--- a/src/test/java/com/uctale/uctale/controller/GameControllerTest.java
+++ b/src/test/java/com/uctale/uctale/controller/GameControllerTest.java
@@ -8,6 +8,7 @@ import com.uctale.uctale.dto.GameChoice;
 import com.uctale.uctale.dto.GameInitRequest;
 import com.uctale.uctale.dto.GameProgressRequest;
 import com.uctale.uctale.dto.GameResponse;
+import com.uctale.uctale.security.AccessSessionInterceptor;
 import com.uctale.uctale.service.GameService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,6 +23,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -31,6 +33,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @ExtendWith(MockitoExtension.class)
 class GameControllerTest {
+
+    private static final String OWNER_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
     @Mock private GameService gameService;
     private MockMvc mockMvc;
@@ -46,7 +50,7 @@ class GameControllerTest {
     }
 
     @Test
-    @DisplayName("게임 초기화 응답은 첫 번째 턴을 제공한다")
+    @DisplayName("게임 초기화 응답은 첫 번째 턴을 제공하고 owner key를 서비스에 전달한다")
     void initGame_ReturnsFirstTurn() throws Exception {
         GameResponse response = new GameResponse(
                 42L,
@@ -56,18 +60,21 @@ class GameControllerTest {
                 List.of(new GameChoice(1, "도망간다")),
                 "/api/game/image?prompt=test&aspectRatio=16%3A9"
         );
-        given(gameService.initGame(any(GameInitRequest.class))).willReturn(response);
+        given(gameService.initGame(eq(OWNER_KEY), any(GameInitRequest.class))).willReturn(response);
 
         mockMvc.perform(post("/api/game/init")
+                        .requestAttr(AccessSessionInterceptor.OWNER_KEY_ATTRIBUTE, OWNER_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new GameInitRequest("좀비 아포칼립스", "김대리"))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.sessionId").value(42))
                 .andExpect(jsonPath("$.turnNumber").value(1));
+
+        verify(gameService).initGame(eq(OWNER_KEY), any(GameInitRequest.class));
     }
 
     @Test
-    @DisplayName("게임 진행 요청은 기대 턴과 함께 다음 턴을 반환한다")
+    @DisplayName("게임 진행 요청은 owner key와 기대 턴을 함께 서비스에 전달한다")
     void progressGame_Success() throws Exception {
         GameProgressRequest request = new GameProgressRequest(42L, 1, 1);
         GameResponse response = new GameResponse(
@@ -78,9 +85,10 @@ class GameControllerTest {
                 List.of(new GameChoice(2, "숨는다")),
                 "/api/game/image?prompt=turn2&aspectRatio=16%3A9"
         );
-        given(gameService.progressGame(any(GameProgressRequest.class))).willReturn(response);
+        given(gameService.progressGame(eq(OWNER_KEY), any(GameProgressRequest.class))).willReturn(response);
 
         mockMvc.perform(post("/api/game/progress")
+                        .requestAttr(AccessSessionInterceptor.OWNER_KEY_ATTRIBUTE, OWNER_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -88,12 +96,27 @@ class GameControllerTest {
     }
 
     @Test
+    @DisplayName("다른 owner의 세션은 존재하지 않는 세션과 동일한 404로 반환한다")
+    void progressGame_MapsOwnershipMismatchToNotFound() throws Exception {
+        given(gameService.progressGame(eq(OWNER_KEY), any(GameProgressRequest.class)))
+                .willThrow(new GameSessionNotFoundException("존재하지 않는 세션입니다."));
+
+        mockMvc.perform(post("/api/game/progress")
+                        .requestAttr(AccessSessionInterceptor.OWNER_KEY_ATTRIBUTE, OWNER_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new GameProgressRequest(42L, 1, 1))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("SESSION_NOT_FOUND"));
+    }
+
+    @Test
     @DisplayName("오래된 턴 요청은 안정적인 409 오류 코드로 반환한다")
     void progressGame_MapsTurnConflict() throws Exception {
-        given(gameService.progressGame(any(GameProgressRequest.class)))
+        given(gameService.progressGame(eq(OWNER_KEY), any(GameProgressRequest.class)))
                 .willThrow(new TurnConflictException("이미 처리되었거나 오래된 턴 요청입니다."));
 
         mockMvc.perform(post("/api/game/progress")
+                        .requestAttr(AccessSessionInterceptor.OWNER_KEY_ATTRIBUTE, OWNER_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new GameProgressRequest(42L, 1, 1))))
                 .andExpect(status().isConflict())
@@ -102,25 +125,13 @@ class GameControllerTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 세션은 404 오류 코드로 반환한다")
-    void progressGame_MapsSessionNotFound() throws Exception {
-        given(gameService.progressGame(any(GameProgressRequest.class)))
-                .willThrow(new GameSessionNotFoundException("존재하지 않는 세션입니다."));
-
-        mockMvc.perform(post("/api/game/progress")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new GameProgressRequest(42L, 1, 1))))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.code").value("SESSION_NOT_FOUND"));
-    }
-
-    @Test
     @DisplayName("현재 턴에 없는 선택지는 422 오류 코드로 반환한다")
     void progressGame_MapsInvalidChoice() throws Exception {
-        given(gameService.progressGame(any(GameProgressRequest.class)))
+        given(gameService.progressGame(eq(OWNER_KEY), any(GameProgressRequest.class)))
                 .willThrow(new InvalidChoiceException("현재 턴에서 선택할 수 없는 선택지입니다."));
 
         mockMvc.perform(post("/api/game/progress")
+                        .requestAttr(AccessSessionInterceptor.OWNER_KEY_ATTRIBUTE, OWNER_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new GameProgressRequest(42L, 99, 1))))
                 .andExpect(status().isUnprocessableEntity())
@@ -131,23 +142,25 @@ class GameControllerTest {
     @DisplayName("빈 세계관 설정은 provider 호출 전에 400으로 거부한다")
     void initGame_RejectsBlankWorldSetting() throws Exception {
         mockMvc.perform(post("/api/game/init")
+                        .requestAttr(AccessSessionInterceptor.OWNER_KEY_ATTRIBUTE, OWNER_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new GameInitRequest("", "김대리"))))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
 
-        verify(gameService, never()).initGame(any(GameInitRequest.class));
+        verify(gameService, never()).initGame(eq(OWNER_KEY), any(GameInitRequest.class));
     }
 
     @Test
     @DisplayName("DB varchar 한계를 넘는 세계관 설정은 provider 호출 전에 거부한다")
     void initGame_RejectsWorldSettingLongerThanDatabaseLimit() throws Exception {
         mockMvc.perform(post("/api/game/init")
+                        .requestAttr(AccessSessionInterceptor.OWNER_KEY_ATTRIBUTE, OWNER_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new GameInitRequest("가".repeat(256), "김대리"))))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
 
-        verify(gameService, never()).initGame(any(GameInitRequest.class));
+        verify(gameService, never()).initGame(eq(OWNER_KEY), any(GameInitRequest.class));
     }
 }

--- a/src/test/java/com/uctale/uctale/controller/GameOwnershipApiIntegrationTest.java
+++ b/src/test/java/com/uctale/uctale/controller/GameOwnershipApiIntegrationTest.java
@@ -1,0 +1,131 @@
+package com.uctale.uctale.controller;
+
+import com.uctale.uctale.application.image.ImageGenerator;
+import com.uctale.uctale.application.narrative.NarrativeContext;
+import com.uctale.uctale.application.narrative.NarrativeGenerator;
+import com.uctale.uctale.application.narrative.NarrativeTurn;
+import com.uctale.uctale.security.AccessSessionInterceptor;
+import com.uctale.uctale.security.AccessSessionService;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import(GameOwnershipApiIntegrationTest.ProviderTestConfig.class)
+@Transactional
+class GameOwnershipApiIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private AccessSessionService accessSessionService;
+    @Autowired private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("다른 접근 주체는 session ID를 알아도 진행할 수 없고 소유자는 정상 진행한다")
+    void progress_RejectsCrossOwnerAndAllowsOwner() throws Exception {
+        AccessSessionService.IssuedSession ownerA = accessSessionService.authenticate("TEST_PASSWORD", null);
+        AccessSessionService.IssuedSession ownerB = accessSessionService.authenticate("TEST_PASSWORD", null);
+
+        MvcResult initResult = mockMvc.perform(post("/api/game/init")
+                        .cookie(accessCookie(ownerA), ownerCookie(ownerA))
+                        .header(AccessSessionInterceptor.CLIENT_HEADER, AccessSessionInterceptor.CLIENT_HEADER_VALUE)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"worldSetting\":\"세계관\",\"characterSetting\":\"캐릭터\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.turnNumber").value(1))
+                .andReturn();
+
+        long sessionId = objectMapper.readTree(initResult.getResponse().getContentAsString())
+                .get("sessionId")
+                .asLong();
+        String progressBody = "{\"sessionId\":" + sessionId + ",\"choiceId\":1,\"expectedTurn\":1}";
+
+        mockMvc.perform(post("/api/game/progress")
+                        .cookie(accessCookie(ownerB), ownerCookie(ownerB))
+                        .header(AccessSessionInterceptor.CLIENT_HEADER, AccessSessionInterceptor.CLIENT_HEADER_VALUE)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(progressBody))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("SESSION_NOT_FOUND"));
+
+        mockMvc.perform(post("/api/game/progress")
+                        .cookie(accessCookie(ownerA), ownerCookie(ownerA))
+                        .header(AccessSessionInterceptor.CLIENT_HEADER, AccessSessionInterceptor.CLIENT_HEADER_VALUE)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(progressBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sessionId").value(sessionId))
+                .andExpect(jsonPath("$.turnNumber").value(2));
+    }
+
+    private Cookie accessCookie(AccessSessionService.IssuedSession session) {
+        return new Cookie(AccessSessionService.COOKIE_NAME, session.accessToken());
+    }
+
+    private Cookie ownerCookie(AccessSessionService.IssuedSession session) {
+        return new Cookie(AccessSessionService.OWNER_COOKIE_NAME, session.ownerToken());
+    }
+
+    @TestConfiguration
+    static class ProviderTestConfig {
+
+        @Bean
+        @Primary
+        NarrativeGenerator testNarrativeGenerator() {
+            return new NarrativeGenerator() {
+                @Override
+                public NarrativeTurn createOpening(String worldSetting, String characterSetting) {
+                    return turn("첫 장면", "첫 이야기", "거리");
+                }
+
+                @Override
+                public NarrativeTurn createNextTurn(NarrativeContext context) {
+                    return turn("다음 장면", "다음 이야기", "골목");
+                }
+
+                private NarrativeTurn turn(String title, String story, String scene) {
+                    return new NarrativeTurn(
+                            title,
+                            story,
+                            List.of(new NarrativeTurn.Choice(1, "진행한다")),
+                            new NarrativeTurn.VisualAssets(scene, List.of(), List.of())
+                    );
+                }
+            };
+        }
+
+        @Bean
+        @Primary
+        ImageGenerator testImageGenerator() {
+            return new ImageGenerator() {
+                @Override
+                public String createPublicUrl(String prompt, String aspectRatio) {
+                    return "/api/game/image?prompt=test&aspectRatio=16%3A9";
+                }
+
+                @Override
+                public GeneratedImage fetchImage(String prompt, String aspectRatio) {
+                    return null;
+                }
+            };
+        }
+    }
+}

--- a/src/test/java/com/uctale/uctale/controller/GameOwnershipApiIntegrationTest.java
+++ b/src/test/java/com/uctale/uctale/controller/GameOwnershipApiIntegrationTest.java
@@ -7,10 +7,10 @@ import com.uctale.uctale.application.narrative.NarrativeTurn;
 import com.uctale.uctale.security.AccessSessionInterceptor;
 import com.uctale.uctale.security.AccessSessionService;
 import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -19,7 +19,9 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
 import tools.jackson.databind.ObjectMapper;
 
 import java.util.List;
@@ -29,14 +31,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
-@AutoConfigureMockMvc
 @Import(GameOwnershipApiIntegrationTest.ProviderTestConfig.class)
 @Transactional
 class GameOwnershipApiIntegrationTest {
 
-    @Autowired private MockMvc mockMvc;
+    @Autowired private WebApplicationContext webApplicationContext;
     @Autowired private AccessSessionService accessSessionService;
     @Autowired private ObjectMapper objectMapper;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+    }
 
     @Test
     @DisplayName("다른 접근 주체는 session ID를 알아도 진행할 수 없고 소유자는 정상 진행한다")

--- a/src/test/java/com/uctale/uctale/security/AccessSessionOwnerTest.java
+++ b/src/test/java/com/uctale/uctale/security/AccessSessionOwnerTest.java
@@ -1,0 +1,57 @@
+package com.uctale.uctale.security;
+
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class AccessSessionOwnerTest {
+
+    private static final String SECRET = "0123456789abcdef0123456789abcdef";
+
+    @Test
+    @DisplayName("재로그인은 장기 owner 쿠키의 owner key를 재사용한다")
+    void authenticate_ReusesOwnerKeyFromOwnerCookie() {
+        AccessSessionService service = new AccessSessionService("TEST_PASSWORD", SECRET, 3600, false);
+
+        AccessSessionService.IssuedSession first = service.authenticate("TEST_PASSWORD", null);
+        AccessSessionService.IssuedSession renewed = service.authenticate("TEST_PASSWORD", first.ownerToken());
+
+        assertThat(renewed.ownerKey()).isEqualTo(first.ownerKey());
+        assertThat(service.validateAndGetPrincipal(renewed.accessToken()).ownerKey()).isEqualTo(first.ownerKey());
+    }
+
+    @Test
+    @DisplayName("기존 access 쿠키만 있는 보호 요청은 같은 owner key의 owner 쿠키를 승격 발급한다")
+    void interceptor_PromotesLegacyAccessTokenToOwnerCookie() throws Exception {
+        AccessSessionService service = new AccessSessionService("TEST_PASSWORD", SECRET, 3600, false);
+        String accessToken = service.authenticate("TEST_PASSWORD");
+        String ownerKey = service.validateAndGetPrincipal(accessToken).ownerKey();
+        AccessSessionInterceptor interceptor = new AccessSessionInterceptor(service);
+        MockMvc mockMvc = MockMvcBuilders.standaloneSetup(new TestController())
+                .addInterceptors(interceptor)
+                .build();
+
+        mockMvc.perform(get("/protected")
+                        .cookie(new Cookie(AccessSessionService.COOKIE_NAME, accessToken))
+                        .header(AccessSessionInterceptor.CLIENT_HEADER, AccessSessionInterceptor.CLIENT_HEADER_VALUE))
+                .andExpect(status().isNoContent())
+                .andExpect(header().string("Set-Cookie", containsString(AccessSessionService.OWNER_COOKIE_NAME + "=")))
+                .andExpect(header().string("Set-Cookie", containsString(service.issueOwnerToken(ownerKey))));
+    }
+
+    @org.springframework.web.bind.annotation.RestController
+    static class TestController {
+        @org.springframework.web.bind.annotation.GetMapping("/protected")
+        org.springframework.http.ResponseEntity<Void> protectedEndpoint() {
+            return org.springframework.http.ResponseEntity.noContent().build();
+        }
+    }
+}

--- a/src/test/java/com/uctale/uctale/service/GameServiceTest.java
+++ b/src/test/java/com/uctale/uctale/service/GameServiceTest.java
@@ -30,12 +30,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class GameServiceTest {
+
+    private static final String OWNER_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
     @Mock private NarrativeGenerator narrativeGenerator;
     @Mock private ImageGenerator imageGenerator;
@@ -57,7 +60,7 @@ class GameServiceTest {
     }
 
     @Test
-    @DisplayName("게임 초기화 응답은 첫 번째 턴을 반환한다")
+    @DisplayName("게임 초기화는 owner key를 새 세션 저장에 전달한다")
     void initGame_ReturnsFirstTurn() {
         GameInitRequest request = new GameInitRequest("좀비 아포칼립스", "김대리");
         NarrativeTurn opening = new NarrativeTurn(
@@ -66,23 +69,23 @@ class GameServiceTest {
                 List.of(new NarrativeTurn.Choice(1, "도망간다")),
                 new NarrativeTurn.VisualAssets("dark street", List.of("zombie"), List.of())
         );
-        GameSession session = new GameSession(request.worldSetting(), request.characterSetting());
+        GameSession session = new GameSession(OWNER_KEY, request.worldSetting(), request.characterSetting());
         ReflectionTestUtils.setField(session, "id", 42L);
 
         given(narrativeGenerator.createOpening("좀비 아포칼립스", "김대리")).willReturn(opening);
         given(imageGenerator.createPublicUrl("zombie, dark street", "16:9"))
                 .willReturn("/api/game/image?prompt=test&aspectRatio=16%3A9");
-        given(gamePersistenceService.saveOpening(any(), any(), any(), any(), any())).willReturn(session);
+        given(gamePersistenceService.saveOpening(eq(OWNER_KEY), any(), any(), any(), any(), any())).willReturn(session);
 
-        GameResponse response = gameService.initGame(request);
+        GameResponse response = gameService.initGame(OWNER_KEY, request);
 
         assertThat(response.sessionId()).isEqualTo(42L);
         assertThat(response.turnNumber()).isEqualTo(1);
-        assertThat(response.choices()).extracting(GameChoice::text).containsExactly("도망간다");
+        verify(gamePersistenceService).saveOpening(eq(OWNER_KEY), any(), any(), any(), any(), any());
     }
 
     @Test
-    @DisplayName("게임 진행은 GameState에서 Narrative Context를 구성한다")
+    @DisplayName("게임 진행은 owner key로 세션을 읽고 저장한다")
     void progressGame_UsesCanonicalGameState() {
         String choicesJson = choiceCodec.serialize(List.of(new GameChoice(1, "문을 잠근다")));
         GamePersistenceService.LoadedTurn loadedTurn = loadedTurn(choicesJson);
@@ -93,66 +96,39 @@ class GameServiceTest {
                 new NarrativeTurn.VisualAssets("", List.of(), List.of())
         );
 
-        given(gamePersistenceService.loadLatestTurn(42L, 1)).willReturn(loadedTurn);
+        given(gamePersistenceService.loadLatestTurn(OWNER_KEY, 42L, 1)).willReturn(loadedTurn);
         given(narrativeGenerator.createNextTurn(any(NarrativeContext.class))).willReturn(nextTurn);
         given(gamePersistenceService.saveNextTurn(
-                42L,
-                1,
-                "문을 잠근다",
-                "다음 스토리",
+                OWNER_KEY, 42L, 1, "문을 잠근다", "다음 스토리",
                 "[{\"id\":1,\"text\":\"기다린다\"}]",
                 "/api/game/image?prompt=old&aspectRatio=16%3A9"
         )).willReturn(2);
 
-        GameResponse response = gameService.progressGame(new GameProgressRequest(42L, 1, 1));
+        GameResponse response = gameService.progressGame(OWNER_KEY, new GameProgressRequest(42L, 1, 1));
 
         assertThat(response.turnNumber()).isEqualTo(2);
         ArgumentCaptor<NarrativeContext> contextCaptor = ArgumentCaptor.forClass(NarrativeContext.class);
         verify(narrativeGenerator).createNextTurn(contextCaptor.capture());
-        NarrativeContext context = contextCaptor.getValue();
-        assertThat(context.worldPremise()).isEqualTo("좀비 아포칼립스");
-        assertThat(context.playerDescription()).isEqualTo("김대리");
-        assertThat(context.playerAction()).isEqualTo("문을 잠근다");
-        assertThat(context.canonicalFacts()).hasSize(2);
-        assertThat(context.recentTurns()).hasSize(1);
+        assertThat(contextCaptor.getValue().playerAction()).isEqualTo("문을 잠근다");
+        verify(gamePersistenceService).saveNextTurn(eq(OWNER_KEY), eq(42L), eq(1), any(), any(), any(), any());
     }
 
     @Test
-    @DisplayName("오래된 턴 요청은 내러티브 생성 전에 거부한다")
-    void progressGame_RejectsStaleTurnBeforeNarrativeCall() {
-        given(gamePersistenceService.loadLatestTurn(42L, 1))
+    @DisplayName("소유권 또는 오래된 턴 거부는 내러티브 생성 전에 발생한다")
+    void progressGame_RejectsBeforeNarrativeCall() {
+        given(gamePersistenceService.loadLatestTurn(OWNER_KEY, 42L, 1))
                 .willThrow(new TurnConflictException("이미 처리되었거나 오래된 턴 요청입니다."));
 
-        assertThatThrownBy(() -> gameService.progressGame(new GameProgressRequest(42L, 1, 1)))
+        assertThatThrownBy(() -> gameService.progressGame(OWNER_KEY, new GameProgressRequest(42L, 1, 1)))
                 .isInstanceOf(TurnConflictException.class);
 
         verify(narrativeGenerator, never()).createNextTurn(any(NarrativeContext.class));
-        verify(gamePersistenceService, never()).saveNextTurn(any(), anyInt(), any(), any(), any(), any());
-    }
-
-    @Test
-    @DisplayName("AI 실패 시 다음 턴을 저장하지 않는다")
-    void progressGame_DoesNotPersistWhenNarrativeFails() {
-        String choicesJson = choiceCodec.serialize(List.of(new GameChoice(1, "문을 잠근다")));
-        given(gamePersistenceService.loadLatestTurn(42L, 1)).willReturn(loadedTurn(choicesJson));
-        given(narrativeGenerator.createNextTurn(any(NarrativeContext.class)))
-                .willThrow(new RuntimeException("AI 호출 실패"));
-
-        assertThatThrownBy(() -> gameService.progressGame(new GameProgressRequest(42L, 1, 1)))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessage("AI 호출 실패");
-
-        verify(gamePersistenceService, never()).saveNextTurn(any(), anyInt(), any(), any(), any(), any());
+        verify(gamePersistenceService, never()).saveNextTurn(any(), any(), anyInt(), any(), any(), any(), any());
     }
 
     private GamePersistenceService.LoadedTurn loadedTurn(String choicesJson) {
         return new GamePersistenceService.LoadedTurn(
-                42L,
-                1,
-                "좀비 아포칼립스",
-                "김대리",
-                "직전 스토리",
-                choicesJson,
+                42L, 1, "좀비 아포칼립스", "김대리", "직전 스토리", choicesJson,
                 "/api/game/image?prompt=old&aspectRatio=16%3A9",
                 GameState.initial("좀비 아포칼립스", "김대리", "직전 스토리")
         );

--- a/src/test/java/com/uctale/uctale/service/GameServiceValidationTest.java
+++ b/src/test/java/com/uctale/uctale/service/GameServiceValidationTest.java
@@ -19,13 +19,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.ArgumentMatchers.any;
 
 @ExtendWith(MockitoExtension.class)
 class GameServiceValidationTest {
+
+    private static final String OWNER_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
     @Mock private NarrativeGenerator narrativeGenerator;
     @Mock private ImageGenerator imageGenerator;
@@ -56,11 +58,11 @@ class GameServiceValidationTest {
         );
         given(narrativeGenerator.createOpening("세계관", "캐릭터")).willReturn(invalidTurn);
 
-        assertThatThrownBy(() -> gameService.initGame(request))
+        assertThatThrownBy(() -> gameService.initGame(OWNER_KEY, request))
                 .isInstanceOf(InvalidNarrativeResponseException.class);
 
         verify(imageGenerator, never()).createPublicUrl(any(), any());
-        verify(gamePersistenceService, never()).saveOpening(any(), any(), any(), any(), any());
+        verify(gamePersistenceService, never()).saveOpening(any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -78,9 +80,9 @@ class GameServiceValidationTest {
         );
         given(narrativeGenerator.createOpening("세계관", "캐릭터")).willReturn(invalidTurn);
 
-        assertThatThrownBy(() -> gameService.initGame(request))
+        assertThatThrownBy(() -> gameService.initGame(OWNER_KEY, request))
                 .isInstanceOf(InvalidNarrativeResponseException.class);
 
-        verify(gamePersistenceService, never()).saveOpening(any(), any(), any(), any(), any());
+        verify(gamePersistenceService, never()).saveOpening(any(), any(), any(), any(), any(), any());
     }
 }


### PR DESCRIPTION
## 왜 필요한가요?

공유 베타 접근 비밀번호를 통과한 사용자끼리는 기존 구조상 `sessionId`만 알면 다른 사용자의 게임 진행 상태에 접근할 수 있었습니다. 접근 세션의 주체와 `GameSession` 소유 관계를 서버와 DB가 직접 관리하도록 해 session ID 추측·노출이 곧 교차 접근으로 이어지지 않게 합니다.

- Closes #25

## 무엇이 바뀌나요?

- 게임 규칙·상태: 게임 규칙과 Narrative/GameState 계약은 변경하지 않습니다.
- Backend / API / DB: 브라우저별 owner key를 도입하고 `GameSession.ownerKey`에 저장합니다. 세션 조회와 다음 턴 저장 모두 `sessionId + ownerKey`로 소유권을 재검증합니다.
- 접근 세션: 단기 `uctale_access`와 별도로 장기 HttpOnly `uctale_owner` 쿠키를 발급합니다. 재로그인 시 유효한 owner 쿠키를 재사용해 접근 세션 만료 후에도 같은 게임 소유자를 유지합니다.
- 기존 #24 호환: 기존 access 쿠키만 가진 사용자는 보호 API 첫 요청에서 access token의 기존 nonce를 owner key로 승격해 owner 쿠키를 발급합니다.
- AI narrative / prompt: 변경 없음.
- Image generation: session ID를 받지 않는 이미지 endpoint는 기존 접근 세션 보호 정책을 유지합니다.
- Frontend / UX: 변경 없음. owner key는 HttpOnly 쿠키에만 존재하며 Web Storage나 응답에 노출하지 않습니다.

## 소유권 / 오류 정책

- 인증되지 않은 요청: 기존 정책대로 401
- 유효한 접근 세션 + 허용 client header 누락: 기존 정책대로 403
- 존재하지 않는 session ID: `SESSION_NOT_FOUND` 404
- 다른 owner의 session ID: 존재 여부 노출을 줄이기 위해 동일하게 `SESSION_NOT_FOUND` 404
- 새 세션: 생성한 owner key에 즉시 귀속
- 진행 요청: Narrative 호출 전 조회와 Narrative 호출 후 저장 직전 모두 소유권 재검증

## 기존 익명 세션 migration

V3 migration에서 기존 `game_session` 행은 `legacy-{id}` owner key로 백필한 뒤 `owner_key`를 NOT NULL로 고정합니다.

실제 owner key는 18~32바이트 랜덤 Base64URL 값만 허용하므로 `legacy-*` 값과 호환되지 않습니다. 따라서 기존 익명 세션은 새 접근 주체가 session ID를 먼저 알아냈다는 이유만으로 선점할 수 없으며, 배포 이후 기존 익명 세션 접근은 차단됩니다.

영구 계정/복구 수단이 없는 현재 공유 베타에서는 기존 익명 데이터를 임의의 새 owner에게 귀속시키는 것보다 안전한 정책으로 판단했습니다. 세부 정책은 `docs/architecture/session-ownership.md`에 문서화했습니다.

## 어떻게 검증했나요?

- [x] controller가 interceptor의 owner principal을 service에 전달하는 단위 테스트
- [x] service가 owner key를 persistence 조회/저장 양쪽에 전달하는 단위 테스트
- [x] 새 세션의 owner 저장 및 동일 owner 정상 조회·진행 persistence integration test
- [x] 다른 owner의 동일 session ID 조회·저장이 `GameSessionNotFoundException`으로 차단되는 integration test
- [x] 실제 MVC/interceptor/service/JPA 경로에서 A가 만든 session을 B가 진행하면 404, A는 정상 진행하는 API integration test
- [x] 재로그인 시 장기 owner cookie를 재사용하는 테스트
- [x] 기존 access-cookie-only 요청에서 owner cookie를 승격 발급하는 호환 테스트
- [x] V1/V2 상태의 기존 익명 row에 V3를 적용해 `legacy-*` 백필 및 NOT NULL을 검증하는 migration test
- [x] `./gradlew clean test`
- [x] `./gradlew build`
- [x] `cd frontend && npm ci && npm test && npm run lint && npm run build`

GitHub Actions CI #72에서 Backend test/build와 Frontend test/lint/build가 모두 성공했습니다.

## PR 전 자체 비판적 리뷰 및 보완

PR 생성 전에 main 대비 전체 diff를 별도로 재검토했습니다.

1. **접근 세션 TTL과 게임 owner 수명의 결합 문제를 방지**
   - 단기 access token의 nonce만 owner identity로 쓰면 1시간 쿠키 만료 후 재로그인 시 자기 게임 소유권을 잃는 문제가 있습니다.
   - 장기 서명 HttpOnly owner cookie를 분리하고 재인증 시 동일 owner key를 재사용하도록 설계했습니다.
2. **기존 #24 access cookie 호환 경로 보완**
   - 배포 시 이미 발급된 v1 access token은 기존 nonce를 그대로 유효한 owner key로 해석하고 보호 요청에서 장기 owner cookie로 승격합니다.
3. **소유권 검사 누락 방지**
   - service에서 한 번 확인하는 데 그치지 않고 persistence의 조회와 저장 직전 재조회 모두 `findByIdAndOwnerKey`를 사용하도록 했습니다.
4. **legacy migration 테스트 누락 발견 및 보완**
   - 초기 구현은 migration 후 동작만 테스트하고 실제 V1/V2 익명 row의 V3 백필 과정은 직접 검증하지 않았습니다.
   - PR 생성 전에 migration 스크립트를 순서대로 실행해 `legacy-*` 백필과 NOT NULL 적용을 확인하는 테스트를 추가했습니다.
5. **정보 노출 정책 재검토**
   - 다른 owner 접근을 403으로 분리하면 session ID 존재 여부가 노출되므로 미존재와 동일한 404로 통일했습니다.

비판적 리뷰 보완 후 CI까지 통과했으며, 현재 코드 기준으로 merge를 막아야 할 추가 결함은 발견하지 못했습니다.

## 게임 상태·AI 안전성

- [x] 소유권 실패는 Narrative provider 호출 전에 차단됩니다.
- [x] 저장 직전에도 같은 owner 조건을 다시 검증합니다.
- [x] GameState / Story Memory / Narrative 계약은 변경하지 않습니다.
- [x] LLM이 owner 또는 접근 제어 상태를 결정하지 않습니다.

## 보안·비용

- [x] owner key는 API 응답, URL, Web Storage에 노출하지 않습니다.
- [x] owner/access 쿠키는 HttpOnly이며 기존 Secure/SameSite 정책을 따릅니다.
- [x] owner token도 HMAC-SHA256으로 서명하며 access token과 서명 payload domain을 분리합니다.
- [x] 다른 owner는 session ID를 알아도 Narrative 호출이나 상태 저장까지 도달하지 못합니다.
- [x] legacy session의 first-knower takeover를 허용하지 않습니다.

## API·DB·운영 영향

- [x] `game_session.owner_key varchar(64) not null` 추가
- [x] `(owner_key, id)` index 추가
- [x] V3 migration에서 기존 익명 session은 `legacy-{id}`로 봉인
- [x] 새 Secret은 필요하지 않으며 기존 `GAME_ACCESS_SESSION_SECRET`을 owner token 서명에도 사용
- [x] 선택 환경변수 `GAME_OWNER_COOKIE_TTL_SECONDS` 추가, 기본값 15,552,000초(180일)
- [x] API 요청/응답 DTO 변경 없음

## 배포 후 확인 항목

- Vercel에서 로그인 → 게임 시작 → 진행이 정상인지 확인
- 다른 브라우저/시크릿 창에서 같은 session ID 진행 요청이 404인지 확인
- access 세션 재인증 후 기존 owner가 유지되는지 확인
- 기존 익명 세션은 의도한 정책대로 접근 불가한지 확인