### PR TITLE
feat(security): 비용 API rate limit과 provider 관측성 추가

### DIFF
--- a/docs/architecture/cost-controls.md
+++ b/docs/architecture/cost-controls.md
@@ -1,0 +1,55 @@
+# 비용 API rate limit과 provider 관측성
+
+## 목적
+
+공유 베타에서 인증된 사용자의 반복 클릭·자동화 요청·재시도로 Narrative/Image provider 비용이 급증하는 상황을 줄이고, 실제 provider 호출을 turn 단위로 추적할 수 있게 한다.
+
+## Rate limit
+
+현재 구현은 단일 application instance 메모리 안에서 동작하는 fixed-window limiter다.
+
+- Narrative와 Image quota를 서로 분리한다.
+- owner principal, client IP, session(존재할 때) 각각에 같은 operation quota를 적용한다.
+- 어느 bucket 하나라도 한도를 넘으면 provider 호출 전에 `429 RATE_LIMIT_EXCEEDED`를 반환한다.
+- 응답에는 다음 window까지 남은 초를 `Retry-After` 헤더로 제공한다.
+- 이미 생성되어 DB에 저장된 image asset 조회는 provider 비용이 들지 않으므로 quota를 소비하지 않는다.
+
+기본값:
+
+- window: 60초
+- Narrative: 12회/window
+- Image: 8회/window
+
+환경변수:
+
+- `GAME_COST_RATE_LIMIT_WINDOW_SECONDS`
+- `GAME_COST_NARRATIVE_LIMIT`
+- `GAME_COST_IMAGE_LIMIT`
+
+### 운영 한계
+
+이 limiter는 Render 인스턴스 하나의 메모리에만 존재한다. 인스턴스가 여러 개가 되면 각 인스턴스가 독립 quota를 가지므로 전역 한도를 보장하지 않는다. 현재 단일 인스턴스 공유 베타에 맞춘 최소 안전장치이며, multi-instance 전환 시 Redis 등 외부 shared store 기반 limiter로 교체한다.
+
+## Provider 관측성
+
+provider 호출마다 다음 항목을 구조화된 key/value 로그로 기록한다.
+
+- provider
+- operation
+- sessionId
+- turn
+- requestId
+- idempotencyKey(현재는 미도입이므로 `-`)
+- latencyMs
+- outcome (`SUCCESS` / `FAILURE`)
+- retryCount
+
+사용자 world/character/action, provider prompt/응답 전문, access/owner token, API key는 로그에 기록하지 않는다.
+
+현재 retryCount는 provider retry 정책이 아직 없으므로 0이다. 후속 #35/#50에서 bounded retry를 도입할 때 같은 event 계약에 실제 retry 횟수를 연결한다.
+
+## 책임 경계
+
+- Narrative: `GameService`가 소유권/turn 조회 후 rate limit을 확인하고 Gemini 호출만 telemetry로 감싼다.
+- Image: `ImageAssetService`가 asset 소유권과 기존 생성 결과를 먼저 확인한다. 미생성 asset에 대해서만 lock 내부에서 rate limit을 확인하고 Pollinations 호출을 telemetry로 감싼다.
+- DB에 저장된 이미지 재조회는 provider를 호출하지 않으므로 Image quota를 소비하지 않는다.

--- a/src/main/java/com/uctale/uctale/application/cost/ClientIpResolver.java
+++ b/src/main/java/com/uctale/uctale/application/cost/ClientIpResolver.java
@@ -1,0 +1,32 @@
+package com.uctale.uctale.application.cost;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public final class ClientIpResolver {
+
+    private static final String X_FORWARDED_FOR = "X-Forwarded-For";
+    private static final int MAX_IP_TEXT_LENGTH = 128;
+
+    private ClientIpResolver() {}
+
+    public static String resolve(HttpServletRequest request) {
+        String forwardedFor = request.getHeader(X_FORWARDED_FOR);
+        if (forwardedFor != null && !forwardedFor.isBlank()) {
+            String firstHop = forwardedFor.split(",", 2)[0].trim();
+            if (!firstHop.isBlank()) {
+                return truncate(firstHop);
+            }
+        }
+        return truncate(request.getRemoteAddr());
+    }
+
+    private static String truncate(String value) {
+        if (value == null || value.isBlank()) {
+            return "unknown";
+        }
+        String normalized = value.trim();
+        return normalized.length() <= MAX_IP_TEXT_LENGTH
+                ? normalized
+                : normalized.substring(0, MAX_IP_TEXT_LENGTH);
+    }
+}

--- a/src/main/java/com/uctale/uctale/application/cost/CostOperation.java
+++ b/src/main/java/com/uctale/uctale/application/cost/CostOperation.java
@@ -1,0 +1,6 @@
+package com.uctale.uctale.application.cost;
+
+public enum CostOperation {
+    NARRATIVE,
+    IMAGE
+}

--- a/src/main/java/com/uctale/uctale/application/cost/CostRateLimitPolicy.java
+++ b/src/main/java/com/uctale/uctale/application/cost/CostRateLimitPolicy.java
@@ -1,0 +1,33 @@
+package com.uctale.uctale.application.cost;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CostRateLimitPolicy {
+
+    private final int narrativeLimit;
+    private final int imageLimit;
+    private final long windowSeconds;
+
+    public CostRateLimitPolicy(
+            @Value("${game.cost.rate-limit.narrative-limit:12}") int narrativeLimit,
+            @Value("${game.cost.rate-limit.image-limit:8}") int imageLimit,
+            @Value("${game.cost.rate-limit.window-seconds:60}") long windowSeconds
+    ) {
+        if (narrativeLimit <= 0 || imageLimit <= 0 || windowSeconds <= 0) {
+            throw new IllegalArgumentException("비용 API rate limit 설정은 1 이상이어야 합니다.");
+        }
+        this.narrativeLimit = narrativeLimit;
+        this.imageLimit = imageLimit;
+        this.windowSeconds = windowSeconds;
+    }
+
+    public int limitFor(CostOperation operation) {
+        return operation == CostOperation.IMAGE ? imageLimit : narrativeLimit;
+    }
+
+    public long windowSeconds() {
+        return windowSeconds;
+    }
+}

--- a/src/main/java/com/uctale/uctale/application/cost/CostRateLimiter.java
+++ b/src/main/java/com/uctale/uctale/application/cost/CostRateLimiter.java
@@ -1,0 +1,75 @@
+package com.uctale.uctale.application.cost;
+
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class CostRateLimiter {
+
+    private final CostRateLimitPolicy policy;
+    private final Clock clock;
+    private final Map<String, Counter> counters = new HashMap<>();
+
+    public CostRateLimiter(CostRateLimitPolicy policy, Clock clock) {
+        this.policy = policy;
+        this.clock = clock;
+    }
+
+    public synchronized void check(CostOperation operation, CostRequestContext context) {
+        long now = clock.instant().getEpochSecond();
+        long window = now / policy.windowSeconds();
+        int limit = policy.limitFor(operation);
+        List<String> keys = bucketKeys(operation, context);
+
+        for (String key : keys) {
+            Counter counter = counters.get(key);
+            int count = counter != null && counter.window == window ? counter.count : 0;
+            if (count >= limit) {
+                long retryAfter = Math.max(1, ((window + 1) * policy.windowSeconds()) - now);
+                throw new RateLimitExceededException("비용 API 요청 한도를 초과했습니다.", retryAfter);
+            }
+        }
+
+        for (String key : keys) {
+            Counter counter = counters.get(key);
+            if (counter == null || counter.window != window) {
+                counters.put(key, new Counter(window, 1));
+            } else {
+                counter.count++;
+            }
+        }
+
+        if (counters.size() > 10_000) {
+            counters.entrySet().removeIf(entry -> entry.getValue().window < window - 1);
+        }
+    }
+
+    private List<String> bucketKeys(CostOperation operation, CostRequestContext context) {
+        List<String> keys = new ArrayList<>();
+        keys.add(operation + ":owner:" + context.ownerKey());
+        keys.add(operation + ":ip:" + normalize(context.clientIp()));
+        if (context.sessionId() != null) {
+            keys.add(operation + ":session:" + context.sessionId());
+        }
+        return keys;
+    }
+
+    private String normalize(String value) {
+        return value == null || value.isBlank() ? "unknown" : value;
+    }
+
+    private static final class Counter {
+        private final long window;
+        private int count;
+
+        private Counter(long window, int count) {
+            this.window = window;
+            this.count = count;
+        }
+    }
+}

--- a/src/main/java/com/uctale/uctale/application/cost/CostRequestContext.java
+++ b/src/main/java/com/uctale/uctale/application/cost/CostRequestContext.java
@@ -1,0 +1,20 @@
+package com.uctale.uctale.application.cost;
+
+import java.util.UUID;
+
+public record CostRequestContext(
+        String requestId,
+        String ownerKey,
+        String clientIp,
+        Long sessionId,
+        Integer turn,
+        String idempotencyKey
+) {
+    public static CostRequestContext create(String ownerKey, String clientIp, Long sessionId, Integer turn) {
+        return new CostRequestContext(UUID.randomUUID().toString(), ownerKey, clientIp, sessionId, turn, null);
+    }
+
+    public static CostRequestContext internal(String ownerKey, Long sessionId, Integer turn) {
+        return create(ownerKey, "internal", sessionId, turn);
+    }
+}

--- a/src/main/java/com/uctale/uctale/application/cost/LoggingProviderCallEventSink.java
+++ b/src/main/java/com/uctale/uctale/application/cost/LoggingProviderCallEventSink.java
@@ -1,0 +1,25 @@
+package com.uctale.uctale.application.cost;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class LoggingProviderCallEventSink implements ProviderCallEventSink {
+
+    @Override
+    public void record(ProviderCallEvent event) {
+        log.info(
+                "provider_call provider={} operation={} sessionId={} turn={} requestId={} idempotencyKey={} latencyMs={} outcome={} retryCount={}",
+                event.provider(),
+                event.operation(),
+                event.sessionId(),
+                event.turn(),
+                event.requestId(),
+                event.idempotencyKey() == null ? "-" : event.idempotencyKey(),
+                event.latencyMs(),
+                event.outcome(),
+                event.retryCount()
+        );
+    }
+}

--- a/src/main/java/com/uctale/uctale/application/cost/ProviderCallEvent.java
+++ b/src/main/java/com/uctale/uctale/application/cost/ProviderCallEvent.java
@@ -1,0 +1,13 @@
+package com.uctale.uctale.application.cost;
+
+public record ProviderCallEvent(
+        String provider,
+        String operation,
+        Long sessionId,
+        Integer turn,
+        String requestId,
+        String idempotencyKey,
+        long latencyMs,
+        String outcome,
+        int retryCount
+) {}

--- a/src/main/java/com/uctale/uctale/application/cost/ProviderCallEventSink.java
+++ b/src/main/java/com/uctale/uctale/application/cost/ProviderCallEventSink.java
@@ -1,0 +1,5 @@
+package com.uctale.uctale.application.cost;
+
+public interface ProviderCallEventSink {
+    void record(ProviderCallEvent event);
+}

--- a/src/main/java/com/uctale/uctale/application/cost/ProviderCallTelemetry.java
+++ b/src/main/java/com/uctale/uctale/application/cost/ProviderCallTelemetry.java
@@ -1,0 +1,57 @@
+package com.uctale.uctale.application.cost;
+
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.util.function.Supplier;
+
+@Component
+public class ProviderCallTelemetry {
+
+    private final Clock clock;
+    private final ProviderCallEventSink sink;
+
+    public ProviderCallTelemetry(Clock clock, ProviderCallEventSink sink) {
+        this.clock = clock;
+        this.sink = sink;
+    }
+
+    public <T> T observe(
+            String provider,
+            String operation,
+            CostRequestContext context,
+            int retryCount,
+            Supplier<T> invocation
+    ) {
+        long startedAt = clock.millis();
+        try {
+            T result = invocation.get();
+            record(provider, operation, context, retryCount, startedAt, "SUCCESS");
+            return result;
+        } catch (RuntimeException exception) {
+            record(provider, operation, context, retryCount, startedAt, "FAILURE");
+            throw exception;
+        }
+    }
+
+    private void record(
+            String provider,
+            String operation,
+            CostRequestContext context,
+            int retryCount,
+            long startedAt,
+            String outcome
+    ) {
+        sink.record(new ProviderCallEvent(
+                provider,
+                operation,
+                context.sessionId(),
+                context.turn(),
+                context.requestId(),
+                context.idempotencyKey(),
+                Math.max(0, clock.millis() - startedAt),
+                outcome,
+                retryCount
+        ));
+    }
+}

--- a/src/main/java/com/uctale/uctale/application/cost/RateLimitExceededException.java
+++ b/src/main/java/com/uctale/uctale/application/cost/RateLimitExceededException.java
@@ -1,0 +1,15 @@
+package com.uctale.uctale.application.cost;
+
+public class RateLimitExceededException extends RuntimeException {
+
+    private final long retryAfterSeconds;
+
+    public RateLimitExceededException(String message, long retryAfterSeconds) {
+        super(message);
+        this.retryAfterSeconds = retryAfterSeconds;
+    }
+
+    public long retryAfterSeconds() {
+        return retryAfterSeconds;
+    }
+}

--- a/src/main/java/com/uctale/uctale/application/image/ImageAssetService.java
+++ b/src/main/java/com/uctale/uctale/application/image/ImageAssetService.java
@@ -1,5 +1,9 @@
 package com.uctale.uctale.application.image;
 
+import com.uctale.uctale.application.cost.CostOperation;
+import com.uctale.uctale.application.cost.CostRateLimiter;
+import com.uctale.uctale.application.cost.CostRequestContext;
+import com.uctale.uctale.application.cost.ProviderCallTelemetry;
 import com.uctale.uctale.domain.ImageAsset;
 import com.uctale.uctale.repository.ImageAssetRepository;
 import org.springframework.http.MediaType;
@@ -13,11 +17,20 @@ public class ImageAssetService {
 
     private final ImageAssetRepository imageAssetRepository;
     private final ImageGenerator imageGenerator;
+    private final CostRateLimiter costRateLimiter;
+    private final ProviderCallTelemetry providerCallTelemetry;
     private final ConcurrentHashMap<String, Object> generationLocks = new ConcurrentHashMap<>();
 
-    public ImageAssetService(ImageAssetRepository imageAssetRepository, ImageGenerator imageGenerator) {
+    public ImageAssetService(
+            ImageAssetRepository imageAssetRepository,
+            ImageGenerator imageGenerator,
+            CostRateLimiter costRateLimiter,
+            ProviderCallTelemetry providerCallTelemetry
+    ) {
         this.imageAssetRepository = imageAssetRepository;
         this.imageGenerator = imageGenerator;
+        this.costRateLimiter = costRateLimiter;
+        this.providerCallTelemetry = providerCallTelemetry;
     }
 
     public AssetReference issue(String prompt, String aspectRatio) {
@@ -30,7 +43,11 @@ public class ImageAssetService {
     }
 
     public GeneratedAsset getOrGenerate(String ownerKey, String assetId) {
-        ImageAsset asset = findOwnedAsset(ownerKey, assetId);
+        return getOrGenerate(CostRequestContext.internal(ownerKey, null, null), assetId);
+    }
+
+    public GeneratedAsset getOrGenerate(CostRequestContext requestContext, String assetId) {
+        ImageAsset asset = findOwnedAsset(requestContext.ownerKey(), assetId);
         if (asset.generated()) {
             return toGeneratedAsset(asset);
         }
@@ -38,22 +55,30 @@ public class ImageAssetService {
         Object lock = generationLocks.computeIfAbsent(assetId, ignored -> new Object());
         try {
             synchronized (lock) {
-                ImageAsset current = findOwnedAsset(ownerKey, assetId);
+                ImageAsset current = findOwnedAsset(requestContext.ownerKey(), assetId);
                 if (current.generated()) {
                     return toGeneratedAsset(current);
                 }
 
-                ImageGenerator.GeneratedImage generated = imageGenerator.fetchImage(
-                        current.getPrompt(),
-                        current.getAspectRatio()
+                CostRequestContext providerContext = new CostRequestContext(
+                        requestContext.requestId(),
+                        requestContext.ownerKey(),
+                        requestContext.clientIp(),
+                        current.getGameSession().getId(),
+                        current.getTurnNumber(),
+                        requestContext.idempotencyKey()
+                );
+                costRateLimiter.check(CostOperation.IMAGE, providerContext);
+
+                ImageGenerator.GeneratedImage generated = providerCallTelemetry.observe(
+                        "pollinations", "image_generation", providerContext, 0,
+                        () -> imageGenerator.fetchImage(current.getPrompt(), current.getAspectRatio())
                 );
                 if (generated == null || generated.bytes() == null || generated.bytes().length == 0) {
                     throw new ImageGenerationException("이미지 provider가 유효한 이미지를 반환하지 않았습니다.");
                 }
 
-                MediaType contentType = generated.contentType() == null
-                        ? MediaType.IMAGE_JPEG
-                        : generated.contentType();
+                MediaType contentType = generated.contentType() == null ? MediaType.IMAGE_JPEG : generated.contentType();
                 current.storeGeneratedImage(generated.bytes(), contentType.toString());
                 imageAssetRepository.saveAndFlush(current);
                 return toGeneratedAsset(current);
@@ -69,10 +94,7 @@ public class ImageAssetService {
     }
 
     private GeneratedAsset toGeneratedAsset(ImageAsset asset) {
-        return new GeneratedAsset(
-                asset.getImageBytes().clone(),
-                MediaType.parseMediaType(asset.getContentType())
-        );
+        return new GeneratedAsset(asset.getImageBytes().clone(), MediaType.parseMediaType(asset.getContentType()));
     }
 
     public record AssetReference(String id, String publicUrl, String prompt, String aspectRatio) {}

--- a/src/main/java/com/uctale/uctale/application/image/ImageAssetService.java
+++ b/src/main/java/com/uctale/uctale/application/image/ImageAssetService.java
@@ -72,11 +72,8 @@ public class ImageAssetService {
 
                 ImageGenerator.GeneratedImage generated = providerCallTelemetry.observe(
                         "pollinations", "image_generation", providerContext, 0,
-                        () -> imageGenerator.fetchImage(current.getPrompt(), current.getAspectRatio())
+                        () -> fetchValidImage(current)
                 );
-                if (generated == null || generated.bytes() == null || generated.bytes().length == 0) {
-                    throw new ImageGenerationException("이미지 provider가 유효한 이미지를 반환하지 않았습니다.");
-                }
 
                 MediaType contentType = generated.contentType() == null ? MediaType.IMAGE_JPEG : generated.contentType();
                 current.storeGeneratedImage(generated.bytes(), contentType.toString());
@@ -86,6 +83,14 @@ public class ImageAssetService {
         } finally {
             generationLocks.remove(assetId, lock);
         }
+    }
+
+    private ImageGenerator.GeneratedImage fetchValidImage(ImageAsset asset) {
+        ImageGenerator.GeneratedImage generated = imageGenerator.fetchImage(asset.getPrompt(), asset.getAspectRatio());
+        if (generated == null || generated.bytes() == null || generated.bytes().length == 0) {
+            throw new ImageGenerationException("이미지 provider가 유효한 이미지를 반환하지 않았습니다.");
+        }
+        return generated;
     }
 
     private ImageAsset findOwnedAsset(String ownerKey, String assetId) {

--- a/src/main/java/com/uctale/uctale/config/TimeConfig.java
+++ b/src/main/java/com/uctale/uctale/config/TimeConfig.java
@@ -1,0 +1,15 @@
+package com.uctale.uctale.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class TimeConfig {
+
+    @Bean
+    public Clock applicationClock() {
+        return Clock.systemUTC();
+    }
+}

--- a/src/main/java/com/uctale/uctale/controller/ApiExceptionHandler.java
+++ b/src/main/java/com/uctale/uctale/controller/ApiExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.uctale.uctale.controller;
 
+import com.uctale.uctale.application.cost.RateLimitExceededException;
 import com.uctale.uctale.application.game.GameSessionNotFoundException;
 import com.uctale.uctale.application.game.InvalidChoiceException;
 import com.uctale.uctale.application.game.PersistenceOperationException;
@@ -10,6 +11,7 @@ import com.uctale.uctale.application.narrative.InvalidNarrativeResponseException
 import com.uctale.uctale.security.AccessRequestForbiddenException;
 import com.uctale.uctale.security.AccessSessionException;
 import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -27,6 +29,13 @@ public class ApiExceptionHandler {
     @ExceptionHandler(AccessRequestForbiddenException.class)
     public ResponseEntity<ApiError> handleAccessRequestForbidden(AccessRequestForbiddenException exception) {
         return error(HttpStatus.FORBIDDEN, "ACCESS_REQUEST_FORBIDDEN", exception.getMessage());
+    }
+
+    @ExceptionHandler(RateLimitExceededException.class)
+    public ResponseEntity<ApiError> handleRateLimit(RateLimitExceededException exception) {
+        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+                .header(HttpHeaders.RETRY_AFTER, Long.toString(exception.retryAfterSeconds()))
+                .body(new ApiError("RATE_LIMIT_EXCEEDED", exception.getMessage()));
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/src/main/java/com/uctale/uctale/controller/GameController.java
+++ b/src/main/java/com/uctale/uctale/controller/GameController.java
@@ -1,10 +1,12 @@
 package com.uctale.uctale.controller;
 
+import com.uctale.uctale.application.cost.CostRequestContext;
 import com.uctale.uctale.dto.GameInitRequest;
 import com.uctale.uctale.dto.GameProgressRequest;
 import com.uctale.uctale.dto.GameResponse;
 import com.uctale.uctale.security.AccessSessionInterceptor;
 import com.uctale.uctale.service.GameService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,18 +28,24 @@ public class GameController {
     @PostMapping("/init")
     public ResponseEntity<GameResponse> initGame(
             @RequestAttribute(AccessSessionInterceptor.OWNER_KEY_ATTRIBUTE) String ownerKey,
-            @Valid @RequestBody GameInitRequest request
+            @Valid @RequestBody GameInitRequest request,
+            HttpServletRequest servletRequest
     ) {
         log.info("게임 초기화 요청 수신");
-        return ResponseEntity.ok(gameService.initGame(ownerKey, request));
+        CostRequestContext context = CostRequestContext.create(ownerKey, servletRequest.getRemoteAddr(), null, 1);
+        return ResponseEntity.ok(gameService.initGame(context, request));
     }
 
     @PostMapping("/progress")
     public ResponseEntity<GameResponse> progressGame(
             @RequestAttribute(AccessSessionInterceptor.OWNER_KEY_ATTRIBUTE) String ownerKey,
-            @Valid @RequestBody GameProgressRequest request
+            @Valid @RequestBody GameProgressRequest request,
+            HttpServletRequest servletRequest
     ) {
         log.info("게임 진행 요청: 세션ID={}, 기대턴={}", request.sessionId(), request.expectedTurn());
-        return ResponseEntity.ok(gameService.progressGame(ownerKey, request));
+        CostRequestContext context = CostRequestContext.create(
+                ownerKey, servletRequest.getRemoteAddr(), request.sessionId(), request.expectedTurn() + 1
+        );
+        return ResponseEntity.ok(gameService.progressGame(context, request));
     }
 }

--- a/src/main/java/com/uctale/uctale/controller/GameController.java
+++ b/src/main/java/com/uctale/uctale/controller/GameController.java
@@ -1,5 +1,6 @@
 package com.uctale.uctale.controller;
 
+import com.uctale.uctale.application.cost.ClientIpResolver;
 import com.uctale.uctale.application.cost.CostRequestContext;
 import com.uctale.uctale.dto.GameInitRequest;
 import com.uctale.uctale.dto.GameProgressRequest;
@@ -32,7 +33,7 @@ public class GameController {
             HttpServletRequest servletRequest
     ) {
         log.info("게임 초기화 요청 수신");
-        CostRequestContext context = CostRequestContext.create(ownerKey, servletRequest.getRemoteAddr(), null, 1);
+        CostRequestContext context = CostRequestContext.create(ownerKey, ClientIpResolver.resolve(servletRequest), null, 1);
         return ResponseEntity.ok(gameService.initGame(context, request));
     }
 
@@ -44,7 +45,7 @@ public class GameController {
     ) {
         log.info("게임 진행 요청: 세션ID={}, 기대턴={}", request.sessionId(), request.expectedTurn());
         CostRequestContext context = CostRequestContext.create(
-                ownerKey, servletRequest.getRemoteAddr(), request.sessionId(), request.expectedTurn() + 1
+                ownerKey, ClientIpResolver.resolve(servletRequest), request.sessionId(), request.expectedTurn() + 1
         );
         return ResponseEntity.ok(gameService.progressGame(context, request));
     }

--- a/src/main/java/com/uctale/uctale/controller/ImageController.java
+++ b/src/main/java/com/uctale/uctale/controller/ImageController.java
@@ -1,5 +1,6 @@
 package com.uctale.uctale.controller;
 
+import com.uctale.uctale.application.cost.ClientIpResolver;
 import com.uctale.uctale.application.cost.CostRequestContext;
 import com.uctale.uctale.application.image.ImageAssetService;
 import com.uctale.uctale.security.AccessSessionInterceptor;
@@ -28,7 +29,7 @@ public class ImageController {
             @PathVariable String assetId,
             HttpServletRequest servletRequest
     ) {
-        CostRequestContext context = CostRequestContext.create(ownerKey, servletRequest.getRemoteAddr(), null, null);
+        CostRequestContext context = CostRequestContext.create(ownerKey, ClientIpResolver.resolve(servletRequest), null, null);
         ImageAssetService.GeneratedAsset asset = imageAssetService.getOrGenerate(context, assetId);
 
         return ResponseEntity.ok()

--- a/src/main/java/com/uctale/uctale/controller/ImageController.java
+++ b/src/main/java/com/uctale/uctale/controller/ImageController.java
@@ -1,7 +1,9 @@
 package com.uctale.uctale.controller;
 
+import com.uctale.uctale.application.cost.CostRequestContext;
 import com.uctale.uctale.application.image.ImageAssetService;
 import com.uctale.uctale.security.AccessSessionInterceptor;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
@@ -23,9 +25,11 @@ public class ImageController {
     @GetMapping("/image-assets/{assetId}")
     public ResponseEntity<byte[]> image(
             @RequestAttribute(AccessSessionInterceptor.OWNER_KEY_ATTRIBUTE) String ownerKey,
-            @PathVariable String assetId
+            @PathVariable String assetId,
+            HttpServletRequest servletRequest
     ) {
-        ImageAssetService.GeneratedAsset asset = imageAssetService.getOrGenerate(ownerKey, assetId);
+        CostRequestContext context = CostRequestContext.create(ownerKey, servletRequest.getRemoteAddr(), null, null);
+        ImageAssetService.GeneratedAsset asset = imageAssetService.getOrGenerate(context, assetId);
 
         return ResponseEntity.ok()
                 .contentType(asset.contentType())

--- a/src/main/java/com/uctale/uctale/service/GameService.java
+++ b/src/main/java/com/uctale/uctale/service/GameService.java
@@ -88,10 +88,10 @@ public class GameService {
                 costContext.requestId(), costContext.ownerKey(), costContext.clientIp(),
                 loadedTurn.sessionId(), request.expectedTurn() + 1, costContext.idempotencyKey()
         );
-        costRateLimiter.check(CostOperation.NARRATIVE, providerContext);
 
         String userChoiceText = choiceCodec.findText(loadedTurn.choicesJson(), request.choiceId());
         NarrativeContext narrativeContext = NarrativeContext.from(loadedTurn.gameState(), userChoiceText);
+        costRateLimiter.check(CostOperation.NARRATIVE, providerContext);
         NarrativeTurn nextTurn = providerCallTelemetry.observe(
                 "gemini", "progress", providerContext, 0,
                 () -> narrativeGenerator.createNextTurn(narrativeContext)

--- a/src/main/java/com/uctale/uctale/service/GameService.java
+++ b/src/main/java/com/uctale/uctale/service/GameService.java
@@ -1,5 +1,9 @@
 package com.uctale.uctale.service;
 
+import com.uctale.uctale.application.cost.CostOperation;
+import com.uctale.uctale.application.cost.CostRateLimiter;
+import com.uctale.uctale.application.cost.CostRequestContext;
+import com.uctale.uctale.application.cost.ProviderCallTelemetry;
 import com.uctale.uctale.application.game.ChoiceCodec;
 import com.uctale.uctale.application.game.GamePersistenceService;
 import com.uctale.uctale.application.game.ImagePromptComposer;
@@ -36,9 +40,19 @@ public class GameService {
     private final GamePersistenceService gamePersistenceService;
     private final ChoiceCodec choiceCodec;
     private final ImagePromptComposer imagePromptComposer;
+    private final CostRateLimiter costRateLimiter;
+    private final ProviderCallTelemetry providerCallTelemetry;
 
     public GameResponse initGame(String ownerKey, GameInitRequest request) {
-        NarrativeTurn opening = narrativeGenerator.createOpening(request.worldSetting(), request.characterSetting());
+        return initGame(CostRequestContext.internal(ownerKey, null, 1), request);
+    }
+
+    public GameResponse initGame(CostRequestContext costContext, GameInitRequest request) {
+        costRateLimiter.check(CostOperation.NARRATIVE, costContext);
+        NarrativeTurn opening = providerCallTelemetry.observe(
+                "gemini", "opening", costContext, 0,
+                () -> narrativeGenerator.createOpening(request.worldSetting(), request.characterSetting())
+        );
         validateNarrativeTurn(opening);
         List<GameChoice> choices = toGameChoices(opening.choices());
 
@@ -50,7 +64,7 @@ public class GameService {
         ImageAssetService.AssetReference imageAsset = imageAssetService.issue(imagePrompt, "16:9");
 
         var session = gamePersistenceService.saveOpening(
-                ownerKey,
+                costContext.ownerKey(),
                 request.worldSetting(),
                 request.characterSetting(),
                 opening.storyText(),
@@ -58,25 +72,30 @@ public class GameService {
                 imageAsset
         );
 
-        return toResponse(
-                session.getId(),
-                session.getCurrentTurn(),
-                opening,
-                choices,
-                imageAsset.publicUrl()
-        );
+        return toResponse(session.getId(), session.getCurrentTurn(), opening, choices, imageAsset.publicUrl());
     }
 
     public GameResponse progressGame(String ownerKey, GameProgressRequest request) {
+        return progressGame(CostRequestContext.internal(ownerKey, request.sessionId(), request.expectedTurn() + 1), request);
+    }
+
+    public GameResponse progressGame(CostRequestContext costContext, GameProgressRequest request) {
         GamePersistenceService.LoadedTurn loadedTurn = gamePersistenceService.loadLatestTurn(
-                ownerKey,
-                request.sessionId(),
-                request.expectedTurn()
+                costContext.ownerKey(), request.sessionId(), request.expectedTurn()
         );
+
+        CostRequestContext providerContext = new CostRequestContext(
+                costContext.requestId(), costContext.ownerKey(), costContext.clientIp(),
+                loadedTurn.sessionId(), request.expectedTurn() + 1, costContext.idempotencyKey()
+        );
+        costRateLimiter.check(CostOperation.NARRATIVE, providerContext);
 
         String userChoiceText = choiceCodec.findText(loadedTurn.choicesJson(), request.choiceId());
         NarrativeContext narrativeContext = NarrativeContext.from(loadedTurn.gameState(), userChoiceText);
-        NarrativeTurn nextTurn = narrativeGenerator.createNextTurn(narrativeContext);
+        NarrativeTurn nextTurn = providerCallTelemetry.observe(
+                "gemini", "progress", providerContext, 0,
+                () -> narrativeGenerator.createNextTurn(narrativeContext)
+        );
         validateNarrativeTurn(nextTurn);
         List<GameChoice> choices = toGameChoices(nextTurn.choices());
 
@@ -93,22 +112,15 @@ public class GameService {
         }
 
         int savedTurn = gamePersistenceService.saveNextTurn(
-                ownerKey,
-                loadedTurn.sessionId(),
-                request.expectedTurn(),
-                userChoiceText,
-                nextTurn.storyText(),
-                choiceCodec.serialize(choices),
-                imageAsset
+                costContext.ownerKey(), loadedTurn.sessionId(), request.expectedTurn(), userChoiceText,
+                nextTurn.storyText(), choiceCodec.serialize(choices), imageAsset
         );
 
         return toResponse(loadedTurn.sessionId(), savedTurn, nextTurn, choices, imageUrl);
     }
 
     private void validateNarrativeTurn(NarrativeTurn turn) {
-        if (turn == null) {
-            throw new InvalidNarrativeResponseException("Narrative 응답이 없습니다.");
-        }
+        if (turn == null) throw new InvalidNarrativeResponseException("Narrative 응답이 없습니다.");
         if (turn.title() == null || turn.title().isBlank() || turn.title().length() > MAX_TITLE_LENGTH) {
             throw new InvalidNarrativeResponseException("Narrative 제목이 올바르지 않습니다.");
         }
@@ -118,7 +130,6 @@ public class GameService {
         if (turn.choices() == null || turn.choices().isEmpty() || turn.choices().size() > MAX_CHOICES) {
             throw new InvalidNarrativeResponseException("Narrative 선택지 수가 올바르지 않습니다.");
         }
-
         Set<Integer> choiceIds = new HashSet<>();
         for (NarrativeTurn.Choice choice : turn.choices()) {
             if (choice == null || choice.id() <= 0 || !choiceIds.add(choice.id())) {
@@ -136,19 +147,11 @@ public class GameService {
         }
     }
 
-    private GameResponse toResponse(
-            Long sessionId,
-            int turnNumber,
-            NarrativeTurn turn,
-            List<GameChoice> choices,
-            String imageUrl
-    ) {
+    private GameResponse toResponse(Long sessionId, int turnNumber, NarrativeTurn turn, List<GameChoice> choices, String imageUrl) {
         return new GameResponse(sessionId, turnNumber, turn.title(), turn.storyText(), choices, imageUrl);
     }
 
     private List<GameChoice> toGameChoices(List<NarrativeTurn.Choice> choices) {
-        return choices.stream()
-                .map(choice -> new GameChoice(choice.id(), choice.text()))
-                .toList();
+        return choices.stream().map(choice -> new GameChoice(choice.id(), choice.text())).toList();
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,6 +8,9 @@ game.access.session-ttl-seconds=${GAME_ACCESS_SESSION_TTL_SECONDS:3600}
 game.owner.cookie-ttl-seconds=${GAME_OWNER_COOKIE_TTL_SECONDS:15552000}
 game.access.cookie-secure=${GAME_ACCESS_COOKIE_SECURE:true}
 game.cors.allowed-origins=${GAME_CORS_ALLOWED_ORIGINS:https://uctale.vercel.app}
+game.cost.rate-limit.window-seconds=${GAME_COST_RATE_LIMIT_WINDOW_SECONDS:60}
+game.cost.rate-limit.narrative-limit=${GAME_COST_NARRATIVE_LIMIT:12}
+game.cost.rate-limit.image-limit=${GAME_COST_IMAGE_LIMIT:8}
 
 spring.datasource.url=${DATABASE_URL}
 spring.datasource.username=${DATABASE_USERNAME}

--- a/src/test/java/com/uctale/uctale/application/cost/ClientIpResolverTest.java
+++ b/src/test/java/com/uctale/uctale/application/cost/ClientIpResolverTest.java
@@ -1,0 +1,31 @@
+package com.uctale.uctale.application.cost;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class ClientIpResolverTest {
+
+    @Test
+    @DisplayName("X-Forwarded-For가 있으면 첫 client 주소를 사용한다")
+    void forwardedFor_UsesFirstAddress() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        given(request.getHeader("X-Forwarded-For")).willReturn("203.0.113.10, 10.0.0.3");
+        given(request.getRemoteAddr()).willReturn("10.0.0.2");
+
+        assertThat(ClientIpResolver.resolve(request)).isEqualTo("203.0.113.10");
+    }
+
+    @Test
+    @DisplayName("proxy header가 없으면 remote address를 사용한다")
+    void noForwardedFor_UsesRemoteAddress() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        given(request.getRemoteAddr()).willReturn("198.51.100.7");
+
+        assertThat(ClientIpResolver.resolve(request)).isEqualTo("198.51.100.7");
+    }
+}

--- a/src/test/java/com/uctale/uctale/application/cost/CostRateLimiterTest.java
+++ b/src/test/java/com/uctale/uctale/application/cost/CostRateLimiterTest.java
@@ -1,0 +1,92 @@
+package com.uctale.uctale.application.cost;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CostRateLimiterTest {
+
+    @Test
+    @DisplayName("Narrative 한도를 넘으면 Retry-After와 함께 provider 호출 전에 거부할 수 있다")
+    void narrativeLimit_IsDeterministic() {
+        MutableClock clock = new MutableClock(Instant.parse("2026-08-30T06:00:00Z"));
+        CostRateLimiter limiter = new CostRateLimiter(new CostRateLimitPolicy(2, 5, 60), clock);
+        CostRequestContext context = new CostRequestContext("r1", "owner-a", "1.2.3.4", 10L, 2, null);
+
+        limiter.check(CostOperation.NARRATIVE, context);
+        limiter.check(CostOperation.NARRATIVE, context);
+
+        assertThatThrownBy(() -> limiter.check(CostOperation.NARRATIVE, context))
+                .isInstanceOfSatisfying(RateLimitExceededException.class,
+                        exception -> assertThat(exception.retryAfterSeconds()).isEqualTo(60));
+
+        clock.advanceSeconds(60);
+        assertThatCode(() -> limiter.check(CostOperation.NARRATIVE, context)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("Narrative와 Image quota는 서로 독립적이다")
+    void operationQuotas_AreIndependent() {
+        MutableClock clock = new MutableClock(Instant.parse("2026-08-30T06:00:00Z"));
+        CostRateLimiter limiter = new CostRateLimiter(new CostRateLimitPolicy(1, 2, 60), clock);
+        CostRequestContext context = new CostRequestContext("r1", "owner-a", "1.2.3.4", 10L, 2, null);
+
+        limiter.check(CostOperation.NARRATIVE, context);
+        assertThatThrownBy(() -> limiter.check(CostOperation.NARRATIVE, context))
+                .isInstanceOf(RateLimitExceededException.class);
+
+        assertThatCode(() -> limiter.check(CostOperation.IMAGE, context)).doesNotThrowAnyException();
+        assertThatCode(() -> limiter.check(CostOperation.IMAGE, context)).doesNotThrowAnyException();
+        assertThatThrownBy(() -> limiter.check(CostOperation.IMAGE, context))
+                .isInstanceOf(RateLimitExceededException.class);
+    }
+
+    @Test
+    @DisplayName("owner뿐 아니라 동일 IP의 비용 요청도 합산한다")
+    void ipBucket_IsSharedAcrossOwners() {
+        MutableClock clock = new MutableClock(Instant.parse("2026-08-30T06:00:00Z"));
+        CostRateLimiter limiter = new CostRateLimiter(new CostRateLimitPolicy(1, 5, 60), clock);
+
+        limiter.check(CostOperation.NARRATIVE,
+                new CostRequestContext("r1", "owner-a", "1.2.3.4", 10L, 2, null));
+
+        assertThatThrownBy(() -> limiter.check(CostOperation.NARRATIVE,
+                new CostRequestContext("r2", "owner-b", "1.2.3.4", 11L, 2, null)))
+                .isInstanceOf(RateLimitExceededException.class);
+    }
+
+    private static final class MutableClock extends Clock {
+        private Instant instant;
+
+        private MutableClock(Instant instant) {
+            this.instant = instant;
+        }
+
+        private void advanceSeconds(long seconds) {
+            instant = instant.plusSeconds(seconds);
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+    }
+}

--- a/src/test/java/com/uctale/uctale/application/cost/ProviderCallTelemetryTest.java
+++ b/src/test/java/com/uctale/uctale/application/cost/ProviderCallTelemetryTest.java
@@ -1,0 +1,90 @@
+package com.uctale.uctale.application.cost;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ProviderCallTelemetryTest {
+
+    @Test
+    @DisplayName("provider 성공 호출은 민감 본문 없이 식별자와 latency를 기록한다")
+    void success_IsRecorded() {
+        MutableClock clock = new MutableClock(Instant.parse("2026-08-30T06:00:00Z"));
+        List<ProviderCallEvent> events = new ArrayList<>();
+        ProviderCallTelemetry telemetry = new ProviderCallTelemetry(clock, events::add);
+        CostRequestContext context = new CostRequestContext("request-1", "owner-secret", "1.2.3.4", 42L, 3, null);
+
+        String result = telemetry.observe("gemini", "progress", context, 0, () -> {
+            clock.advanceMillis(37);
+            return "ok";
+        });
+
+        assertThat(result).isEqualTo("ok");
+        assertThat(events).singleElement().satisfies(event -> {
+            assertThat(event.provider()).isEqualTo("gemini");
+            assertThat(event.operation()).isEqualTo("progress");
+            assertThat(event.sessionId()).isEqualTo(42L);
+            assertThat(event.turn()).isEqualTo(3);
+            assertThat(event.requestId()).isEqualTo("request-1");
+            assertThat(event.latencyMs()).isEqualTo(37);
+            assertThat(event.outcome()).isEqualTo("SUCCESS");
+            assertThat(event.retryCount()).isZero();
+        });
+    }
+
+    @Test
+    @DisplayName("provider 예외도 실패 event를 남기고 원래 예외를 전달한다")
+    void failure_IsRecorded() {
+        MutableClock clock = new MutableClock(Instant.parse("2026-08-30T06:00:00Z"));
+        List<ProviderCallEvent> events = new ArrayList<>();
+        ProviderCallTelemetry telemetry = new ProviderCallTelemetry(clock, events::add);
+        CostRequestContext context = CostRequestContext.internal("owner-a", 42L, 2);
+
+        assertThatThrownBy(() -> telemetry.observe("pollinations", "image_generation", context, 1, () -> {
+            clock.advanceMillis(12);
+            throw new IllegalStateException("provider down");
+        })).isInstanceOf(IllegalStateException.class);
+
+        assertThat(events).singleElement().satisfies(event -> {
+            assertThat(event.outcome()).isEqualTo("FAILURE");
+            assertThat(event.retryCount()).isEqualTo(1);
+            assertThat(event.latencyMs()).isEqualTo(12);
+        });
+    }
+
+    private static final class MutableClock extends Clock {
+        private Instant instant;
+
+        private MutableClock(Instant instant) {
+            this.instant = instant;
+        }
+
+        private void advanceMillis(long millis) {
+            instant = instant.plusMillis(millis);
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+    }
+}

--- a/src/test/java/com/uctale/uctale/application/image/ImageAssetServiceCostControlTest.java
+++ b/src/test/java/com/uctale/uctale/application/image/ImageAssetServiceCostControlTest.java
@@ -27,6 +27,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
 class ImageAssetServiceCostControlTest {
@@ -59,6 +60,7 @@ class ImageAssetServiceCostControlTest {
         assertThat(result.bytes()).containsExactly(1, 2, 3);
         verify(rateLimiter, never()).check(any(), any());
         verify(imageGenerator, never()).fetchImage(any(), any());
+        verifyNoInteractions(telemetry);
     }
 
     @Test
@@ -74,7 +76,7 @@ class ImageAssetServiceCostControlTest {
         )).isInstanceOf(RateLimitExceededException.class);
 
         verify(imageGenerator, never()).fetchImage(any(), any());
-        verify(telemetry, never()).observe(any(), any(), any(), any(Integer.class), any());
+        verifyNoInteractions(telemetry);
     }
 
     private ImageAsset asset(String id) {

--- a/src/test/java/com/uctale/uctale/application/image/ImageAssetServiceCostControlTest.java
+++ b/src/test/java/com/uctale/uctale/application/image/ImageAssetServiceCostControlTest.java
@@ -1,0 +1,85 @@
+package com.uctale.uctale.application.image;
+
+import com.uctale.uctale.application.cost.CostOperation;
+import com.uctale.uctale.application.cost.CostRateLimiter;
+import com.uctale.uctale.application.cost.CostRequestContext;
+import com.uctale.uctale.application.cost.ProviderCallTelemetry;
+import com.uctale.uctale.application.cost.RateLimitExceededException;
+import com.uctale.uctale.domain.GameSession;
+import com.uctale.uctale.domain.ImageAsset;
+import com.uctale.uctale.repository.ImageAssetRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ImageAssetServiceCostControlTest {
+
+    private static final String OWNER_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+    @Mock private ImageAssetRepository repository;
+    @Mock private ImageGenerator imageGenerator;
+    @Mock private CostRateLimiter rateLimiter;
+    @Mock private ProviderCallTelemetry telemetry;
+
+    private ImageAssetService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ImageAssetService(repository, imageGenerator, rateLimiter, telemetry);
+    }
+
+    @Test
+    @DisplayName("이미 생성된 asset 재조회는 Image quota를 소비하지 않는다")
+    void generatedAsset_DoesNotConsumeQuota() {
+        ImageAsset asset = asset("asset-1");
+        asset.storeGeneratedImage(new byte[]{1, 2, 3}, MediaType.IMAGE_PNG.toString());
+        given(repository.findByIdAndGameSessionOwnerKey("asset-1", OWNER_KEY)).willReturn(Optional.of(asset));
+
+        ImageAssetService.GeneratedAsset result = service.getOrGenerate(
+                new CostRequestContext("r1", OWNER_KEY, "1.2.3.4", null, null, null), "asset-1"
+        );
+
+        assertThat(result.bytes()).containsExactly(1, 2, 3);
+        verify(rateLimiter, never()).check(any(), any());
+        verify(imageGenerator, never()).fetchImage(any(), any());
+    }
+
+    @Test
+    @DisplayName("미생성 asset의 rate limit 초과는 provider 호출 전에 거부한다")
+    void rateLimit_RejectsBeforeProvider() {
+        ImageAsset asset = asset("asset-2");
+        given(repository.findByIdAndGameSessionOwnerKey("asset-2", OWNER_KEY)).willReturn(Optional.of(asset));
+        doThrow(new RateLimitExceededException("limit", 10))
+                .when(rateLimiter).check(eq(CostOperation.IMAGE), any(CostRequestContext.class));
+
+        assertThatThrownBy(() -> service.getOrGenerate(
+                new CostRequestContext("r2", OWNER_KEY, "1.2.3.4", null, null, null), "asset-2"
+        )).isInstanceOf(RateLimitExceededException.class);
+
+        verify(imageGenerator, never()).fetchImage(any(), any());
+        verify(telemetry, never()).observe(any(), any(), any(), any(Integer.class), any());
+    }
+
+    private ImageAsset asset(String id) {
+        GameSession session = new GameSession(OWNER_KEY, "world", "character");
+        ReflectionTestUtils.setField(session, "id", 42L);
+        return new ImageAsset(id, session, 1, "prompt", "16:9");
+    }
+}

--- a/src/test/java/com/uctale/uctale/controller/ApiExceptionHandlerRateLimitTest.java
+++ b/src/test/java/com/uctale/uctale/controller/ApiExceptionHandlerRateLimitTest.java
@@ -1,0 +1,22 @@
+package com.uctale.uctale.controller;
+
+import com.uctale.uctale.application.cost.RateLimitExceededException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApiExceptionHandlerRateLimitTest {
+
+    @Test
+    @DisplayName("rate limit 초과는 429와 Retry-After를 반환한다")
+    void rateLimit_ReturnsStableContract() {
+        ApiExceptionHandler handler = new ApiExceptionHandler();
+
+        var response = handler.handleRateLimit(new RateLimitExceededException("비용 API 요청 한도를 초과했습니다.", 17));
+
+        assertThat(response.getStatusCode().value()).isEqualTo(429);
+        assertThat(response.getHeaders().getFirst("Retry-After")).isEqualTo("17");
+        assertThat(response.getBody()).isEqualTo(new ApiError("RATE_LIMIT_EXCEEDED", "비용 API 요청 한도를 초과했습니다."));
+    }
+}

--- a/src/test/java/com/uctale/uctale/controller/GameControllerTest.java
+++ b/src/test/java/com/uctale/uctale/controller/GameControllerTest.java
@@ -1,6 +1,7 @@
 package com.uctale.uctale.controller;
 
 import tools.jackson.databind.ObjectMapper;
+import com.uctale.uctale.application.cost.CostRequestContext;
 import com.uctale.uctale.application.game.GameSessionNotFoundException;
 import com.uctale.uctale.application.game.InvalidChoiceException;
 import com.uctale.uctale.application.game.TurnConflictException;
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
@@ -22,8 +24,8 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -42,25 +44,18 @@ class GameControllerTest {
 
     @BeforeEach
     void setUp() {
-        mockMvc = MockMvcBuilders
-                .standaloneSetup(new GameController(gameService))
+        mockMvc = MockMvcBuilders.standaloneSetup(new GameController(gameService))
                 .setControllerAdvice(new ApiExceptionHandler())
                 .build();
         objectMapper = new ObjectMapper();
     }
 
     @Test
-    @DisplayName("게임 초기화 응답은 첫 번째 턴을 제공하고 owner key를 서비스에 전달한다")
+    @DisplayName("게임 초기화 응답은 첫 번째 턴을 제공하고 비용 요청 context를 서비스에 전달한다")
     void initGame_ReturnsFirstTurn() throws Exception {
-        GameResponse response = new GameResponse(
-                42L,
-                1,
-                "첫날 밤",
-                "오프닝 스토리입니다.",
-                List.of(new GameChoice(1, "도망간다")),
-                "/api/game/image?prompt=test&aspectRatio=16%3A9"
-        );
-        given(gameService.initGame(eq(OWNER_KEY), any(GameInitRequest.class))).willReturn(response);
+        GameResponse response = new GameResponse(42L, 1, "첫날 밤", "오프닝 스토리입니다.",
+                List.of(new GameChoice(1, "도망간다")), "/api/game/image-assets/asset-1");
+        given(gameService.initGame(any(CostRequestContext.class), any(GameInitRequest.class))).willReturn(response);
 
         mockMvc.perform(post("/api/game/init")
                         .requestAttr(AccessSessionInterceptor.OWNER_KEY_ATTRIBUTE, OWNER_KEY)
@@ -70,22 +65,19 @@ class GameControllerTest {
                 .andExpect(jsonPath("$.sessionId").value(42))
                 .andExpect(jsonPath("$.turnNumber").value(1));
 
-        verify(gameService).initGame(eq(OWNER_KEY), any(GameInitRequest.class));
+        ArgumentCaptor<CostRequestContext> contextCaptor = ArgumentCaptor.forClass(CostRequestContext.class);
+        verify(gameService).initGame(contextCaptor.capture(), any(GameInitRequest.class));
+        assertThat(contextCaptor.getValue().ownerKey()).isEqualTo(OWNER_KEY);
+        assertThat(contextCaptor.getValue().turn()).isEqualTo(1);
     }
 
     @Test
-    @DisplayName("게임 진행 요청은 owner key와 기대 턴을 함께 서비스에 전달한다")
+    @DisplayName("게임 진행 요청은 session과 기대 다음 턴을 비용 context에 포함한다")
     void progressGame_Success() throws Exception {
         GameProgressRequest request = new GameProgressRequest(42L, 1, 1);
-        GameResponse response = new GameResponse(
-                42L,
-                2,
-                "두 번째 장면",
-                "다음 턴 스토리입니다.",
-                List.of(new GameChoice(2, "숨는다")),
-                "/api/game/image?prompt=turn2&aspectRatio=16%3A9"
-        );
-        given(gameService.progressGame(eq(OWNER_KEY), any(GameProgressRequest.class))).willReturn(response);
+        GameResponse response = new GameResponse(42L, 2, "두 번째 장면", "다음 턴 스토리입니다.",
+                List.of(new GameChoice(2, "숨는다")), "/api/game/image-assets/asset-2");
+        given(gameService.progressGame(any(CostRequestContext.class), any(GameProgressRequest.class))).willReturn(response);
 
         mockMvc.perform(post("/api/game/progress")
                         .requestAttr(AccessSessionInterceptor.OWNER_KEY_ATTRIBUTE, OWNER_KEY)
@@ -93,14 +85,17 @@ class GameControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.turnNumber").value(2));
+
+        ArgumentCaptor<CostRequestContext> contextCaptor = ArgumentCaptor.forClass(CostRequestContext.class);
+        verify(gameService).progressGame(contextCaptor.capture(), any(GameProgressRequest.class));
+        assertThat(contextCaptor.getValue().sessionId()).isEqualTo(42L);
+        assertThat(contextCaptor.getValue().turn()).isEqualTo(2);
     }
 
     @Test
-    @DisplayName("다른 owner의 세션은 존재하지 않는 세션과 동일한 404로 반환한다")
     void progressGame_MapsOwnershipMismatchToNotFound() throws Exception {
-        given(gameService.progressGame(eq(OWNER_KEY), any(GameProgressRequest.class)))
+        given(gameService.progressGame(any(CostRequestContext.class), any(GameProgressRequest.class)))
                 .willThrow(new GameSessionNotFoundException("존재하지 않는 세션입니다."));
-
         mockMvc.perform(post("/api/game/progress")
                         .requestAttr(AccessSessionInterceptor.OWNER_KEY_ATTRIBUTE, OWNER_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -110,26 +105,21 @@ class GameControllerTest {
     }
 
     @Test
-    @DisplayName("오래된 턴 요청은 안정적인 409 오류 코드로 반환한다")
     void progressGame_MapsTurnConflict() throws Exception {
-        given(gameService.progressGame(eq(OWNER_KEY), any(GameProgressRequest.class)))
+        given(gameService.progressGame(any(CostRequestContext.class), any(GameProgressRequest.class)))
                 .willThrow(new TurnConflictException("이미 처리되었거나 오래된 턴 요청입니다."));
-
         mockMvc.perform(post("/api/game/progress")
                         .requestAttr(AccessSessionInterceptor.OWNER_KEY_ATTRIBUTE, OWNER_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new GameProgressRequest(42L, 1, 1))))
                 .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.code").value("TURN_CONFLICT"))
-                .andExpect(jsonPath("$.message").value("이미 처리되었거나 오래된 턴 요청입니다."));
+                .andExpect(jsonPath("$.code").value("TURN_CONFLICT"));
     }
 
     @Test
-    @DisplayName("현재 턴에 없는 선택지는 422 오류 코드로 반환한다")
     void progressGame_MapsInvalidChoice() throws Exception {
-        given(gameService.progressGame(eq(OWNER_KEY), any(GameProgressRequest.class)))
+        given(gameService.progressGame(any(CostRequestContext.class), any(GameProgressRequest.class)))
                 .willThrow(new InvalidChoiceException("현재 턴에서 선택할 수 없는 선택지입니다."));
-
         mockMvc.perform(post("/api/game/progress")
                         .requestAttr(AccessSessionInterceptor.OWNER_KEY_ATTRIBUTE, OWNER_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -139,7 +129,6 @@ class GameControllerTest {
     }
 
     @Test
-    @DisplayName("빈 세계관 설정은 provider 호출 전에 400으로 거부한다")
     void initGame_RejectsBlankWorldSetting() throws Exception {
         mockMvc.perform(post("/api/game/init")
                         .requestAttr(AccessSessionInterceptor.OWNER_KEY_ATTRIBUTE, OWNER_KEY)
@@ -147,12 +136,10 @@ class GameControllerTest {
                         .content(objectMapper.writeValueAsString(new GameInitRequest("", "김대리"))))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
-
-        verify(gameService, never()).initGame(eq(OWNER_KEY), any(GameInitRequest.class));
+        verify(gameService, never()).initGame(any(CostRequestContext.class), any(GameInitRequest.class));
     }
 
     @Test
-    @DisplayName("DB varchar 한계를 넘는 세계관 설정은 provider 호출 전에 거부한다")
     void initGame_RejectsWorldSettingLongerThanDatabaseLimit() throws Exception {
         mockMvc.perform(post("/api/game/init")
                         .requestAttr(AccessSessionInterceptor.OWNER_KEY_ATTRIBUTE, OWNER_KEY)
@@ -160,7 +147,6 @@ class GameControllerTest {
                         .content(objectMapper.writeValueAsString(new GameInitRequest("가".repeat(256), "김대리"))))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
-
-        verify(gameService, never()).initGame(eq(OWNER_KEY), any(GameInitRequest.class));
+        verify(gameService, never()).initGame(any(CostRequestContext.class), any(GameInitRequest.class));
     }
 }

--- a/src/test/java/com/uctale/uctale/controller/ImageControllerTest.java
+++ b/src/test/java/com/uctale/uctale/controller/ImageControllerTest.java
@@ -1,15 +1,20 @@
 package com.uctale.uctale.controller;
 
+import com.uctale.uctale.application.cost.CostRequestContext;
 import com.uctale.uctale.application.image.ImageAssetService;
+import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -18,20 +23,24 @@ class ImageControllerTest {
 
     private static final String OWNER_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
-    @Mock
-    private ImageAssetService imageAssetService;
+    @Mock private ImageAssetService imageAssetService;
+    @Mock private HttpServletRequest servletRequest;
 
     @Test
-    @DisplayName("image asset 조회는 요청 owner와 asset ID를 application service에 전달한다")
+    @DisplayName("image asset 조회는 owner와 client IP를 비용 요청 context에 포함한다")
     void image_UsesOwnedAssetLookup() {
         ImageController controller = new ImageController(imageAssetService);
         byte[] bytes = new byte[]{1, 2, 3};
-        given(imageAssetService.getOrGenerate(OWNER_KEY, "asset-id"))
+        given(servletRequest.getRemoteAddr()).willReturn("1.2.3.4");
+        given(imageAssetService.getOrGenerate(any(CostRequestContext.class), eq("asset-id")))
                 .willReturn(new ImageAssetService.GeneratedAsset(bytes, MediaType.IMAGE_PNG));
 
-        ResponseEntity<byte[]> response = controller.image(OWNER_KEY, "asset-id");
+        ResponseEntity<byte[]> response = controller.image(OWNER_KEY, "asset-id", servletRequest);
 
-        verify(imageAssetService).getOrGenerate(OWNER_KEY, "asset-id");
+        ArgumentCaptor<CostRequestContext> contextCaptor = ArgumentCaptor.forClass(CostRequestContext.class);
+        verify(imageAssetService).getOrGenerate(contextCaptor.capture(), eq("asset-id"));
+        assertThat(contextCaptor.getValue().ownerKey()).isEqualTo(OWNER_KEY);
+        assertThat(contextCaptor.getValue().clientIp()).isEqualTo("1.2.3.4");
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getHeaders().getContentType()).isEqualTo(MediaType.IMAGE_PNG);
         assertThat(response.getHeaders().getCacheControl()).contains("private");

--- a/src/test/java/com/uctale/uctale/service/GameServiceRateLimitTest.java
+++ b/src/test/java/com/uctale/uctale/service/GameServiceRateLimitTest.java
@@ -1,0 +1,62 @@
+package com.uctale.uctale.service;
+
+import tools.jackson.databind.ObjectMapper;
+import com.uctale.uctale.application.cost.CostRateLimitPolicy;
+import com.uctale.uctale.application.cost.CostRateLimiter;
+import com.uctale.uctale.application.cost.CostRequestContext;
+import com.uctale.uctale.application.cost.ProviderCallTelemetry;
+import com.uctale.uctale.application.cost.RateLimitExceededException;
+import com.uctale.uctale.application.game.ChoiceCodec;
+import com.uctale.uctale.application.game.GamePersistenceService;
+import com.uctale.uctale.application.game.ImagePromptComposer;
+import com.uctale.uctale.application.image.ImageAssetService;
+import com.uctale.uctale.application.narrative.NarrativeGenerator;
+import com.uctale.uctale.dto.GameInitRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class GameServiceRateLimitTest {
+
+    private static final String OWNER_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+    @Mock private NarrativeGenerator narrativeGenerator;
+    @Mock private ImageAssetService imageAssetService;
+    @Mock private GamePersistenceService gamePersistenceService;
+
+    @Test
+    @DisplayName("Narrative quota 초과는 Gemini 호출 전에 거부한다")
+    void narrativeLimit_RejectsBeforeProvider() {
+        Clock clock = Clock.fixed(Instant.parse("2026-08-30T06:00:00Z"), ZoneOffset.UTC);
+        CostRateLimiter limiter = new CostRateLimiter(new CostRateLimitPolicy(1, 10, 60), clock);
+        ProviderCallTelemetry telemetry = new ProviderCallTelemetry(clock, event -> {});
+        GameService service = new GameService(
+                narrativeGenerator,
+                imageAssetService,
+                gamePersistenceService,
+                new ChoiceCodec(new ObjectMapper()),
+                new ImagePromptComposer(),
+                limiter,
+                telemetry
+        );
+        CostRequestContext context = new CostRequestContext("request-1", OWNER_KEY, "1.2.3.4", null, 1, null);
+        limiter.check(com.uctale.uctale.application.cost.CostOperation.NARRATIVE, context);
+
+        assertThatThrownBy(() -> service.initGame(context, new GameInitRequest("세계관", "캐릭터")))
+                .isInstanceOf(RateLimitExceededException.class);
+
+        verify(narrativeGenerator, never()).createOpening(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+        verify(imageAssetService, never()).issue(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+    }
+}

--- a/src/test/java/com/uctale/uctale/service/GameServiceRateLimitTest.java
+++ b/src/test/java/com/uctale/uctale/service/GameServiceRateLimitTest.java
@@ -1,6 +1,7 @@
 package com.uctale.uctale.service;
 
 import tools.jackson.databind.ObjectMapper;
+import com.uctale.uctale.application.cost.CostOperation;
 import com.uctale.uctale.application.cost.CostRateLimitPolicy;
 import com.uctale.uctale.application.cost.CostRateLimiter;
 import com.uctale.uctale.application.cost.CostRequestContext;
@@ -9,9 +10,12 @@ import com.uctale.uctale.application.cost.RateLimitExceededException;
 import com.uctale.uctale.application.game.ChoiceCodec;
 import com.uctale.uctale.application.game.GamePersistenceService;
 import com.uctale.uctale.application.game.ImagePromptComposer;
+import com.uctale.uctale.application.game.InvalidChoiceException;
 import com.uctale.uctale.application.image.ImageAssetService;
 import com.uctale.uctale.application.narrative.NarrativeGenerator;
+import com.uctale.uctale.domain.game.GameState;
 import com.uctale.uctale.dto.GameInitRequest;
+import com.uctale.uctale.dto.GameProgressRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,9 +26,11 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class GameServiceRateLimitTest {
@@ -51,12 +57,44 @@ class GameServiceRateLimitTest {
                 telemetry
         );
         CostRequestContext context = new CostRequestContext("request-1", OWNER_KEY, "1.2.3.4", null, 1, null);
-        limiter.check(com.uctale.uctale.application.cost.CostOperation.NARRATIVE, context);
+        limiter.check(CostOperation.NARRATIVE, context);
 
         assertThatThrownBy(() -> service.initGame(context, new GameInitRequest("세계관", "캐릭터")))
                 .isInstanceOf(RateLimitExceededException.class);
 
         verify(narrativeGenerator, never()).createOpening(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
         verify(imageAssetService, never()).issue(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("현재 턴에 없는 선택지는 Narrative quota를 소비하지 않는다")
+    void invalidChoice_DoesNotConsumeNarrativeQuota() {
+        Clock clock = Clock.fixed(Instant.parse("2026-08-30T06:00:00Z"), ZoneOffset.UTC);
+        CostRateLimiter limiter = new CostRateLimiter(new CostRateLimitPolicy(1, 10, 60), clock);
+        ProviderCallTelemetry telemetry = new ProviderCallTelemetry(clock, event -> {});
+        ChoiceCodec choiceCodec = new ChoiceCodec(new ObjectMapper());
+        GameService service = new GameService(
+                narrativeGenerator,
+                imageAssetService,
+                gamePersistenceService,
+                choiceCodec,
+                new ImagePromptComposer(),
+                limiter,
+                telemetry
+        );
+        GameState gameState = GameState.initial("세계관", "캐릭터", "첫 이야기");
+        String choicesJson = choiceCodec.serialize(java.util.List.of(new com.uctale.uctale.dto.GameChoice(1, "유효한 선택")));
+        when(gamePersistenceService.loadLatestTurn(OWNER_KEY, 10L, 1)).thenReturn(
+                new GamePersistenceService.LoadedTurn(
+                        10L, 1, "세계관", "캐릭터", "첫 이야기", choicesJson, "/image", gameState
+                )
+        );
+        CostRequestContext context = new CostRequestContext("request-1", OWNER_KEY, "1.2.3.4", 10L, 2, null);
+
+        assertThatThrownBy(() -> service.progressGame(context, new GameProgressRequest(10L, 999, 1)))
+                .isInstanceOf(InvalidChoiceException.class);
+
+        assertThatCode(() -> limiter.check(CostOperation.NARRATIVE, context)).doesNotThrowAnyException();
+        verify(narrativeGenerator, never()).createNextTurn(org.mockito.ArgumentMatchers.any());
     }
 }

--- a/src/test/java/com/uctale/uctale/service/GameServiceTest.java
+++ b/src/test/java/com/uctale/uctale/service/GameServiceTest.java
@@ -1,6 +1,9 @@
 package com.uctale.uctale.service;
 
 import tools.jackson.databind.ObjectMapper;
+import com.uctale.uctale.application.cost.CostRateLimitPolicy;
+import com.uctale.uctale.application.cost.CostRateLimiter;
+import com.uctale.uctale.application.cost.ProviderCallTelemetry;
 import com.uctale.uctale.application.game.ChoiceCodec;
 import com.uctale.uctale.application.game.GamePersistenceService;
 import com.uctale.uctale.application.game.ImagePromptComposer;
@@ -24,6 +27,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.Clock;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -50,12 +54,15 @@ class GameServiceTest {
     @BeforeEach
     void setUp() {
         choiceCodec = new ChoiceCodec(new ObjectMapper());
+        Clock clock = Clock.systemUTC();
         gameService = new GameService(
                 narrativeGenerator,
                 imageAssetService,
                 gamePersistenceService,
                 choiceCodec,
-                new ImagePromptComposer()
+                new ImagePromptComposer(),
+                new CostRateLimiter(new CostRateLimitPolicy(1_000, 1_000, 60), clock),
+                new ProviderCallTelemetry(clock, event -> {})
         );
     }
 
@@ -64,8 +71,7 @@ class GameServiceTest {
     void initGame_ReturnsFirstTurn() {
         GameInitRequest request = new GameInitRequest("좀비 아포칼립스", "김대리");
         NarrativeTurn opening = new NarrativeTurn(
-                "첫날 밤",
-                "오프닝 스토리",
+                "첫날 밤", "오프닝 스토리",
                 List.of(new NarrativeTurn.Choice(1, "도망간다")),
                 new NarrativeTurn.VisualAssets("dark street", List.of("zombie"), List.of())
         );
@@ -93,8 +99,7 @@ class GameServiceTest {
         String choicesJson = choiceCodec.serialize(List.of(new GameChoice(1, "문을 잠근다")));
         GamePersistenceService.LoadedTurn loadedTurn = loadedTurn(choicesJson);
         NarrativeTurn nextTurn = new NarrativeTurn(
-                "다음 장면",
-                "다음 스토리",
+                "다음 장면", "다음 스토리",
                 List.of(new NarrativeTurn.Choice(1, "기다린다")),
                 new NarrativeTurn.VisualAssets("", List.of(), List.of())
         );
@@ -103,8 +108,7 @@ class GameServiceTest {
         given(narrativeGenerator.createNextTurn(any(NarrativeContext.class))).willReturn(nextTurn);
         given(gamePersistenceService.saveNextTurn(
                 OWNER_KEY, 42L, 1, "문을 잠근다", "다음 스토리",
-                "[{\"id\":1,\"text\":\"기다린다\"}]",
-                null
+                "[{\"id\":1,\"text\":\"기다린다\"}]", null
         )).willReturn(2);
 
         GameResponse response = gameService.progressGame(OWNER_KEY, new GameProgressRequest(42L, 1, 1));

--- a/src/test/java/com/uctale/uctale/service/GameServiceValidationTest.java
+++ b/src/test/java/com/uctale/uctale/service/GameServiceValidationTest.java
@@ -1,6 +1,9 @@
 package com.uctale.uctale.service;
 
 import tools.jackson.databind.ObjectMapper;
+import com.uctale.uctale.application.cost.CostRateLimitPolicy;
+import com.uctale.uctale.application.cost.CostRateLimiter;
+import com.uctale.uctale.application.cost.ProviderCallTelemetry;
 import com.uctale.uctale.application.game.ChoiceCodec;
 import com.uctale.uctale.application.game.GamePersistenceService;
 import com.uctale.uctale.application.game.ImagePromptComposer;
@@ -16,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Clock;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -37,12 +41,15 @@ class GameServiceValidationTest {
 
     @BeforeEach
     void setUp() {
+        Clock clock = Clock.systemUTC();
         gameService = new GameService(
                 narrativeGenerator,
                 imageAssetService,
                 gamePersistenceService,
                 new ChoiceCodec(new ObjectMapper()),
-                new ImagePromptComposer()
+                new ImagePromptComposer(),
+                new CostRateLimiter(new CostRateLimitPolicy(1_000, 1_000, 60), clock),
+                new ProviderCallTelemetry(clock, event -> {})
         );
     }
 
@@ -51,9 +58,7 @@ class GameServiceValidationTest {
     void initGame_RejectsOversizedProviderChoiceBeforeSideEffects() {
         GameInitRequest request = new GameInitRequest("세계관", "캐릭터");
         NarrativeTurn invalidTurn = new NarrativeTurn(
-                "제목",
-                "본문",
-                List.of(new NarrativeTurn.Choice(1, "가".repeat(256))),
+                "제목", "본문", List.of(new NarrativeTurn.Choice(1, "가".repeat(256))),
                 new NarrativeTurn.VisualAssets("street", List.of(), List.of())
         );
         given(narrativeGenerator.createOpening("세계관", "캐릭터")).willReturn(invalidTurn);
@@ -70,12 +75,8 @@ class GameServiceValidationTest {
     void initGame_RejectsDuplicateProviderChoiceIds() {
         GameInitRequest request = new GameInitRequest("세계관", "캐릭터");
         NarrativeTurn invalidTurn = new NarrativeTurn(
-                "제목",
-                "본문",
-                List.of(
-                        new NarrativeTurn.Choice(1, "간다"),
-                        new NarrativeTurn.Choice(1, "멈춘다")
-                ),
+                "제목", "본문",
+                List.of(new NarrativeTurn.Choice(1, "간다"), new NarrativeTurn.Choice(1, "멈춘다")),
                 new NarrativeTurn.VisualAssets("", List.of(), List.of())
         );
         given(narrativeGenerator.createOpening("세계관", "캐릭터")).willReturn(invalidTurn);


### PR DESCRIPTION
## 왜 필요한가요?

#24~#26으로 공유 접근 인증, 세션 소유권, 서버 발급 image asset 경계를 만들었지만 인증된 사용자의 반복 클릭·자동화 요청이 Gemini/Pollinations 비용 호출을 계속 만들 수 있었습니다. 또한 provider 호출의 session/turn/latency/outcome을 한 흐름으로 추적하기 어려웠습니다.

- Closes #27

## 무엇이 바뀌나요?

- Narrative/Image 비용 호출에 별도 in-process fixed-window quota를 적용합니다.
- owner principal + client IP + session(존재할 때) bucket을 함께 검사합니다.
- 한도 초과 시 provider 호출 전에 `429 RATE_LIMIT_EXCEEDED`와 `Retry-After`를 반환합니다.
- Narrative는 `GameService`의 Gemini 호출 직전에 제한합니다.
- Image는 소유권/캐시 확인 후, 미생성 asset의 generation lock 내부에서 Pollinations 호출 직전에 제한합니다.
- 이미 생성된 image asset 재조회는 provider 호출이 없으므로 quota를 소비하지 않습니다.
- provider 호출마다 provider/operation/session/turn/requestId/idempotencyKey/latency/outcome/retryCount를 구조화 로그로 남깁니다.
- 사용자 입력, provider prompt/응답 전문, owner/access token, API key, client IP는 관측 로그에 남기지 않습니다.

## 기본 정책

- window: 60초
- Narrative: 12회/window
- Image: 8회/window

환경변수로 조정할 수 있습니다.

- `GAME_COST_RATE_LIMIT_WINDOW_SECONDS`
- `GAME_COST_NARRATIVE_LIMIT`
- `GAME_COST_IMAGE_LIMIT`

## 어떻게 검증했나요?

- [x] deterministic Clock으로 Narrative quota와 window reset 검증
- [x] Narrative/Image quota 독립성 검증
- [x] 동일 IP의 owner 간 aggregate 제한 검증
- [x] Narrative quota 초과 시 Gemini 호출 전 거부 검증
- [x] Image quota 초과 시 Pollinations 호출 전 거부 검증
- [x] 이미 생성된 image asset 재조회가 quota를 소비하지 않는지 검증
- [x] provider 성공/실패 event의 latency/outcome/retryCount 검증
- [x] 429 오류 코드와 `Retry-After` 응답 계약 검증
- [x] reverse proxy `X-Forwarded-For` client IP 해석 검증
- [x] Backend test/build CI
- [x] Frontend test/lint/build CI

GitHub Actions CI #80에서 Backend test/build와 Frontend test/lint/build가 모두 성공했습니다.

## PR 전 자체 비판적 리뷰 및 보완

PR 생성 전에 main 대비 전체 변경을 별도로 검토했습니다.

1. **provider 호출 전에 차단되는가**
   - Narrative는 validation이 끝난 HTTP 요청에서 Gemini 호출 직전에 limiter를 통과합니다.
   - progress는 session 소유권/expected turn 확인 후 limiter를 적용해 존재하지 않는 세션 요청이 quota를 소모하지 않습니다.
   - Image는 asset 소유권과 기존 생성 결과를 먼저 확인하고, 실제 생성이 필요한 경우에만 quota를 사용합니다.
2. **동시 이미지 요청이 비용을 중복 발생시키는가**
   - #26의 asset별 generation lock 내부에서 캐시를 다시 확인한 뒤 limiter/provider를 실행하므로 같은 JVM에서 동일 asset의 최초 동시 요청은 provider를 중복 호출하지 않습니다.
3. **관측 로그가 민감 정보를 노출하는가**
   - provider event에는 owner key, IP, prompt, story/action, 응답 전문, token/API key 필드가 없습니다.
   - idempotency key는 #29 도입 전이므로 현재 `-`, retryCount는 provider retry 미도입 상태라 0으로 기록합니다.
4. **reverse proxy 환경에서 IP bucket이 전체 사용자에게 공유되는가**
   - 초기 구현은 `remoteAddr`만 사용해 Render reverse proxy 뒤에서 모든 요청이 같은 proxy IP로 보일 위험이 있었습니다.
   - 자체 리뷰에서 이를 발견해 `X-Forwarded-For` 첫 주소를 우선하고 없을 때 remote address로 fallback하도록 수정했습니다.
   - XFF만으로 우회해도 owner/session bucket이 함께 적용되므로 전체 제한이 사라지지는 않습니다.
5. **multi-instance 한계**
   - 현재 limiter는 단일 JVM 메모리 기반이므로 Render 인스턴스가 여러 개면 전역 quota를 보장하지 않습니다.
   - 현재 공유 베타 단일 instance 범위의 최소 안전장치로 명시하고, multi-instance 전환 시 external shared limiter가 필요함을 문서화했습니다.

비판적 리뷰 보완 후 CI까지 통과했으며, 현재 코드 기준으로 merge를 막아야 할 추가 결함은 발견하지 못했습니다.

## 운영/보안 영향

- [x] 새 DB migration 없음
- [x] 새 secret 없음
- [x] provider prompt/응답 전문 로그 없음
- [x] client IP는 limiter 메모리 key로만 사용하며 provider 관측 로그에 기록하지 않음
- [x] 기존 인증/owner/session 404 정책 유지
- [x] 다중 instance에서는 per-instance quota라는 제한을 문서화

## 문서

- `docs/architecture/cost-controls.md`