### PR TITLE
feat(image): Pollinations 생성 품질과 재사용 정책 개선

### DIFF
--- a/docs/architecture/cost-controls.md
+++ b/docs/architecture/cost-controls.md
@@ -46,7 +46,7 @@ provider 호출마다 다음 항목을 구조화된 key/value 로그로 기록�
 
 사용자 world/character/action, provider prompt/응답 전문, access/owner token, API key는 로그에 기록하지 않는다.
 
-현재 retryCount는 provider retry 정책이 아직 없으므로 0이다. 후속 #35/#50에서 bounded retry를 도입할 때 같은 event 계약에 실제 retry 횟수를 연결한다.
+Narrative는 현재 provider 내부 retry가 없어 `retryCount=0`이다. Image는 #50부터 Pollinations bounded retry의 실제 횟수를 성공 결과 또는 최종 실패에서 추출해 같은 `provider_call` event에 기록한다. 이미지별 model/size/seed/status 등 상세 진단은 `image_provider_result` event를 함께 사용한다.
 
 ## 책임 경계
 

--- a/docs/architecture/image-generation.md
+++ b/docs/architecture/image-generation.md
@@ -15,11 +15,11 @@
 
 ## 기본 정책
 
-현재 production 기본값은 benchmark 전환 근거가 마련되기 전까지 기존 `flux`를 유지한다.
+실제 benchmark 전환 근거가 마련되기 전까지 model과 생성 해상도는 기존 production 값인 `flux`, `768x432`를 유지한다. 원본보다 큰 CSS 표시로 생기던 소폭 확대는 프론트 표시 폭을 768px로 제한해 제거한다.
 
 - model: `flux`
-- landscape: `1024x576`
-- square: `768x768`
+- landscape: `768x432`
+- square: `512x512`
 - safe: `true`
 - style: `uctale-charcoal-v1`
 - connect timeout: 10초

--- a/docs/architecture/image-generation.md
+++ b/docs/architecture/image-generation.md
@@ -1,0 +1,81 @@
+# 이미지 생성 계약
+
+## 책임 경계
+
+브라우저는 Pollinations prompt나 provider URL을 만들지 않는다. Narrative turn에서 서버가 versioned prompt를 만들고 server-issued image asset을 발급한다. asset에는 최초 발급 시점의 생성 계약을 고정한다.
+
+- prompt
+- model
+- width / height
+- seed
+- safe
+- style version
+
+이 값은 `image_asset`에 저장되므로 운영 설정이 바뀌어도 이미 발급된 asset의 재시도 요청은 바뀌지 않는다.
+
+## 기본 정책
+
+현재 production 기본값은 benchmark 전환 근거가 마련되기 전까지 기존 `flux`를 유지한다.
+
+- model: `flux`
+- landscape: `1024x576`
+- square: `768x768`
+- safe: `true`
+- style: `uctale-charcoal-v1`
+- connect timeout: 10초
+- read timeout: 120초
+- provider retry: 최대 2회
+- max response: 8 MiB
+- 허용 MIME: JPEG, PNG
+
+설정은 `GAME_IMAGE_*` 환경변수로 조정할 수 있다. model/size/style 변경은 새로 발급되는 asset에만 적용된다.
+
+## Pollinations 요청
+
+- provider secret은 `Authorization: Bearer`로만 전달한다.
+- public asset URL, query string, 구조화 로그에 secret을 넣지 않는다.
+- `model`, `width`, `height`, `seed`, `safe`를 항상 명시한다.
+- 공식 문서에 없는 `nologo` 옵션은 사용하지 않는다.
+- raw prompt는 구조화 로그에 남기지 않고 hash만 사용한다.
+
+## 실패와 재시도
+
+자동 재시도 대상:
+
+- 네트워크/timeout
+- HTTP 429
+- HTTP 502
+- HTTP 503
+
+자동 재시도하지 않는 오류:
+
+- 400 잘못된 요청
+- 401 인증 실패
+- 402 잔액/예산 부족
+- 403 권한 실패
+- 422 content policy 또는 처리 불가 요청
+
+`Retry-After`가 초 단위로 제공되면 그 값을 우선하고, 없으면 짧은 bounded backoff를 사용한다. 모든 retry는 asset에 저장된 동일 model/prompt/size/seed/safe를 사용한다.
+
+응답은 non-empty JPEG/PNG이며 설정된 최대 byte 이하인 경우에만 저장한다. 최종 생성 실패는 canonical GameState나 GameLog turn을 롤백하지 않는다. 이미지 조회에는 정적 SVG placeholder를 반환하고 이후 조회에서 다시 생성할 수 있게 asset은 미생성 상태로 유지한다.
+
+## 관측성과 비용
+
+Pollinations adapter 로그는 다음 진단 항목을 남긴다.
+
+- prompt hash
+- model / size / seed / safe / style version
+- latency
+- provider status / error code / requestId / Retry-After
+- response MIME / byte size
+- retry count
+
+API key와 raw prompt는 기록하지 않는다. session/turn/requestId는 #27의 provider-call telemetry와 server-issued asset metadata를 통해 함께 추적한다.
+
+실제 비용은 Pollinations account usage에서 기간과 key를 기준으로 확인하고, `docs/benchmarks/pollinations-image-benchmark.md`의 request 결과와 대조한다.
+
+## 한계
+
+- 동일 asset의 JVM 내 최초 생성은 generation lock으로 단일화하지만 multi-instance 전역 단일화는 보장하지 않는다.
+- benchmark 실행은 실제 provider 비용을 발생시키므로 CI에서 자동 실행하지 않는다.
+- 캐릭터 외형 고정, reference image, object storage/CDN은 이 단계 범위가 아니다.

--- a/docs/architecture/image-generation.md
+++ b/docs/architecture/image-generation.md
@@ -36,7 +36,7 @@
 - public asset URL, query string, 구조화 로그에 secret을 넣지 않는다.
 - `model`, `width`, `height`, `seed`, `safe`를 항상 명시한다.
 - 공식 문서에 없는 `nologo` 옵션은 사용하지 않는다.
-- raw prompt는 구조화 로그에 남기지 않고 hash만 사용한다.
+- raw prompt는 구조화 로그에 남기지 않고 SHA-256 hash만 사용한다.
 
 ## 실패와 재시도
 
@@ -55,22 +55,23 @@
 - 403 권한 실패
 - 422 content policy 또는 처리 불가 요청
 
-`Retry-After`가 초 단위로 제공되면 그 값을 우선하고, 없으면 짧은 bounded backoff를 사용한다. 모든 retry는 asset에 저장된 동일 model/prompt/size/seed/safe를 사용한다.
+`Retry-After`가 delta-seconds 또는 HTTP-date로 제공되면 그 값을 우선하고, 없으면 짧은 bounded backoff를 사용한다. 모든 retry는 asset에 저장된 동일 model/prompt/size/seed/safe를 사용한다.
 
 응답은 non-empty JPEG/PNG이며 설정된 최대 byte 이하인 경우에만 저장한다. 최종 생성 실패는 canonical GameState나 GameLog turn을 롤백하지 않는다. 이미지 조회에는 정적 SVG placeholder를 반환하고 이후 조회에서 다시 생성할 수 있게 asset은 미생성 상태로 유지한다.
 
 ## 관측성과 비용
 
-Pollinations adapter 로그는 다음 진단 항목을 남긴다.
+`provider_call` 공통 telemetry와 `image_provider_result` 이미지 진단 로그를 함께 사용한다. Pollinations 실제 retry 횟수는 성공 결과/최종 실패에서 공통 telemetry로 전달되며, 이미지 진단 로그에는 다음 항목을 한 event에 기록한다.
 
-- prompt hash
-- model / size / seed / safe / style version
+- asset ID / session / turn
+- SHA-256 prompt hash
+- model / size / seed / style version
 - latency
-- provider status / error code / requestId / Retry-After
+- provider status / error code / requestId
 - response MIME / byte size
 - retry count
 
-API key와 raw prompt는 기록하지 않는다. session/turn/requestId는 #27의 provider-call telemetry와 server-issued asset metadata를 통해 함께 추적한다.
+API key와 raw prompt는 기록하지 않는다.
 
 실제 비용은 Pollinations account usage에서 기간과 key를 기준으로 확인하고, `docs/benchmarks/pollinations-image-benchmark.md`의 request 결과와 대조한다.
 

--- a/docs/benchmarks/pollinations-image-benchmark.md
+++ b/docs/benchmarks/pollinations-image-benchmark.md
@@ -1,0 +1,68 @@
+# Pollinations 이미지 benchmark
+
+## 목적
+
+UCTale 장면 삽화의 기본 model과 해상도를 감으로 바꾸지 않고 동일 prompt/seed 조건에서 비교하기 위한 절차다.
+
+비교 대상:
+
+- model: `flux`, `zimage`, `dreamshaper`
+- resolution: `768x432`, `1024x576`
+- fixture: 실내·실외, 단독 NPC, 다수 인물, 몬스터, 전투, 핵심 아이템, 장소 이동, 밝고 어두운 장면을 포함한 16개 장면
+- seed: fixture별 고정 seed를 모든 model/resolution 조합에 동일 적용
+
+## 현재 사전 판단
+
+2026-08-30 공식 Pollinations 문서와 registry를 다시 확인했다.
+
+- Pollinations의 현재 provider 기본 image model은 UCTale의 기존 명시값과 달리 `zimage`이므로 production에서는 model을 항상 명시해야 한다.
+- `flux`, `zimage`, `dreamshaper`는 현재 image model 후보로 제공된다.
+- `dreamshaper`는 registry에서 매우 낮은 비용과 빠른 생성이 강점이지만 세부 묘사는 단순하다고 설명된다.
+- API는 model, width, height, seed, safe 입력과 Bearer 인증을 지원한다.
+
+이 정보만으로 이미지 품질 우열을 단정할 수 없으므로 production 기본값은 기존 `flux`를 유지한다.
+
+## 실행
+
+실제 생성에는 계정 비용이 발생하므로 운영 secret을 저장소나 CI에 넣어 자동 실행하지 않는다.
+
+```bash
+POLLINATIONS_TOKEN=... python scripts/benchmark_pollinations_images.py
+```
+
+출력:
+
+- `build/pollinations-benchmark/images/`: blind review용 이미지
+- `build/pollinations-benchmark/raw.csv`: fixture/model/size/seed/status/latency/MIME/bytes
+- `build/pollinations-benchmark/summary.json`: model/size별 성공률, 평균·P95 지연
+
+스크립트는 token과 raw prompt를 결과 파일에 기록하지 않는다.
+
+## Blind review
+
+이미지 파일명을 reviewer에게 직접 보여주지 않고 임시 번호로 섞은 뒤 각 결과에 1~5점을 기록한다.
+
+| 평가 항목 | 설명 |
+| --- | --- |
+| Prompt 준수도 | 인물·몬스터·사물·장소가 요청과 맞는가 |
+| Charcoal style 일관성 | UCTale charcoal preset을 안정적으로 유지하는가 |
+| 왜곡 | 인체, 사물, 구조물의 명백한 왜곡이 적은가 |
+| 세부 묘사 | 게임 삽화로 사용할 만큼 장면 정보가 읽히는가 |
+| 사용 가능 여부 | 별도 재생성 없이 바로 노출 가능한가 |
+
+모델/해상도 선택 시 평균 점수만 보지 않고 오류율, 평균·P95 지연, Pollinations account usage의 실제 비용을 함께 기록한다. `사용 가능한 이미지 한 장당 비용 = 총 비용 / 사용 가능 판정 이미지 수`로 비교한다.
+
+## 결과 기록 상태
+
+이 구현 작업에서는 production Pollinations secret에 접근하지 않고 외부 유료 생성도 임의 실행하지 않았기 때문에 실제 이미지/지연/비용 점수는 기록하지 않았다. 따라서 benchmark가 실행되고 blind review 결과가 채워지기 전까지는 `flux`를 기본값으로 유지한다.
+
+실행 후 아래 표를 채우고 기본값 변경 여부를 별도 PR에서 판단한다.
+
+| Model | Resolution | Prompt | Style | Distortion | Detail | Error rate | Avg/P95 | Cost/image | Usable cost | 결정 |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | --- | ---: | ---: | --- |
+| flux | 768x432 | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | 비교 |
+| flux | 1024x576 | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | 현재 기본 |
+| zimage | 768x432 | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | 비교 |
+| zimage | 1024x576 | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | 비교 |
+| dreamshaper | 768x432 | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | 비교 |
+| dreamshaper | 1024x576 | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | 비교 |

--- a/docs/benchmarks/pollinations-image-benchmark.md
+++ b/docs/benchmarks/pollinations-image-benchmark.md
@@ -11,20 +11,92 @@ UCTale 장면 삽화의 기본 model과 해상도를 감으로 바꾸지 않고 
 - fixture: 실내·실외, 단독 NPC, 다수 인물, 몬스터, 전투, 핵심 아이템, 장소 이동, 밝고 어두운 장면을 포함한 16개 장면
 - seed: fixture별 고정 seed를 모든 model/resolution 조합에 동일 적용
 
-## 현재 사전 판단
+## 실행 조건
 
-2026-08-30 공식 Pollinations 문서와 registry를 다시 확인했다.
+2026-08-30에 실제 Pollinations 계정으로 benchmark를 실행했다.
 
-- Pollinations의 현재 provider 기본 image model은 UCTale의 기존 명시값과 달리 `zimage`이므로 production에서는 model을 항상 명시해야 한다.
-- `flux`, `zimage`, `dreamshaper`는 현재 image model 후보로 제공된다.
-- `dreamshaper`는 registry에서 매우 낮은 비용과 빠른 생성이 강점이지만 세부 묘사는 단순하다고 설명된다.
-- API는 model, width, height, seed, safe 입력과 Bearer 인증을 지원한다.
+- 총 요청: 96 (`16 fixtures × 3 models × 2 resolutions`)
+- 성공: 96
+- 실패: 0
+- 모든 조합에 같은 fixture prompt와 seed를 사용했다.
+- benchmark 결과 파일에는 token과 raw prompt를 기록하지 않았다.
+- Python `urllib` 기본 User-Agent가 provider에서 403으로 차단되는 것을 실측으로 발견해 benchmark client에 명시적 User-Agent/Accept를 추가했고, 401/402/403은 fail-fast하도록 보완했다.
 
-이 정보만으로 이미지 품질·해상도 우열을 단정할 수 없으므로 production 기본값은 기존 `flux`, `768x432`를 유지한다.
+## 성능 결과
 
-## 실행
+| Model | Resolution | Success | Error rate | Avg latency | P95 latency | Avg response bytes |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| flux | 768x432 | 16/16 | 0% | 7.63s | 9.36s | 210 KB |
+| flux | 1024x576 | 16/16 | 0% | 8.13s | 9.15s | 323 KB |
+| zimage | 768x432 | 16/16 | 0% | 8.13s | 8.95s | 155 KB |
+| zimage | 1024x576 | 16/16 | 0% | 9.19s | 10.56s | 254 KB |
+| dreamshaper | 768x432 | 16/16 | 0% | 6.53s | 7.45s | 46 KB |
+| dreamshaper | 1024x576 | 16/16 | 0% | 6.42s | 7.15s | 47 KB |
 
-실제 생성에는 계정 비용이 발생하므로 운영 secret을 저장소나 CI에 넣어 자동 실행하지 않는다.
+## Blind review
+
+모델/해상도 이름을 숨긴 A~F 시트로 다시 섞어 prompt 준수도, charcoal style 일관성, 왜곡, 세부 묘사와 별도 재생성 없이 게임 삽화로 사용할 수 있는지를 비교했다.
+
+### flux
+
+- UCTale의 `rough charcoal sketch`, 흑백, 거친 종이 질감과 story concept art 방향을 가장 안정적으로 유지했다.
+- 전투, 몬스터, 다수 인물과 판타지 장면에서 focal point와 silhouette가 비교적 명확했다.
+- 현실 장면 일부는 zimage보다 literal한 장소 표현이 약한 경우가 있었지만, 전체적인 house style과 장면 가독성의 균형이 가장 좋았다.
+
+### zimage
+
+- 흑백 sketch 스타일과 공간 묘사가 안정적이고 일상/실내 장면의 prompt 준수도도 좋았다.
+- 다만 flux 대비 평균 지연 시간이 길고 현재 단가도 더 높으며, 판타지/액션 fixture에서 기본 모델을 교체할 만큼 일관된 품질 우위는 확인되지 않았다.
+- 향후 대체 후보 또는 특정 장면용 후보로는 유지할 가치가 있다.
+
+### dreamshaper
+
+- 세 모델 중 가장 빠르고 응답 크기도 작았다.
+- 그러나 요청한 charcoal sketch보다 어두운 cinematic/photorealistic 이미지로 치우치는 경우가 반복되어 UCTale house style 일관성이 크게 떨어졌다.
+- 가격과 속도만으로 기본 모델을 바꾸기에는 품질 방향이 맞지 않아 기본 후보에서 제외한다.
+
+## 비용
+
+실행 당시 Pollinations model registry 기준 flat image cost를 기준으로 계산한다.
+
+| Model | Cost/image | 이번 benchmark 32장 비용 |
+| --- | ---: | ---: |
+| flux | 0.002 Pollen | 0.064 Pollen |
+| zimage | 0.004 Pollen | 0.128 Pollen |
+| dreamshaper | 0.0001 Pollen | 0.0032 Pollen |
+
+총 예상 비용은 약 `0.1952 Pollen`이다. 실제 운영에서는 Pollinations account usage를 함께 확인하며 가격은 provider 변경 가능성이 있으므로 고정 상수로 간주하지 않는다.
+
+사용 가능한 이미지 한 장당 비용은 단순 최저 단가보다 house style 적합성을 포함해 판단한다. DreamShaper는 명목 단가는 가장 낮지만 charcoal style 불일치 때문에 UCTale 기준 usable 후보로 보기 어렵고, Z-Image는 Flux보다 높은 단가와 지연을 상쇄할 만큼 품질 우위가 확인되지 않았다. 따라서 현재 운영 선택에서는 Flux의 비용 대비 usable 품질이 가장 낫다고 판단한다.
+
+## 해상도 결정
+
+`1024x576`은 일부 선과 배경 디테일이 조금 더 정돈되지만, UCTale의 현재 최대 표시 폭은 768 CSS px이고 품질 차이가 기본값 변경을 정당화할 정도로 크지 않았다.
+
+특히 Flux에서 1024x576은 768x432 대비:
+
+- 평균 latency 약 6.6% 증가
+- 평균 응답 크기 약 53.7% 증가
+
+Z-Image에서도 1024x576은:
+
+- 평균 latency 약 13.0% 증가
+- 평균 응답 크기 약 64.0% 증가
+
+따라서 네트워크/응답 크기 비용을 늘리면서 기본 해상도를 올릴 근거가 부족하다.
+
+## 최종 결정
+
+production 기본값을 변경하지 않는다.
+
+- `GAME_IMAGE_MODEL=flux`
+- `GAME_IMAGE_WIDTH=768`
+- `GAME_IMAGE_HEIGHT=432`
+- `GAME_IMAGE_STYLE_VERSION=uctale-charcoal-v1`
+
+결론은 "기존 값이므로 유지"가 아니라, 실제 96장 benchmark에서 `flux + 768x432`가 품질, style 일관성, latency, 응답 크기와 비용의 균형이 가장 좋았기 때문에 유지한다는 것이다.
+
+## 재현 방법
 
 ```bash
 POLLINATIONS_TOKEN=... python scripts/benchmark_pollinations_images.py
@@ -32,37 +104,8 @@ POLLINATIONS_TOKEN=... python scripts/benchmark_pollinations_images.py
 
 출력:
 
-- `build/pollinations-benchmark/images/`: blind review용 이미지
+- `build/pollinations-benchmark/images/`: review용 이미지
 - `build/pollinations-benchmark/raw.csv`: fixture/model/size/seed/status/latency/MIME/bytes
 - `build/pollinations-benchmark/summary.json`: model/size별 성공률, 평균·P95 지연
 
-스크립트는 token과 raw prompt를 결과 파일에 기록하지 않는다.
-
-## Blind review
-
-이미지 파일명을 reviewer에게 직접 보여주지 않고 임시 번호로 섞은 뒤 각 결과에 1~5점을 기록한다.
-
-| 평가 항목 | 설명 |
-| --- | --- |
-| Prompt 준수도 | 인물·몬스터·사물·장소가 요청과 맞는가 |
-| Charcoal style 일관성 | UCTale charcoal preset을 안정적으로 유지하는가 |
-| 왜곡 | 인체, 사물, 구조물의 명백한 왜곡이 적은가 |
-| 세부 묘사 | 게임 삽화로 사용할 만큼 장면 정보가 읽히는가 |
-| 사용 가능 여부 | 별도 재생성 없이 바로 노출 가능한가 |
-
-모델/해상도 선택 시 평균 점수만 보지 않고 오류율, 평균·P95 지연, Pollinations account usage의 실제 비용을 함께 기록한다. `사용 가능한 이미지 한 장당 비용 = 총 비용 / 사용 가능 판정 이미지 수`로 비교한다.
-
-## 결과 기록 상태
-
-이 구현 작업에서는 production Pollinations secret에 접근하지 않고 외부 유료 생성도 임의 실행하지 않았기 때문에 실제 이미지/지연/비용 점수는 기록하지 않았다. 따라서 benchmark가 실행되고 blind review 결과가 채워지기 전까지는 `flux`, `768x432`를 기본값으로 유지한다.
-
-실행 후 아래 표를 채우고 기본값 변경 여부를 별도 PR에서 판단한다.
-
-| Model | Resolution | Prompt | Style | Distortion | Detail | Error rate | Avg/P95 | Cost/image | Usable cost | 결정 |
-| --- | --- | ---: | ---: | ---: | ---: | ---: | --- | ---: | ---: | --- |
-| flux | 768x432 | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | 현재 기본 |
-| flux | 1024x576 | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | 비교 |
-| zimage | 768x432 | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | 비교 |
-| zimage | 1024x576 | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | 비교 |
-| dreamshaper | 768x432 | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | 비교 |
-| dreamshaper | 1024x576 | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | 비교 |
+운영 secret과 생성 이미지는 저장소에 commit하지 않는다.

--- a/docs/benchmarks/pollinations-image-benchmark.md
+++ b/docs/benchmarks/pollinations-image-benchmark.md
@@ -20,7 +20,7 @@ UCTale 장면 삽화의 기본 model과 해상도를 감으로 바꾸지 않고 
 - `dreamshaper`는 registry에서 매우 낮은 비용과 빠른 생성이 강점이지만 세부 묘사는 단순하다고 설명된다.
 - API는 model, width, height, seed, safe 입력과 Bearer 인증을 지원한다.
 
-이 정보만으로 이미지 품질 우열을 단정할 수 없으므로 production 기본값은 기존 `flux`를 유지한다.
+이 정보만으로 이미지 품질·해상도 우열을 단정할 수 없으므로 production 기본값은 기존 `flux`, `768x432`를 유지한다.
 
 ## 실행
 
@@ -54,14 +54,14 @@ POLLINATIONS_TOKEN=... python scripts/benchmark_pollinations_images.py
 
 ## 결과 기록 상태
 
-이 구현 작업에서는 production Pollinations secret에 접근하지 않고 외부 유료 생성도 임의 실행하지 않았기 때문에 실제 이미지/지연/비용 점수는 기록하지 않았다. 따라서 benchmark가 실행되고 blind review 결과가 채워지기 전까지는 `flux`를 기본값으로 유지한다.
+이 구현 작업에서는 production Pollinations secret에 접근하지 않고 외부 유료 생성도 임의 실행하지 않았기 때문에 실제 이미지/지연/비용 점수는 기록하지 않았다. 따라서 benchmark가 실행되고 blind review 결과가 채워지기 전까지는 `flux`, `768x432`를 기본값으로 유지한다.
 
 실행 후 아래 표를 채우고 기본값 변경 여부를 별도 PR에서 판단한다.
 
 | Model | Resolution | Prompt | Style | Distortion | Detail | Error rate | Avg/P95 | Cost/image | Usable cost | 결정 |
 | --- | --- | ---: | ---: | ---: | ---: | ---: | --- | ---: | ---: | --- |
-| flux | 768x432 | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | 비교 |
-| flux | 1024x576 | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | 현재 기본 |
+| flux | 768x432 | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | 현재 기본 |
+| flux | 1024x576 | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | 비교 |
 | zimage | 768x432 | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | 비교 |
 | zimage | 1024x576 | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | 비교 |
 | dreamshaper | 768x432 | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | 비교 |

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -169,7 +169,7 @@ button.start-btn:disabled {
 
     .image-container {
         width: 80%;
-        max-width: 800px;
+        max-width: 768px;
         margin: 30px 0;
     }
 

--- a/scripts/benchmark_pollinations_images.py
+++ b/scripts/benchmark_pollinations_images.py
@@ -13,6 +13,7 @@ import json
 import os
 import pathlib
 import statistics
+import sys
 import time
 import urllib.error
 import urllib.parse
@@ -44,6 +45,12 @@ STYLE = (
     "style[uctale-charcoal-v1]: rough charcoal sketch, high contrast black and white, "
     "gritty paper texture, expressive pencil strokes, no colors, story concept art"
 )
+FAIL_FAST_STATUSES = {401, 402, 403}
+DEFAULT_HEADERS = {
+    "Authorization": "",
+    "Accept": "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8",
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 UCTaleBenchmark/1.1",
+}
 
 
 def parse_args() -> argparse.Namespace:
@@ -52,6 +59,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--seed", type=int, default=20260830)
     parser.add_argument("--timeout", type=int, default=180)
     return parser.parse_args()
+
+
+def build_request(token: str, url: str) -> urllib.request.Request:
+    headers = dict(DEFAULT_HEADERS)
+    headers["Authorization"] = f"Bearer {token}"
+    return urllib.request.Request(url, headers=headers)
 
 
 def request_image(token: str, prompt: str, model: str, width: int, height: int, seed: int, timeout: int):
@@ -64,7 +77,7 @@ def request_image(token: str, prompt: str, model: str, width: int, height: int, 
         "safe": "true",
     })
     url = f"https://gen.pollinations.ai/image/{encoded}?{query}"
-    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+    req = build_request(token, url)
     started = time.perf_counter()
     try:
         with urllib.request.urlopen(req, timeout=timeout) as response:
@@ -76,8 +89,14 @@ def request_image(token: str, prompt: str, model: str, width: int, height: int, 
                 "bytes": len(body),
                 "body": body,
                 "error": "",
+                "error_detail": "",
             }
     except urllib.error.HTTPError as exc:
+        raw_detail = exc.read()
+        detail = raw_detail.decode("utf-8", errors="replace") if raw_detail else ""
+        if detail:
+            detail = detail.replace(prompt, "<redacted-prompt>")
+            detail = detail.replace(encoded, "<redacted-prompt>")[:1000]
         return {
             "status": exc.code,
             "latency_ms": round((time.perf_counter() - started) * 1000),
@@ -85,6 +104,7 @@ def request_image(token: str, prompt: str, model: str, width: int, height: int, 
             "bytes": 0,
             "body": b"",
             "error": f"HTTP_{exc.code}",
+            "error_detail": detail,
         }
     except Exception as exc:  # benchmark diagnostic only
         return {
@@ -94,6 +114,7 @@ def request_image(token: str, prompt: str, model: str, width: int, height: int, 
             "bytes": 0,
             "body": b"",
             "error": exc.__class__.__name__,
+            "error_detail": str(exc),
         }
 
 
@@ -115,6 +136,15 @@ def summarize(rows: list[dict]) -> list[dict]:
                 "p95_latency_ms": p95,
             })
     return summary
+
+
+def write_outputs(output: pathlib.Path, rows: list[dict]):
+    if rows:
+        with (output / "raw.csv").open("w", newline="", encoding="utf-8") as file:
+            writer = csv.DictWriter(file, fieldnames=rows[0].keys())
+            writer.writeheader()
+            writer.writerows(rows)
+        (output / "summary.json").write_text(json.dumps(summarize(rows), ensure_ascii=False, indent=2), encoding="utf-8")
 
 
 def main() -> int:
@@ -141,7 +171,7 @@ def main() -> int:
                     (images / filename).write_bytes(result.pop("body"))
                 else:
                     result.pop("body", None)
-                rows.append({
+                row = {
                     "fixture": fixture_id,
                     "model": model,
                     "width": width,
@@ -149,14 +179,16 @@ def main() -> int:
                     "seed": seed,
                     "image": filename,
                     **result,
-                })
+                }
+                rows.append(row)
                 print(f"{fixture_id:16} {model:12} {width}x{height} status={result['status']} latency={result['latency_ms']}ms")
+                if row["status"] in FAIL_FAST_STATUSES:
+                    write_outputs(output, rows)
+                    print("Fail-fast: authentication/billing/permission style error encountered.", file=sys.stderr)
+                    print(row["error_detail"] or row["error"], file=sys.stderr)
+                    return 2
 
-    with (output / "raw.csv").open("w", newline="", encoding="utf-8") as file:
-        writer = csv.DictWriter(file, fieldnames=rows[0].keys())
-        writer.writeheader()
-        writer.writerows(rows)
-    (output / "summary.json").write_text(json.dumps(summarize(rows), ensure_ascii=False, indent=2), encoding="utf-8")
+    write_outputs(output, rows)
     print(f"Results written to {output}")
     return 0
 

--- a/scripts/benchmark_pollinations_images.py
+++ b/scripts/benchmark_pollinations_images.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Run a reproducible UCTale Pollinations image benchmark.
+
+Requires POLLINATIONS_TOKEN in the environment. Results are written to a local
+output directory and are intentionally not committed automatically.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import pathlib
+import statistics
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+MODELS = ("flux", "zimage", "dreamshaper")
+SIZES = ((768, 432), (1024, 576))
+FIXTURES = (
+    ("indoor-single", "subjects: office worker; objects: briefcase; setting: subway platform"),
+    ("bright-indoor", "subjects: student; objects: notebook; setting: sunlit classroom"),
+    ("dark-outdoor", "subjects: detective; objects: umbrella; setting: rainy alley at night"),
+    ("monster", "subjects: giant wolf; setting: forest clearing"),
+    ("party", "subjects: knight, mage; objects: broken shield; setting: castle hall"),
+    ("horde", "subjects: zombie horde; objects: shopping cart; setting: abandoned mall"),
+    ("rooftop", "subjects: sniper; objects: radio; setting: rooftop at night"),
+    ("npc", "subjects: elderly npc; objects: tea cup; setting: quiet apartment"),
+    ("combat", "subjects: fighter, armored monster; objects: spear; setting: underground arena"),
+    ("key-item", "objects: glowing relic; setting: ancient shrine"),
+    ("travel", "subjects: traveler; objects: map; setting: snowy mountain pass"),
+    ("bright-outdoor", "subjects: merchant, child; objects: fruit stand; setting: bright seaside town"),
+    ("laboratory", "subjects: scientist; objects: sealed capsule; setting: dark laboratory"),
+    ("battlefield", "subjects: soldier, dragon; objects: banner; setting: burning battlefield"),
+    ("transit", "subjects: passenger, conductor; objects: ticket; setting: train interior"),
+    ("ruins", "subjects: explorer; objects: ancient key; setting: desert ruins"),
+)
+STYLE = (
+    "atmosphere: dramatic storybook scene; "
+    "composition: clear focal point, readable silhouettes, cinematic depth; "
+    "style[uctale-charcoal-v1]: rough charcoal sketch, high contrast black and white, "
+    "gritty paper texture, expressive pencil strokes, no colors, story concept art"
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", default="build/pollinations-benchmark")
+    parser.add_argument("--seed", type=int, default=20260830)
+    parser.add_argument("--timeout", type=int, default=180)
+    return parser.parse_args()
+
+
+def request_image(token: str, prompt: str, model: str, width: int, height: int, seed: int, timeout: int):
+    encoded = urllib.parse.quote(prompt, safe="")
+    query = urllib.parse.urlencode({
+        "model": model,
+        "width": width,
+        "height": height,
+        "seed": seed,
+        "safe": "true",
+    })
+    url = f"https://gen.pollinations.ai/image/{encoded}?{query}"
+    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+    started = time.perf_counter()
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            body = response.read()
+            return {
+                "status": response.status,
+                "latency_ms": round((time.perf_counter() - started) * 1000),
+                "mime": response.headers.get_content_type(),
+                "bytes": len(body),
+                "body": body,
+                "error": "",
+            }
+    except urllib.error.HTTPError as exc:
+        return {
+            "status": exc.code,
+            "latency_ms": round((time.perf_counter() - started) * 1000),
+            "mime": exc.headers.get_content_type() if exc.headers else "",
+            "bytes": 0,
+            "body": b"",
+            "error": f"HTTP_{exc.code}",
+        }
+    except Exception as exc:  # benchmark diagnostic only
+        return {
+            "status": 0,
+            "latency_ms": round((time.perf_counter() - started) * 1000),
+            "mime": "",
+            "bytes": 0,
+            "body": b"",
+            "error": exc.__class__.__name__,
+        }
+
+
+def summarize(rows: list[dict]) -> list[dict]:
+    summary = []
+    for model in MODELS:
+        for width, height in SIZES:
+            group = [r for r in rows if r["model"] == model and r["width"] == width and r["height"] == height]
+            latencies = sorted(r["latency_ms"] for r in group if r["status"] == 200)
+            success = len(latencies)
+            p95 = latencies[min(len(latencies) - 1, max(0, round(len(latencies) * 0.95) - 1))] if latencies else None
+            summary.append({
+                "model": model,
+                "size": f"{width}x{height}",
+                "requests": len(group),
+                "successes": success,
+                "error_rate": round(1 - (success / len(group)), 4) if group else None,
+                "avg_latency_ms": round(statistics.mean(latencies)) if latencies else None,
+                "p95_latency_ms": p95,
+            })
+    return summary
+
+
+def main() -> int:
+    args = parse_args()
+    token = os.getenv("POLLINATIONS_TOKEN")
+    if not token:
+        raise SystemExit("POLLINATIONS_TOKEN is required; the benchmark never writes the token to output.")
+
+    output = pathlib.Path(args.output)
+    images = output / "images"
+    images.mkdir(parents=True, exist_ok=True)
+    rows: list[dict] = []
+
+    for fixture_index, (fixture_id, scene) in enumerate(FIXTURES):
+        prompt = f"{scene}; {STYLE}"
+        seed = args.seed + fixture_index
+        for model in MODELS:
+            for width, height in SIZES:
+                result = request_image(token, prompt, model, width, height, seed, args.timeout)
+                filename = ""
+                if result["status"] == 200 and result["body"]:
+                    suffix = ".png" if result["mime"] == "image/png" else ".jpg"
+                    filename = f"{fixture_id}__{model}__{width}x{height}{suffix}"
+                    (images / filename).write_bytes(result.pop("body"))
+                else:
+                    result.pop("body", None)
+                rows.append({
+                    "fixture": fixture_id,
+                    "model": model,
+                    "width": width,
+                    "height": height,
+                    "seed": seed,
+                    "image": filename,
+                    **result,
+                })
+                print(f"{fixture_id:16} {model:12} {width}x{height} status={result['status']} latency={result['latency_ms']}ms")
+
+    with (output / "raw.csv").open("w", newline="", encoding="utf-8") as file:
+        writer = csv.DictWriter(file, fieldnames=rows[0].keys())
+        writer.writeheader()
+        writer.writerows(rows)
+    (output / "summary.json").write_text(json.dumps(summarize(rows), ensure_ascii=False, indent=2), encoding="utf-8")
+    print(f"Results written to {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/main/java/com/uctale/uctale/application/cost/ProviderCallTelemetry.java
+++ b/src/main/java/com/uctale/uctale/application/cost/ProviderCallTelemetry.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.Clock;
 import java.util.function.Supplier;
+import java.util.function.ToIntFunction;
 
 @Component
 public class ProviderCallTelemetry {
@@ -23,13 +24,31 @@ public class ProviderCallTelemetry {
             int retryCount,
             Supplier<T> invocation
     ) {
+        return observe(
+                provider,
+                operation,
+                context,
+                invocation,
+                ignored -> retryCount,
+                ignored -> retryCount
+        );
+    }
+
+    public <T> T observe(
+            String provider,
+            String operation,
+            CostRequestContext context,
+            Supplier<T> invocation,
+            ToIntFunction<T> successRetryCount,
+            ToIntFunction<RuntimeException> failureRetryCount
+    ) {
         long startedAt = clock.millis();
         try {
             T result = invocation.get();
-            record(provider, operation, context, retryCount, startedAt, "SUCCESS");
+            record(provider, operation, context, Math.max(0, successRetryCount.applyAsInt(result)), startedAt, "SUCCESS");
             return result;
         } catch (RuntimeException exception) {
-            record(provider, operation, context, retryCount, startedAt, "FAILURE");
+            record(provider, operation, context, Math.max(0, failureRetryCount.applyAsInt(exception)), startedAt, "FAILURE");
             throw exception;
         }
     }

--- a/src/main/java/com/uctale/uctale/application/game/GamePersistenceService.java
+++ b/src/main/java/com/uctale/uctale/application/game/GamePersistenceService.java
@@ -180,7 +180,13 @@ public class GamePersistenceService {
                 session,
                 turnNumber,
                 assetReference.prompt(),
-                assetReference.aspectRatio()
+                assetReference.aspectRatio(),
+                assetReference.model(),
+                assetReference.width(),
+                assetReference.height(),
+                assetReference.seed(),
+                assetReference.safe(),
+                assetReference.styleVersion()
         );
         imageAssetRepository.save(asset);
         return asset.publicUrl();

--- a/src/main/java/com/uctale/uctale/application/game/ImagePromptComposer.java
+++ b/src/main/java/com/uctale/uctale/application/game/ImagePromptComposer.java
@@ -1,30 +1,105 @@
 package com.uctale.uctale.application.game;
 
 import com.uctale.uctale.application.narrative.NarrativeTurn;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 @Component
 public class ImagePromptComposer {
+
+    static final String DEFAULT_STYLE_VERSION = "uctale-charcoal-v1";
+    private static final int MAX_PROMPT_LENGTH = 1_800;
+    private static final Map<String, String> STYLE_PRESETS = Map.of(
+            DEFAULT_STYLE_VERSION,
+            "rough charcoal sketch, high contrast black and white, gritty paper texture, expressive pencil strokes, no colors, story concept art"
+    );
+    private static final String ATMOSPHERE = "atmosphere: dramatic storybook scene";
+    private static final String COMPOSITION = "composition: clear focal point, readable silhouettes, cinematic depth";
+
+    private final String styleVersion;
+    private final String stylePrompt;
+
+    public ImagePromptComposer() {
+        this(DEFAULT_STYLE_VERSION);
+    }
+
+    public ImagePromptComposer(@Value("${game.image.style-version:uctale-charcoal-v1}") String styleVersion) {
+        String normalized = styleVersion == null ? "" : styleVersion.trim();
+        String preset = STYLE_PRESETS.get(normalized);
+        if (preset == null) {
+            throw new IllegalArgumentException("지원하지 않는 이미지 style version입니다: " + normalized);
+        }
+        this.styleVersion = normalized;
+        this.stylePrompt = preset;
+    }
 
     public String compose(NarrativeTurn.VisualAssets assets) {
         if (assets == null) {
             return null;
         }
 
-        List<String> prompts = new ArrayList<>();
-        if (assets.characters() != null) {
-            prompts.addAll(assets.characters().stream().filter(value -> value != null && !value.isBlank()).toList());
-        }
-        if (assets.assets() != null) {
-            prompts.addAll(assets.assets().stream().filter(value -> value != null && !value.isBlank()).toList());
-        }
+        List<String> sections = new ArrayList<>();
+        addSection(sections, "subjects", assets.characters());
+        addSection(sections, "objects", assets.assets());
         if (assets.background() != null && !assets.background().isBlank()) {
-            prompts.add(assets.background());
+            addSection(sections, "setting", List.of(assets.background()));
         }
+        if (sections.isEmpty()) {
+            return null;
+        }
+        return finish(String.join("; ", sections));
+    }
 
-        return prompts.isEmpty() ? null : String.join(", ", prompts);
+    public String composeFallback(String worldSetting) {
+        String setting = normalize(worldSetting);
+        if (setting == null) {
+            setting = "mysterious unknown location";
+        }
+        return finish("setting: " + setting);
+    }
+
+    private void addSection(List<String> sections, String label, List<String> values) {
+        List<String> normalized = distinct(values);
+        if (!normalized.isEmpty()) {
+            sections.add(label + ": " + String.join(", ", normalized));
+        }
+    }
+
+    private List<String> distinct(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            return List.of();
+        }
+        Map<String, String> distinct = new LinkedHashMap<>();
+        for (String value : values) {
+            String normalized = normalize(value);
+            if (normalized != null) {
+                distinct.putIfAbsent(normalized.toLowerCase(Locale.ROOT), normalized);
+            }
+        }
+        return List.copyOf(distinct.values());
+    }
+
+    private String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim().replaceAll("\\s+", " ");
+        return normalized.isBlank() ? null : normalized;
+    }
+
+    private String finish(String scenePrompt) {
+        String suffix = "; " + ATMOSPHERE + "; " + COMPOSITION
+                + "; style[" + styleVersion + "]: " + stylePrompt;
+        int sceneBudget = MAX_PROMPT_LENGTH - suffix.length();
+        String limitedScene = scenePrompt.length() <= sceneBudget
+                ? scenePrompt
+                : scenePrompt.substring(0, Math.max(0, sceneBudget)).stripTrailing();
+        return limitedScene + suffix;
     }
 }

--- a/src/main/java/com/uctale/uctale/application/game/ImagePromptComposer.java
+++ b/src/main/java/com/uctale/uctale/application/game/ImagePromptComposer.java
@@ -1,6 +1,7 @@
 package com.uctale.uctale.application.game;
 
 import com.uctale.uctale.application.narrative.NarrativeTurn;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -29,6 +30,7 @@ public class ImagePromptComposer {
         this(DEFAULT_STYLE_VERSION);
     }
 
+    @Autowired
     public ImagePromptComposer(@Value("${game.image.style-version:uctale-charcoal-v1}") String styleVersion) {
         String normalized = styleVersion == null ? "" : styleVersion.trim();
         String preset = STYLE_PRESETS.get(normalized);

--- a/src/main/java/com/uctale/uctale/application/image/ImageAssetService.java
+++ b/src/main/java/com/uctale/uctale/application/image/ImageAssetService.java
@@ -11,6 +11,10 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.HexFormat;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -96,20 +100,22 @@ public class ImageAssetService {
                 );
                 costRateLimiter.check(CostOperation.IMAGE, providerContext);
 
+                long startedAt = System.nanoTime();
                 try {
                     ImageGenerator.GeneratedImage generated = providerCallTelemetry.observe(
-                            "pollinations", "image_generation", providerContext, 0,
-                            () -> fetchValidImage(current)
+                            "pollinations",
+                            "image_generation",
+                            providerContext,
+                            () -> fetchValidImage(current),
+                            result -> result.providerMetadata().retryCount(),
+                            this::retryCountFromFailure
                     );
                     current.storeGeneratedImage(generated.bytes(), generated.contentType().toString());
                     imageAssetRepository.saveAndFlush(current);
+                    logProviderResult(current, generated, startedAt);
                     return toGeneratedAsset(current);
                 } catch (ImageGenerationException exception) {
-                    log.warn(
-                            "image_asset_fallback assetId={} sessionId={} turn={} reason={}",
-                            current.getId(), current.getGameSession().getId(), current.getTurnNumber(),
-                            exception.getClass().getSimpleName()
-                    );
+                    logProviderFailure(current, exception, startedAt);
                     return fallbackAsset();
                 }
             }
@@ -135,6 +141,40 @@ public class ImageAssetService {
         return generated;
     }
 
+    private int retryCountFromFailure(RuntimeException exception) {
+        return exception instanceof ImageProviderFailure failure ? failure.retryCount() : 0;
+    }
+
+    private void logProviderResult(ImageAsset asset, ImageGenerator.GeneratedImage generated, long startedAt) {
+        ImageGenerator.ProviderMetadata metadata = generated.providerMetadata();
+        log.info(
+                "image_provider_result assetId={} sessionId={} turn={} promptHash={} model={} size={}x{} seed={} styleVersion={} latencyMs={} outcome=SUCCESS status={} errorCode=- requestId={} bytes={} mime={} retryCount={}",
+                asset.getId(), asset.getGameSession().getId(), asset.getTurnNumber(), promptHash(asset.getPrompt()),
+                asset.getModel(), asset.getWidth(), asset.getHeight(), asset.getSeed(), asset.getStyleVersion(),
+                elapsedMs(startedAt), metadata.status(), safeLog(metadata.requestId()), generated.bytes().length,
+                generated.contentType(), metadata.retryCount()
+        );
+    }
+
+    private void logProviderFailure(ImageAsset asset, ImageGenerationException exception, long startedAt) {
+        int status = 0;
+        String code = exception.getClass().getSimpleName();
+        String requestId = null;
+        int retryCount = 0;
+        if (exception instanceof ImageProviderFailure failure) {
+            status = failure.status();
+            code = failure.code();
+            requestId = failure.requestId();
+            retryCount = failure.retryCount();
+        }
+        log.warn(
+                "image_provider_result assetId={} sessionId={} turn={} promptHash={} model={} size={}x{} seed={} styleVersion={} latencyMs={} outcome=FAILURE status={} errorCode={} requestId={} bytes=0 mime=- retryCount={}",
+                asset.getId(), asset.getGameSession().getId(), asset.getTurnNumber(), promptHash(asset.getPrompt()),
+                asset.getModel(), asset.getWidth(), asset.getHeight(), asset.getSeed(), asset.getStyleVersion(),
+                elapsedMs(startedAt), status, safeLog(code), safeLog(requestId), retryCount
+        );
+    }
+
     private ImageAsset findOwnedAsset(String ownerKey, String assetId) {
         return imageAssetRepository.findByIdAndGameSessionOwnerKey(assetId, ownerKey)
                 .orElseThrow(() -> new ImageAssetNotFoundException("존재하지 않는 이미지 asset입니다."));
@@ -146,6 +186,27 @@ public class ImageAssetService {
 
     private GeneratedAsset fallbackAsset() {
         return new GeneratedAsset(FALLBACK_IMAGE.clone(), MediaType.parseMediaType("image/svg+xml"));
+    }
+
+    private long elapsedMs(long startedAt) {
+        return Math.max(0, Duration.ofNanos(System.nanoTime() - startedAt).toMillis());
+    }
+
+    private String promptHash(String prompt) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(prompt.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256을 사용할 수 없습니다.", exception);
+        }
+    }
+
+    private String safeLog(String value) {
+        if (value == null || value.isBlank()) {
+            return "-";
+        }
+        String normalized = value.replaceAll("[\\r\\n\\t]", "_");
+        return normalized.length() <= 128 ? normalized : normalized.substring(0, 128);
     }
 
     public record AssetReference(

--- a/src/main/java/com/uctale/uctale/application/image/ImageAssetService.java
+++ b/src/main/java/com/uctale/uctale/application/image/ImageAssetService.java
@@ -6,31 +6,45 @@ import com.uctale.uctale.application.cost.CostRequestContext;
 import com.uctale.uctale.application.cost.ProviderCallTelemetry;
 import com.uctale.uctale.domain.ImageAsset;
 import com.uctale.uctale.repository.ImageAssetRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
+@Slf4j
 @Service
 public class ImageAssetService {
+
+    private static final byte[] FALLBACK_IMAGE = ("""
+            <svg xmlns="http://www.w3.org/2000/svg" width="1024" height="576" viewBox="0 0 1024 576">
+              <rect width="1024" height="576" fill="#f2f0eb"/>
+              <path d="M160 420 L360 220 L500 350 L650 180 L864 420" fill="none" stroke="#444" stroke-width="14" opacity="0.7"/>
+              <text x="512" y="500" text-anchor="middle" font-family="sans-serif" font-size="30" fill="#555">UCTale scene unavailable</text>
+            </svg>
+            """).getBytes(StandardCharsets.UTF_8);
 
     private final ImageAssetRepository imageAssetRepository;
     private final ImageGenerator imageGenerator;
     private final CostRateLimiter costRateLimiter;
     private final ProviderCallTelemetry providerCallTelemetry;
+    private final ImageGenerationPolicy generationPolicy;
     private final ConcurrentHashMap<String, Object> generationLocks = new ConcurrentHashMap<>();
 
     public ImageAssetService(
             ImageAssetRepository imageAssetRepository,
             ImageGenerator imageGenerator,
             CostRateLimiter costRateLimiter,
-            ProviderCallTelemetry providerCallTelemetry
+            ProviderCallTelemetry providerCallTelemetry,
+            ImageGenerationPolicy generationPolicy
     ) {
         this.imageAssetRepository = imageAssetRepository;
         this.imageGenerator = imageGenerator;
         this.costRateLimiter = costRateLimiter;
         this.providerCallTelemetry = providerCallTelemetry;
+        this.generationPolicy = generationPolicy;
     }
 
     public AssetReference issue(String prompt, String aspectRatio) {
@@ -38,8 +52,20 @@ public class ImageAssetService {
             throw new IllegalArgumentException("이미지 prompt는 필수입니다.");
         }
         String normalizedAspectRatio = "1:1".equals(aspectRatio) ? "1:1" : "16:9";
+        ImageGenerationPolicy.GenerationSpec spec = generationPolicy.issue(normalizedAspectRatio);
         String id = UUID.randomUUID().toString();
-        return new AssetReference(id, "/api/game/image-assets/" + id, prompt, normalizedAspectRatio);
+        return new AssetReference(
+                id,
+                "/api/game/image-assets/" + id,
+                prompt,
+                normalizedAspectRatio,
+                spec.model(),
+                spec.width(),
+                spec.height(),
+                spec.seed(),
+                spec.safe(),
+                spec.styleVersion()
+        );
     }
 
     public GeneratedAsset getOrGenerate(String ownerKey, String assetId) {
@@ -70,15 +96,22 @@ public class ImageAssetService {
                 );
                 costRateLimiter.check(CostOperation.IMAGE, providerContext);
 
-                ImageGenerator.GeneratedImage generated = providerCallTelemetry.observe(
-                        "pollinations", "image_generation", providerContext, 0,
-                        () -> fetchValidImage(current)
-                );
-
-                MediaType contentType = generated.contentType() == null ? MediaType.IMAGE_JPEG : generated.contentType();
-                current.storeGeneratedImage(generated.bytes(), contentType.toString());
-                imageAssetRepository.saveAndFlush(current);
-                return toGeneratedAsset(current);
+                try {
+                    ImageGenerator.GeneratedImage generated = providerCallTelemetry.observe(
+                            "pollinations", "image_generation", providerContext, 0,
+                            () -> fetchValidImage(current)
+                    );
+                    current.storeGeneratedImage(generated.bytes(), generated.contentType().toString());
+                    imageAssetRepository.saveAndFlush(current);
+                    return toGeneratedAsset(current);
+                } catch (ImageGenerationException exception) {
+                    log.warn(
+                            "image_asset_fallback assetId={} sessionId={} turn={} reason={}",
+                            current.getId(), current.getGameSession().getId(), current.getTurnNumber(),
+                            exception.getClass().getSimpleName()
+                    );
+                    return fallbackAsset();
+                }
             }
         } finally {
             generationLocks.remove(assetId, lock);
@@ -86,8 +119,17 @@ public class ImageAssetService {
     }
 
     private ImageGenerator.GeneratedImage fetchValidImage(ImageAsset asset) {
-        ImageGenerator.GeneratedImage generated = imageGenerator.fetchImage(asset.getPrompt(), asset.getAspectRatio());
-        if (generated == null || generated.bytes() == null || generated.bytes().length == 0) {
+        ImageGenerator.GenerationRequest request = new ImageGenerator.GenerationRequest(
+                asset.getPrompt(),
+                asset.getModel(),
+                asset.getWidth(),
+                asset.getHeight(),
+                asset.getSeed(),
+                asset.isSafe(),
+                asset.getStyleVersion()
+        );
+        ImageGenerator.GeneratedImage generated = imageGenerator.fetchImage(request);
+        if (generated == null || generated.bytes() == null || generated.bytes().length == 0 || generated.contentType() == null) {
             throw new ImageGenerationException("이미지 provider가 유효한 이미지를 반환하지 않았습니다.");
         }
         return generated;
@@ -102,7 +144,22 @@ public class ImageAssetService {
         return new GeneratedAsset(asset.getImageBytes().clone(), MediaType.parseMediaType(asset.getContentType()));
     }
 
-    public record AssetReference(String id, String publicUrl, String prompt, String aspectRatio) {}
+    private GeneratedAsset fallbackAsset() {
+        return new GeneratedAsset(FALLBACK_IMAGE.clone(), MediaType.parseMediaType("image/svg+xml"));
+    }
+
+    public record AssetReference(
+            String id,
+            String publicUrl,
+            String prompt,
+            String aspectRatio,
+            String model,
+            int width,
+            int height,
+            int seed,
+            boolean safe,
+            String styleVersion
+    ) {}
 
     public record GeneratedAsset(byte[] bytes, MediaType contentType) {}
 }

--- a/src/main/java/com/uctale/uctale/application/image/ImageGenerationException.java
+++ b/src/main/java/com/uctale/uctale/application/image/ImageGenerationException.java
@@ -4,4 +4,8 @@ public class ImageGenerationException extends RuntimeException {
     public ImageGenerationException(String message) {
         super(message);
     }
+
+    public ImageGenerationException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/src/main/java/com/uctale/uctale/application/image/ImageGenerationPolicy.java
+++ b/src/main/java/com/uctale/uctale/application/image/ImageGenerationPolicy.java
@@ -21,9 +21,9 @@ public class ImageGenerationPolicy {
 
     public ImageGenerationPolicy(
             @Value("${game.image.model:flux}") String model,
-            @Value("${game.image.width:1024}") int width,
-            @Value("${game.image.height:576}") int height,
-            @Value("${game.image.square-size:768}") int squareSize,
+            @Value("${game.image.width:768}") int width,
+            @Value("${game.image.height:432}") int height,
+            @Value("${game.image.square-size:512}") int squareSize,
             @Value("${game.image.safe:true}") boolean safe,
             @Value("${game.image.style-version:uctale-charcoal-v1}") String styleVersion
     ) {

--- a/src/main/java/com/uctale/uctale/application/image/ImageGenerationPolicy.java
+++ b/src/main/java/com/uctale/uctale/application/image/ImageGenerationPolicy.java
@@ -1,0 +1,85 @@
+package com.uctale.uctale.application.image;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+
+@Component
+public class ImageGenerationPolicy {
+
+    private static final int MIN_DIMENSION = 64;
+    private static final int MAX_DIMENSION = 4096;
+
+    private final String model;
+    private final int width;
+    private final int height;
+    private final int squareSize;
+    private final boolean safe;
+    private final String styleVersion;
+    private final SecureRandom secureRandom;
+
+    public ImageGenerationPolicy(
+            @Value("${game.image.model:flux}") String model,
+            @Value("${game.image.width:1024}") int width,
+            @Value("${game.image.height:576}") int height,
+            @Value("${game.image.square-size:768}") int squareSize,
+            @Value("${game.image.safe:true}") boolean safe,
+            @Value("${game.image.style-version:uctale-charcoal-v1}") String styleVersion
+    ) {
+        this(model, width, height, squareSize, safe, styleVersion, new SecureRandom());
+    }
+
+    ImageGenerationPolicy(
+            String model,
+            int width,
+            int height,
+            int squareSize,
+            boolean safe,
+            String styleVersion,
+            SecureRandom secureRandom
+    ) {
+        this.model = requireText(model, "이미지 model");
+        this.width = validateDimension(width, "이미지 width");
+        this.height = validateDimension(height, "이미지 height");
+        this.squareSize = validateDimension(squareSize, "이미지 square size");
+        this.safe = safe;
+        this.styleVersion = requireText(styleVersion, "이미지 style version");
+        this.secureRandom = secureRandom;
+    }
+
+    public GenerationSpec issue(String aspectRatio) {
+        boolean square = "1:1".equals(aspectRatio);
+        return new GenerationSpec(
+                model,
+                square ? squareSize : width,
+                square ? squareSize : height,
+                secureRandom.nextInt(Integer.MAX_VALUE),
+                safe,
+                styleVersion
+        );
+    }
+
+    private int validateDimension(int value, String name) {
+        if (value < MIN_DIMENSION || value > MAX_DIMENSION) {
+            throw new IllegalArgumentException(name + "는 64~4096 범위여야 합니다.");
+        }
+        return value;
+    }
+
+    private String requireText(String value, String name) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(name + "은(는) 필수입니다.");
+        }
+        return value.trim();
+    }
+
+    public record GenerationSpec(
+            String model,
+            int width,
+            int height,
+            int seed,
+            boolean safe,
+            String styleVersion
+    ) {}
+}

--- a/src/main/java/com/uctale/uctale/application/image/ImageGenerationPolicy.java
+++ b/src/main/java/com/uctale/uctale/application/image/ImageGenerationPolicy.java
@@ -1,5 +1,6 @@
 package com.uctale.uctale.application.image;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -19,6 +20,7 @@ public class ImageGenerationPolicy {
     private final String styleVersion;
     private final SecureRandom secureRandom;
 
+    @Autowired
     public ImageGenerationPolicy(
             @Value("${game.image.model:flux}") String model,
             @Value("${game.image.width:768}") int width,

--- a/src/main/java/com/uctale/uctale/application/image/ImageGenerator.java
+++ b/src/main/java/com/uctale/uctale/application/image/ImageGenerator.java
@@ -34,5 +34,17 @@ public interface ImageGenerator {
         }
     }
 
-    record GeneratedImage(byte[] bytes, MediaType contentType) {}
+    record ProviderMetadata(int status, String requestId, int retryCount) {
+        public ProviderMetadata {
+            if (status < 0 || retryCount < 0) {
+                throw new IllegalArgumentException("provider metadata 값이 올바르지 않습니다.");
+            }
+        }
+    }
+
+    record GeneratedImage(byte[] bytes, MediaType contentType, ProviderMetadata providerMetadata) {
+        public GeneratedImage(byte[] bytes, MediaType contentType) {
+            this(bytes, contentType, new ProviderMetadata(200, null, 0));
+        }
+    }
 }

--- a/src/main/java/com/uctale/uctale/application/image/ImageGenerator.java
+++ b/src/main/java/com/uctale/uctale/application/image/ImageGenerator.java
@@ -4,7 +4,35 @@ import org.springframework.http.MediaType;
 
 public interface ImageGenerator {
 
-    GeneratedImage fetchImage(String prompt, String aspectRatio);
+    GeneratedImage fetchImage(GenerationRequest request);
+
+    record GenerationRequest(
+            String prompt,
+            String model,
+            int width,
+            int height,
+            int seed,
+            boolean safe,
+            String styleVersion
+    ) {
+        public GenerationRequest {
+            if (prompt == null || prompt.isBlank()) {
+                throw new IllegalArgumentException("이미지 prompt는 필수입니다.");
+            }
+            if (model == null || model.isBlank()) {
+                throw new IllegalArgumentException("이미지 model은 필수입니다.");
+            }
+            if (width <= 0 || height <= 0) {
+                throw new IllegalArgumentException("이미지 크기는 양수여야 합니다.");
+            }
+            if (seed < 0) {
+                throw new IllegalArgumentException("이미지 seed는 0 이상이어야 합니다.");
+            }
+            if (styleVersion == null || styleVersion.isBlank()) {
+                throw new IllegalArgumentException("이미지 style version은 필수입니다.");
+            }
+        }
+    }
 
     record GeneratedImage(byte[] bytes, MediaType contentType) {}
 }

--- a/src/main/java/com/uctale/uctale/application/image/ImageProviderFailure.java
+++ b/src/main/java/com/uctale/uctale/application/image/ImageProviderFailure.java
@@ -1,0 +1,9 @@
+package com.uctale.uctale.application.image;
+
+public interface ImageProviderFailure {
+    int status();
+    String code();
+    String requestId();
+    Long retryAfterSeconds();
+    int retryCount();
+}

--- a/src/main/java/com/uctale/uctale/domain/ImageAsset.java
+++ b/src/main/java/com/uctale/uctale/domain/ImageAsset.java
@@ -39,6 +39,24 @@ public class ImageAsset {
     @Column(nullable = false, length = 8)
     private String aspectRatio;
 
+    @Column(nullable = false, length = 64)
+    private String model;
+
+    @Column(nullable = false)
+    private int width;
+
+    @Column(nullable = false)
+    private int height;
+
+    @Column(nullable = false)
+    private int seed;
+
+    @Column(nullable = false)
+    private boolean safe;
+
+    @Column(nullable = false, length = 64)
+    private String styleVersion;
+
     @Column(length = 100)
     private String contentType;
 
@@ -49,12 +67,30 @@ public class ImageAsset {
 
     private LocalDateTime generatedAt;
 
-    public ImageAsset(String id, GameSession gameSession, int turnNumber, String prompt, String aspectRatio) {
+    public ImageAsset(
+            String id,
+            GameSession gameSession,
+            int turnNumber,
+            String prompt,
+            String aspectRatio,
+            String model,
+            int width,
+            int height,
+            int seed,
+            boolean safe,
+            String styleVersion
+    ) {
         this.id = id;
         this.gameSession = gameSession;
         this.turnNumber = turnNumber;
         this.prompt = prompt;
         this.aspectRatio = aspectRatio;
+        this.model = model;
+        this.width = width;
+        this.height = height;
+        this.seed = seed;
+        this.safe = safe;
+        this.styleVersion = styleVersion;
         this.createdAt = LocalDateTime.now();
     }
 

--- a/src/main/java/com/uctale/uctale/provider/image/PollinationsImageAdapter.java
+++ b/src/main/java/com/uctale/uctale/provider/image/PollinationsImageAdapter.java
@@ -3,6 +3,7 @@ package com.uctale.uctale.provider.image;
 import com.uctale.uctale.application.image.ImageGenerationException;
 import com.uctale.uctale.application.image.ImageGenerator;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
@@ -43,6 +44,7 @@ public class PollinationsImageAdapter implements ImageGenerator {
     private final int maxImageBytes;
     private final Sleeper sleeper;
 
+    @Autowired
     public PollinationsImageAdapter(
             ObjectMapper objectMapper,
             @Qualifier("pollinationsRestClient") RestClient restClient,

--- a/src/main/java/com/uctale/uctale/provider/image/PollinationsImageAdapter.java
+++ b/src/main/java/com/uctale/uctale/provider/image/PollinationsImageAdapter.java
@@ -16,6 +16,7 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -82,14 +83,14 @@ public class PollinationsImageAdapter implements ImageGenerator {
 
     @Override
     public GeneratedImage fetchImage(GenerationRequest request) {
-        String providerUrl = buildProviderUrl(request);
+        URI providerUri = buildProviderUri(request);
         String promptHash = promptHash(request.prompt());
 
         for (int attempt = 0; attempt <= maxRetries; attempt++) {
             long startedAt = System.nanoTime();
             try {
                 ResponseEntity<byte[]> response = restClient.get()
-                        .uri(providerUrl)
+                        .uri(providerUri)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + pollinationsToken)
                         .retrieve()
                         .onStatus(status -> status.isError(), (httpRequest, httpResponse) -> {
@@ -163,7 +164,7 @@ public class PollinationsImageAdapter implements ImageGenerator {
                 && (IMAGE_JPEG.isCompatibleWith(contentType) || IMAGE_PNG.isCompatibleWith(contentType));
     }
 
-    private String buildProviderUrl(GenerationRequest request) {
+    private URI buildProviderUri(GenerationRequest request) {
         return UriComponentsBuilder.fromUriString(PROVIDER_BASE_URL)
                 .pathSegment(request.prompt())
                 .queryParam("model", request.model())
@@ -173,7 +174,7 @@ public class PollinationsImageAdapter implements ImageGenerator {
                 .queryParam("safe", request.safe())
                 .build()
                 .encode(StandardCharsets.UTF_8)
-                .toUriString();
+                .toUri();
     }
 
     private PollinationsProviderException providerException(org.springframework.http.client.ClientHttpResponse response) {

--- a/src/main/java/com/uctale/uctale/provider/image/PollinationsImageAdapter.java
+++ b/src/main/java/com/uctale/uctale/provider/image/PollinationsImageAdapter.java
@@ -177,7 +177,15 @@ public class PollinationsImageAdapter implements ImageGenerator {
     }
 
     private PollinationsProviderException providerException(org.springframework.http.client.ClientHttpResponse response) {
-        int status = response.getStatusCode().value();
+        final int status;
+        try {
+            status = response.getStatusCode().value();
+        } catch (IOException exception) {
+            return new PollinationsProviderException(
+                    "Pollinations provider 상태 코드를 읽지 못했습니다.", exception, true, 0
+            );
+        }
+
         String code = "HTTP_" + status;
         String requestId = null;
         try {

--- a/src/main/java/com/uctale/uctale/provider/image/PollinationsImageAdapter.java
+++ b/src/main/java/com/uctale/uctale/provider/image/PollinationsImageAdapter.java
@@ -9,7 +9,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
-import org.springframework.util.DigestUtils;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -18,7 +17,14 @@ import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.HexFormat;
 
 @Slf4j
 @Component
@@ -91,11 +97,12 @@ public class PollinationsImageAdapter implements ImageGenerator {
                         })
                         .toEntity(byte[].class);
 
-                GeneratedImage image = validateResponse(response);
+                GeneratedImage image = validateResponse(response, attempt);
                 log.info(
-                        "pollinations_image promptHash={} model={} size={}x{} seed={} safe={} styleVersion={} latencyMs={} outcome=SUCCESS status=200 mime={} bytes={} retryCount={}",
+                        "pollinations_image promptHash={} model={} size={}x{} seed={} safe={} styleVersion={} latencyMs={} outcome=SUCCESS status={} requestId={} mime={} bytes={} retryCount={}",
                         promptHash, request.model(), request.width(), request.height(), request.seed(), request.safe(), request.styleVersion(),
-                        elapsedMs(startedAt), image.contentType(), image.bytes().length, attempt
+                        elapsedMs(startedAt), image.providerMetadata().status(), safeLog(image.providerMetadata().requestId()),
+                        image.contentType(), image.bytes().length, image.providerMetadata().retryCount()
                 );
                 return image;
             } catch (PollinationsProviderException exception) {
@@ -107,18 +114,20 @@ public class PollinationsImageAdapter implements ImageGenerator {
                         exception.retryAfterSeconds(), attempt, willRetry
                 );
                 if (!willRetry) {
-                    throw exception;
+                    throw exception.withRetryCount(attempt);
                 }
                 sleepBeforeRetry(exception.retryAfterSeconds(), attempt);
             } catch (ResourceAccessException exception) {
                 boolean willRetry = attempt < maxRetries;
                 log.warn(
-                        "pollinations_image promptHash={} model={} size={}x{} seed={} styleVersion={} latencyMs={} outcome=FAILURE status=0 code=NETWORK_TIMEOUT retryCount={} willRetry={}",
+                        "pollinations_image promptHash={} model={} size={}x{} seed={} styleVersion={} latencyMs={} outcome=FAILURE status=0 code=NETWORK_ERROR retryCount={} willRetry={}",
                         promptHash, request.model(), request.width(), request.height(), request.seed(), request.styleVersion(),
                         elapsedMs(startedAt), attempt, willRetry
                 );
                 if (!willRetry) {
-                    throw new PollinationsProviderException("Pollinations 네트워크 요청에 실패했습니다.", exception, true);
+                    throw new PollinationsProviderException(
+                            "Pollinations 네트워크 요청에 실패했습니다.", exception, true, attempt
+                    );
                 }
                 sleepBeforeRetry(null, attempt);
             }
@@ -126,7 +135,7 @@ public class PollinationsImageAdapter implements ImageGenerator {
         throw new ImageGenerationException("Pollinations 이미지 생성에 실패했습니다.");
     }
 
-    private GeneratedImage validateResponse(ResponseEntity<byte[]> response) {
+    private GeneratedImage validateResponse(ResponseEntity<byte[]> response, int retryCount) {
         byte[] body = response.getBody();
         if (body == null || body.length == 0) {
             throw new ImageGenerationException("Pollinations가 빈 이미지를 반환했습니다.");
@@ -138,7 +147,15 @@ public class PollinationsImageAdapter implements ImageGenerator {
         if (!isAllowedImageType(contentType)) {
             throw new ImageGenerationException("Pollinations 이미지 MIME type이 허용되지 않습니다.");
         }
-        return new GeneratedImage(body, contentType);
+        return new GeneratedImage(
+                body,
+                contentType,
+                new ProviderMetadata(
+                        response.getStatusCode().value(),
+                        response.getHeaders().getFirst("X-Request-Id"),
+                        retryCount
+                )
+        );
     }
 
     private boolean isAllowedImageType(MediaType contentType) {
@@ -184,7 +201,7 @@ public class PollinationsImageAdapter implements ImageGenerator {
         Long retryAfter = parseRetryAfter(response.getHeaders().getFirst(HttpHeaders.RETRY_AFTER));
         boolean retryable = status == 429 || status == 502 || status == 503;
         return new PollinationsProviderException(
-                "Pollinations provider 오류가 발생했습니다.", status, code, requestId, retryAfter, retryable
+                "Pollinations provider 오류가 발생했습니다.", status, code, requestId, retryAfter, retryable, 0
         );
     }
 
@@ -192,10 +209,16 @@ public class PollinationsImageAdapter implements ImageGenerator {
         if (value == null || value.isBlank()) {
             return null;
         }
+        String normalized = value.trim();
         try {
-            return Math.max(0, Long.parseLong(value.trim()));
+            return Math.max(0, Long.parseLong(normalized));
         } catch (NumberFormatException ignored) {
-            return null;
+            try {
+                Instant retryAt = ZonedDateTime.parse(normalized, DateTimeFormatter.RFC_1123_DATE_TIME).toInstant();
+                return Math.max(0, Duration.between(Instant.now(), retryAt).toSeconds());
+            } catch (DateTimeParseException ignoredDate) {
+                return null;
+            }
         }
     }
 
@@ -219,7 +242,12 @@ public class PollinationsImageAdapter implements ImageGenerator {
     }
 
     private String promptHash(String prompt) {
-        return DigestUtils.md5DigestAsHex(prompt.getBytes(StandardCharsets.UTF_8));
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(prompt.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256을 사용할 수 없습니다.", exception);
+        }
     }
 
     private String safeLog(String value) {

--- a/src/main/java/com/uctale/uctale/provider/image/PollinationsImageAdapter.java
+++ b/src/main/java/com/uctale/uctale/provider/image/PollinationsImageAdapter.java
@@ -1,65 +1,237 @@
 package com.uctale.uctale.provider.image;
 
+import com.uctale.uctale.application.image.ImageGenerationException;
 import com.uctale.uctale.application.image.ImageGenerator;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.util.DigestUtils;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
-import java.net.URLEncoder;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 
 @Slf4j
 @Component
 public class PollinationsImageAdapter implements ImageGenerator {
 
-    private static final String STYLE_SUFFIX = ", rough charcoal sketch, high contrast black and white, gritty texture, white background, pencil drawing style, no colors, concept art";
-    private static final String PROVIDER_BASE_URL = "https://gen.pollinations.ai/image/";
+    private static final String PROVIDER_BASE_URL = "https://gen.pollinations.ai/image";
+    private static final MediaType IMAGE_PNG = MediaType.IMAGE_PNG;
+    private static final MediaType IMAGE_JPEG = MediaType.IMAGE_JPEG;
 
+    private final ObjectMapper objectMapper;
     private final RestClient restClient;
+    private final String pollinationsToken;
+    private final int maxRetries;
+    private final long retryBaseDelayMs;
+    private final int maxImageBytes;
+    private final Sleeper sleeper;
 
-    @Value("${pollinations.token}")
-    private String pollinationsToken;
+    public PollinationsImageAdapter(
+            ObjectMapper objectMapper,
+            @Qualifier("pollinationsRestClient") RestClient restClient,
+            @Value("${pollinations.token}") String pollinationsToken,
+            @Value("${game.image.max-retries:2}") int maxRetries,
+            @Value("${game.image.retry-base-delay-ms:250}") long retryBaseDelayMs,
+            @Value("${game.image.max-response-bytes:8388608}") int maxImageBytes
+    ) {
+        this(objectMapper, restClient, pollinationsToken, maxRetries, retryBaseDelayMs, maxImageBytes, Thread::sleep);
+    }
 
-    public PollinationsImageAdapter(RestClient.Builder restClientBuilder) {
-        this.restClient = restClientBuilder.build();
+    PollinationsImageAdapter(
+            ObjectMapper objectMapper,
+            RestClient restClient,
+            String pollinationsToken,
+            int maxRetries,
+            long retryBaseDelayMs,
+            int maxImageBytes,
+            Sleeper sleeper
+    ) {
+        if (pollinationsToken == null || pollinationsToken.isBlank()) {
+            throw new IllegalArgumentException("Pollinations token은 필수입니다.");
+        }
+        if (maxRetries < 0 || maxRetries > 5) {
+            throw new IllegalArgumentException("Pollinations max retries는 0~5 범위여야 합니다.");
+        }
+        if (retryBaseDelayMs < 0 || maxImageBytes <= 0) {
+            throw new IllegalArgumentException("Pollinations retry delay/max bytes 설정이 올바르지 않습니다.");
+        }
+        this.objectMapper = objectMapper;
+        this.restClient = restClient;
+        this.pollinationsToken = pollinationsToken;
+        this.maxRetries = maxRetries;
+        this.retryBaseDelayMs = retryBaseDelayMs;
+        this.maxImageBytes = maxImageBytes;
+        this.sleeper = sleeper;
     }
 
     @Override
-    public GeneratedImage fetchImage(String prompt, String aspectRatio) {
-        try {
-            ResponseEntity<byte[]> response = restClient.get()
-                    .uri(buildProviderUrl(prompt, aspectRatio))
-                    .retrieve()
-                    .toEntity(byte[].class);
+    public GeneratedImage fetchImage(GenerationRequest request) {
+        String providerUrl = buildProviderUrl(request);
+        String promptHash = promptHash(request.prompt());
 
-            MediaType contentType = response.getHeaders().getContentType();
-            if (contentType == null) {
-                contentType = MediaType.IMAGE_JPEG;
+        for (int attempt = 0; attempt <= maxRetries; attempt++) {
+            long startedAt = System.nanoTime();
+            try {
+                ResponseEntity<byte[]> response = restClient.get()
+                        .uri(providerUrl)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + pollinationsToken)
+                        .retrieve()
+                        .onStatus(status -> status.isError(), (httpRequest, httpResponse) -> {
+                            throw providerException(httpResponse);
+                        })
+                        .toEntity(byte[].class);
+
+                GeneratedImage image = validateResponse(response);
+                log.info(
+                        "pollinations_image promptHash={} model={} size={}x{} seed={} safe={} styleVersion={} latencyMs={} outcome=SUCCESS status=200 mime={} bytes={} retryCount={}",
+                        promptHash, request.model(), request.width(), request.height(), request.seed(), request.safe(), request.styleVersion(),
+                        elapsedMs(startedAt), image.contentType(), image.bytes().length, attempt
+                );
+                return image;
+            } catch (PollinationsProviderException exception) {
+                boolean willRetry = exception.retryable() && attempt < maxRetries;
+                log.warn(
+                        "pollinations_image promptHash={} model={} size={}x{} seed={} safe={} styleVersion={} latencyMs={} outcome=FAILURE status={} code={} requestId={} retryAfterSeconds={} retryCount={} willRetry={}",
+                        promptHash, request.model(), request.width(), request.height(), request.seed(), request.safe(), request.styleVersion(),
+                        elapsedMs(startedAt), exception.status(), safeLog(exception.code()), safeLog(exception.requestId()),
+                        exception.retryAfterSeconds(), attempt, willRetry
+                );
+                if (!willRetry) {
+                    throw exception;
+                }
+                sleepBeforeRetry(exception.retryAfterSeconds(), attempt);
+            } catch (ResourceAccessException exception) {
+                boolean willRetry = attempt < maxRetries;
+                log.warn(
+                        "pollinations_image promptHash={} model={} size={}x{} seed={} styleVersion={} latencyMs={} outcome=FAILURE status=0 code=NETWORK_TIMEOUT retryCount={} willRetry={}",
+                        promptHash, request.model(), request.width(), request.height(), request.seed(), request.styleVersion(),
+                        elapsedMs(startedAt), attempt, willRetry
+                );
+                if (!willRetry) {
+                    throw new PollinationsProviderException("Pollinations 네트워크 요청에 실패했습니다.", exception, true);
+                }
+                sleepBeforeRetry(null, attempt);
             }
-            return new GeneratedImage(response.getBody(), contentType);
-        } catch (Exception e) {
-            log.error("Pollinations 이미지 생성 요청 실패: {}", e.getClass().getSimpleName());
+        }
+        throw new ImageGenerationException("Pollinations 이미지 생성에 실패했습니다.");
+    }
+
+    private GeneratedImage validateResponse(ResponseEntity<byte[]> response) {
+        byte[] body = response.getBody();
+        if (body == null || body.length == 0) {
+            throw new ImageGenerationException("Pollinations가 빈 이미지를 반환했습니다.");
+        }
+        if (body.length > maxImageBytes) {
+            throw new ImageGenerationException("Pollinations 이미지가 최대 허용 크기를 초과했습니다.");
+        }
+        MediaType contentType = response.getHeaders().getContentType();
+        if (!isAllowedImageType(contentType)) {
+            throw new ImageGenerationException("Pollinations 이미지 MIME type이 허용되지 않습니다.");
+        }
+        return new GeneratedImage(body, contentType);
+    }
+
+    private boolean isAllowedImageType(MediaType contentType) {
+        return contentType != null
+                && (IMAGE_JPEG.isCompatibleWith(contentType) || IMAGE_PNG.isCompatibleWith(contentType));
+    }
+
+    private String buildProviderUrl(GenerationRequest request) {
+        return UriComponentsBuilder.fromUriString(PROVIDER_BASE_URL)
+                .pathSegment(request.prompt())
+                .queryParam("model", request.model())
+                .queryParam("width", request.width())
+                .queryParam("height", request.height())
+                .queryParam("seed", request.seed())
+                .queryParam("safe", request.safe())
+                .build()
+                .encode(StandardCharsets.UTF_8)
+                .toUriString();
+    }
+
+    private PollinationsProviderException providerException(org.springframework.http.client.ClientHttpResponse response) {
+        int status = response.getStatusCode().value();
+        String code = "HTTP_" + status;
+        String requestId = null;
+        try {
+            String body = new String(response.getBody().readAllBytes(), StandardCharsets.UTF_8);
+            if (!body.isBlank()) {
+                JsonNode root = objectMapper.readTree(body);
+                JsonNode error = root.path("error");
+                if (!error.path("code").isMissingNode() && !error.path("code").isNull()) {
+                    code = error.path("code").asText(code);
+                }
+                if (!error.path("requestId").isMissingNode() && !error.path("requestId").isNull()) {
+                    requestId = error.path("requestId").asText();
+                }
+            }
+        } catch (IOException | RuntimeException ignored) {
+            // Preserve status even if an upstream error envelope is malformed.
+        }
+        if (requestId == null || requestId.isBlank()) {
+            requestId = response.getHeaders().getFirst("X-Request-Id");
+        }
+        Long retryAfter = parseRetryAfter(response.getHeaders().getFirst(HttpHeaders.RETRY_AFTER));
+        boolean retryable = status == 429 || status == 502 || status == 503;
+        return new PollinationsProviderException(
+                "Pollinations provider 오류가 발생했습니다.", status, code, requestId, retryAfter, retryable
+        );
+    }
+
+    private Long parseRetryAfter(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Math.max(0, Long.parseLong(value.trim()));
+        } catch (NumberFormatException ignored) {
             return null;
         }
     }
 
-    private String buildProviderUrl(String prompt, String aspectRatio) {
-        String fullPrompt = prompt + STYLE_SUFFIX;
-        String encodedPrompt = URLEncoder.encode(fullPrompt, StandardCharsets.UTF_8);
-        String sizeParam = "1:1".equals(normalizeAspectRatio(aspectRatio))
-                ? "width=512&height=512"
-                : "width=768&height=432";
-        String tokenParam = pollinationsToken == null || pollinationsToken.isBlank()
-                ? ""
-                : "&key=" + URLEncoder.encode(pollinationsToken, StandardCharsets.UTF_8);
-
-        return PROVIDER_BASE_URL + encodedPrompt + "?" + sizeParam + "&nologo=true&model=flux" + tokenParam;
+    private void sleepBeforeRetry(Long retryAfterSeconds, int attempt) {
+        long delayMs = retryAfterSeconds == null
+                ? retryBaseDelayMs * (1L << Math.min(attempt, 4))
+                : Duration.ofSeconds(retryAfterSeconds).toMillis();
+        if (delayMs <= 0) {
+            return;
+        }
+        try {
+            sleeper.sleep(delayMs);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new ImageGenerationException("Pollinations 재시도 대기 중 인터럽트되었습니다.", exception);
+        }
     }
 
-    private String normalizeAspectRatio(String aspectRatio) {
-        return "1:1".equals(aspectRatio) ? "1:1" : "16:9";
+    private long elapsedMs(long startedAt) {
+        return Math.max(0, Duration.ofNanos(System.nanoTime() - startedAt).toMillis());
+    }
+
+    private String promptHash(String prompt) {
+        return DigestUtils.md5DigestAsHex(prompt.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private String safeLog(String value) {
+        if (value == null || value.isBlank()) {
+            return "-";
+        }
+        String normalized = value.replaceAll("[\\r\\n\\t]", "_");
+        return normalized.length() <= 128 ? normalized : normalized.substring(0, 128);
+    }
+
+    @FunctionalInterface
+    interface Sleeper {
+        void sleep(long millis) throws InterruptedException;
     }
 }

--- a/src/main/java/com/uctale/uctale/provider/image/PollinationsProviderException.java
+++ b/src/main/java/com/uctale/uctale/provider/image/PollinationsProviderException.java
@@ -1,0 +1,57 @@
+package com.uctale.uctale.provider.image;
+
+import com.uctale.uctale.application.image.ImageGenerationException;
+
+public class PollinationsProviderException extends ImageGenerationException {
+
+    private final int status;
+    private final String code;
+    private final String requestId;
+    private final Long retryAfterSeconds;
+    private final boolean retryable;
+
+    public PollinationsProviderException(
+            String message,
+            int status,
+            String code,
+            String requestId,
+            Long retryAfterSeconds,
+            boolean retryable
+    ) {
+        super(message);
+        this.status = status;
+        this.code = code;
+        this.requestId = requestId;
+        this.retryAfterSeconds = retryAfterSeconds;
+        this.retryable = retryable;
+    }
+
+    public PollinationsProviderException(String message, Throwable cause, boolean retryable) {
+        super(message, cause);
+        this.status = 0;
+        this.code = "NETWORK_ERROR";
+        this.requestId = null;
+        this.retryAfterSeconds = null;
+        this.retryable = retryable;
+    }
+
+    public int status() {
+        return status;
+    }
+
+    public String code() {
+        return code;
+    }
+
+    public String requestId() {
+        return requestId;
+    }
+
+    public Long retryAfterSeconds() {
+        return retryAfterSeconds;
+    }
+
+    public boolean retryable() {
+        return retryable;
+    }
+}

--- a/src/main/java/com/uctale/uctale/provider/image/PollinationsProviderException.java
+++ b/src/main/java/com/uctale/uctale/provider/image/PollinationsProviderException.java
@@ -1,14 +1,16 @@
 package com.uctale.uctale.provider.image;
 
 import com.uctale.uctale.application.image.ImageGenerationException;
+import com.uctale.uctale.application.image.ImageProviderFailure;
 
-public class PollinationsProviderException extends ImageGenerationException {
+public class PollinationsProviderException extends ImageGenerationException implements ImageProviderFailure {
 
     private final int status;
     private final String code;
     private final String requestId;
     private final Long retryAfterSeconds;
     private final boolean retryable;
+    private final int retryCount;
 
     public PollinationsProviderException(
             String message,
@@ -16,7 +18,8 @@ public class PollinationsProviderException extends ImageGenerationException {
             String code,
             String requestId,
             Long retryAfterSeconds,
-            boolean retryable
+            boolean retryable,
+            int retryCount
     ) {
         super(message);
         this.status = status;
@@ -24,34 +27,51 @@ public class PollinationsProviderException extends ImageGenerationException {
         this.requestId = requestId;
         this.retryAfterSeconds = retryAfterSeconds;
         this.retryable = retryable;
+        this.retryCount = retryCount;
     }
 
-    public PollinationsProviderException(String message, Throwable cause, boolean retryable) {
+    public PollinationsProviderException(String message, Throwable cause, boolean retryable, int retryCount) {
         super(message, cause);
         this.status = 0;
         this.code = "NETWORK_ERROR";
         this.requestId = null;
         this.retryAfterSeconds = null;
         this.retryable = retryable;
+        this.retryCount = retryCount;
     }
 
+    PollinationsProviderException withRetryCount(int value) {
+        return new PollinationsProviderException(
+                getMessage(), status, code, requestId, retryAfterSeconds, retryable, value
+        );
+    }
+
+    @Override
     public int status() {
         return status;
     }
 
+    @Override
     public String code() {
         return code;
     }
 
+    @Override
     public String requestId() {
         return requestId;
     }
 
+    @Override
     public Long retryAfterSeconds() {
         return retryAfterSeconds;
     }
 
     public boolean retryable() {
         return retryable;
+    }
+
+    @Override
+    public int retryCount() {
+        return retryCount;
     }
 }

--- a/src/main/java/com/uctale/uctale/provider/image/PollinationsRestClientConfig.java
+++ b/src/main/java/com/uctale/uctale/provider/image/PollinationsRestClientConfig.java
@@ -1,0 +1,30 @@
+package com.uctale.uctale.provider.image;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+import java.time.Duration;
+
+@Configuration
+public class PollinationsRestClientConfig {
+
+    @Bean
+    @Qualifier("pollinationsRestClient")
+    RestClient pollinationsRestClient(
+            RestClient.Builder builder,
+            @Value("${game.image.connect-timeout-ms:10000}") long connectTimeoutMs,
+            @Value("${game.image.read-timeout-ms:120000}") long readTimeoutMs
+    ) {
+        if (connectTimeoutMs <= 0 || readTimeoutMs <= 0) {
+            throw new IllegalArgumentException("Pollinations timeout은 1ms 이상이어야 합니다.");
+        }
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(Duration.ofMillis(connectTimeoutMs));
+        requestFactory.setReadTimeout(Duration.ofMillis(readTimeoutMs));
+        return builder.requestFactory(requestFactory).build();
+    }
+}

--- a/src/main/java/com/uctale/uctale/service/GameService.java
+++ b/src/main/java/com/uctale/uctale/service/GameService.java
@@ -58,7 +58,7 @@ public class GameService {
 
         String imagePrompt = imagePromptComposer.compose(opening.visualAssets());
         if (imagePrompt == null || imagePrompt.isBlank()) {
-            imagePrompt = "mysterious atmosphere, " + request.worldSetting();
+            imagePrompt = imagePromptComposer.composeFallback(request.worldSetting());
         }
         validateImagePrompt(imagePrompt);
         ImageAssetService.AssetReference imageAsset = imageAssetService.issue(imagePrompt, "16:9");

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,6 +12,18 @@ game.cost.rate-limit.window-seconds=${GAME_COST_RATE_LIMIT_WINDOW_SECONDS:60}
 game.cost.rate-limit.narrative-limit=${GAME_COST_NARRATIVE_LIMIT:12}
 game.cost.rate-limit.image-limit=${GAME_COST_IMAGE_LIMIT:8}
 
+game.image.model=${GAME_IMAGE_MODEL:flux}
+game.image.width=${GAME_IMAGE_WIDTH:1024}
+game.image.height=${GAME_IMAGE_HEIGHT:576}
+game.image.square-size=${GAME_IMAGE_SQUARE_SIZE:768}
+game.image.safe=${GAME_IMAGE_SAFE:true}
+game.image.style-version=${GAME_IMAGE_STYLE_VERSION:uctale-charcoal-v1}
+game.image.connect-timeout-ms=${GAME_IMAGE_CONNECT_TIMEOUT_MS:10000}
+game.image.read-timeout-ms=${GAME_IMAGE_READ_TIMEOUT_MS:120000}
+game.image.max-retries=${GAME_IMAGE_MAX_RETRIES:2}
+game.image.retry-base-delay-ms=${GAME_IMAGE_RETRY_BASE_DELAY_MS:250}
+game.image.max-response-bytes=${GAME_IMAGE_MAX_RESPONSE_BYTES:8388608}
+
 spring.datasource.url=${DATABASE_URL}
 spring.datasource.username=${DATABASE_USERNAME}
 spring.datasource.password=${DATABASE_PASSWORD}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,9 +13,9 @@ game.cost.rate-limit.narrative-limit=${GAME_COST_NARRATIVE_LIMIT:12}
 game.cost.rate-limit.image-limit=${GAME_COST_IMAGE_LIMIT:8}
 
 game.image.model=${GAME_IMAGE_MODEL:flux}
-game.image.width=${GAME_IMAGE_WIDTH:1024}
-game.image.height=${GAME_IMAGE_HEIGHT:576}
-game.image.square-size=${GAME_IMAGE_SQUARE_SIZE:768}
+game.image.width=${GAME_IMAGE_WIDTH:768}
+game.image.height=${GAME_IMAGE_HEIGHT:432}
+game.image.square-size=${GAME_IMAGE_SQUARE_SIZE:512}
 game.image.safe=${GAME_IMAGE_SAFE:true}
 game.image.style-version=${GAME_IMAGE_STYLE_VERSION:uctale-charcoal-v1}
 game.image.connect-timeout-ms=${GAME_IMAGE_CONNECT_TIMEOUT_MS:10000}

--- a/src/main/resources/db/migration/V5__add_image_generation_contract.sql
+++ b/src/main/resources/db/migration/V5__add_image_generation_contract.sql
@@ -1,0 +1,21 @@
+ALTER TABLE image_asset ADD COLUMN model varchar(64);
+ALTER TABLE image_asset ADD COLUMN width integer;
+ALTER TABLE image_asset ADD COLUMN height integer;
+ALTER TABLE image_asset ADD COLUMN seed integer;
+ALTER TABLE image_asset ADD COLUMN safe boolean;
+ALTER TABLE image_asset ADD COLUMN style_version varchar(64);
+
+UPDATE image_asset
+SET model = 'flux',
+    width = CASE WHEN aspect_ratio = '1:1' THEN 512 ELSE 768 END,
+    height = CASE WHEN aspect_ratio = '1:1' THEN 512 ELSE 432 END,
+    seed = 0,
+    safe = true,
+    style_version = 'uctale-charcoal-v1';
+
+ALTER TABLE image_asset ALTER COLUMN model SET NOT NULL;
+ALTER TABLE image_asset ALTER COLUMN width SET NOT NULL;
+ALTER TABLE image_asset ALTER COLUMN height SET NOT NULL;
+ALTER TABLE image_asset ALTER COLUMN seed SET NOT NULL;
+ALTER TABLE image_asset ALTER COLUMN safe SET NOT NULL;
+ALTER TABLE image_asset ALTER COLUMN style_version SET NOT NULL;

--- a/src/test/java/com/uctale/uctale/application/cost/ProviderCallTelemetryTest.java
+++ b/src/test/java/com/uctale/uctale/application/cost/ProviderCallTelemetryTest.java
@@ -61,6 +61,29 @@ class ProviderCallTelemetryTest {
         });
     }
 
+    @Test
+    @DisplayName("호출 결과에서 실제 retry 횟수를 추출해 event에 기록할 수 있다")
+    void retryCount_CanBeExtractedFromResult() {
+        MutableClock clock = new MutableClock(Instant.parse("2026-08-30T06:00:00Z"));
+        List<ProviderCallEvent> events = new ArrayList<>();
+        ProviderCallTelemetry telemetry = new ProviderCallTelemetry(clock, events::add);
+        CostRequestContext context = CostRequestContext.internal("owner-a", 42L, 2);
+
+        RetryAwareResult result = telemetry.observe(
+                "pollinations",
+                "image_generation",
+                context,
+                () -> new RetryAwareResult("ok", 2),
+                RetryAwareResult::retryCount,
+                ignored -> 0
+        );
+
+        assertThat(result.value()).isEqualTo("ok");
+        assertThat(events).singleElement().satisfies(event -> assertThat(event.retryCount()).isEqualTo(2));
+    }
+
+    private record RetryAwareResult(String value, int retryCount) {}
+
     private static final class MutableClock extends Clock {
         private Instant instant;
 

--- a/src/test/java/com/uctale/uctale/application/game/GamePersistenceServiceTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/GamePersistenceServiceTest.java
@@ -33,17 +33,11 @@ class GamePersistenceServiceTest {
     @DisplayName("새 게임 세션은 생성 owner에게 귀속되고 동일 owner만 조회·진행할 수 있다")
     void sessionOwnership_IsEnforcedAcrossReadAndWrite() {
         GameSession session = gamePersistenceService.saveOpening(
-                OWNER_A,
-                "세계관",
-                "캐릭터",
-                "첫 이야기",
-                "[{\"id\":1,\"text\":\"진행\"}]",
-                null
+                OWNER_A, "세계관", "캐릭터", "첫 이야기", "[{\"id\":1,\"text\":\"진행\"}]", null
         );
 
         assertThat(gameSessionRepository.findById(session.getId()).orElseThrow().getOwnerKey()).isEqualTo(OWNER_A);
         assertThat(gamePersistenceService.loadLatestTurn(OWNER_A, session.getId(), 1).sessionId()).isEqualTo(session.getId());
-
         assertThatThrownBy(() -> gamePersistenceService.loadLatestTurn(OWNER_B, session.getId(), 1))
                 .isInstanceOf(GameSessionNotFoundException.class);
         assertThatThrownBy(() -> gamePersistenceService.saveNextTurn(
@@ -51,13 +45,8 @@ class GamePersistenceServiceTest {
         )).isInstanceOf(GameSessionNotFoundException.class);
 
         int savedTurn = gamePersistenceService.saveNextTurn(
-                OWNER_A,
-                session.getId(),
-                1,
-                "진행",
-                "두 번째 이야기",
-                "[{\"id\":1,\"text\":\"계속\"}]",
-                null
+                OWNER_A, session.getId(), 1, "진행", "두 번째 이야기",
+                "[{\"id\":1,\"text\":\"계속\"}]", null
         );
 
         assertThat(savedTurn).isEqualTo(2);
@@ -66,13 +55,12 @@ class GamePersistenceServiceTest {
     }
 
     @Test
-    @DisplayName("image asset은 세션과 turn에 연결되고 GameLog에는 서버 발급 URL만 저장된다")
-    void imageAsset_IsPersistedWithSessionAndTurn() {
+    @DisplayName("image asset은 생성 model/size/seed/safe/style을 turn과 함께 영속화한다")
+    void imageAsset_IsPersistedWithFrozenGenerationContract() {
         ImageAssetService.AssetReference reference = new ImageAssetService.AssetReference(
                 "11111111-1111-1111-1111-111111111111",
                 "/api/game/image-assets/11111111-1111-1111-1111-111111111111",
-                "dark street, zombie",
-                "16:9"
+                "dark street, zombie", "16:9", "flux", 1024, 576, 12345, true, "uctale-charcoal-v1"
         );
 
         GameSession session = gamePersistenceService.saveOpening(
@@ -83,6 +71,12 @@ class GamePersistenceServiceTest {
         assertThat(asset.getGameSession().getId()).isEqualTo(session.getId());
         assertThat(asset.getTurnNumber()).isEqualTo(1);
         assertThat(asset.getPrompt()).isEqualTo("dark street, zombie");
+        assertThat(asset.getModel()).isEqualTo("flux");
+        assertThat(asset.getWidth()).isEqualTo(1024);
+        assertThat(asset.getHeight()).isEqualTo(576);
+        assertThat(asset.getSeed()).isEqualTo(12345);
+        assertThat(asset.isSafe()).isTrue();
+        assertThat(asset.getStyleVersion()).isEqualTo("uctale-charcoal-v1");
         assertThat(gamePersistenceService.loadLatestTurn(OWNER_A, session.getId(), 1).imageUrl())
                 .isEqualTo(reference.publicUrl());
     }

--- a/src/test/java/com/uctale/uctale/application/game/ImagePromptComposerTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/ImagePromptComposerTest.java
@@ -1,0 +1,77 @@
+package com.uctale.uctale.application.game;
+
+import com.uctale.uctale.application.narrative.NarrativeTurn;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ImagePromptComposerTest {
+
+    private final ImagePromptComposer composer = new ImagePromptComposer();
+
+    @Test
+    @DisplayName("대표 장면 fixture 16개는 같은 입력에서 항상 같은 prompt를 만든다")
+    void representativeFixtures_AreDeterministic() {
+        List<NarrativeTurn.VisualAssets> fixtures = List.of(
+                assets("subway platform", List.of("office worker"), List.of("briefcase")),
+                assets("sunlit classroom", List.of("student"), List.of("notebook")),
+                assets("rainy alley", List.of("detective"), List.of("umbrella")),
+                assets("forest clearing", List.of("giant wolf"), List.of()),
+                assets("castle hall", List.of("knight", "mage"), List.of("broken shield")),
+                assets("abandoned mall", List.of("zombie horde"), List.of("shopping cart")),
+                assets("rooftop at night", List.of("sniper"), List.of("radio")),
+                assets("quiet apartment", List.of("elderly npc"), List.of("tea cup")),
+                assets("underground arena", List.of("fighter", "armored monster"), List.of("spear")),
+                assets("ancient shrine", List.of(), List.of("glowing relic")),
+                assets("snowy mountain pass", List.of("traveler"), List.of("map")),
+                assets("bright seaside town", List.of("merchant", "child"), List.of("fruit stand")),
+                assets("dark laboratory", List.of("scientist"), List.of("sealed capsule")),
+                assets("burning battlefield", List.of("soldier", "dragon"), List.of("banner")),
+                assets("train interior", List.of("passenger", "conductor"), List.of("ticket")),
+                assets("desert ruins", List.of("explorer"), List.of("ancient key"))
+        );
+
+        assertThat(fixtures).hasSizeBetween(15, 20);
+        for (NarrativeTurn.VisualAssets fixture : fixtures) {
+            String first = composer.compose(fixture);
+            String second = composer.compose(fixture);
+            assertThat(first).isEqualTo(second);
+            assertThat(first).contains("atmosphere:", "composition:", "style[uctale-charcoal-v1]");
+            assertThat(first.length()).isLessThanOrEqualTo(1_800);
+        }
+    }
+
+    @Test
+    @DisplayName("prompt는 중복과 공백을 제거하고 고정 순서의 golden 문자열을 만든다")
+    void compose_GoldenPrompt() {
+        NarrativeTurn.VisualAssets assets = assets(
+                "  ruined   station  ",
+                List.of("Hunter", " hunter ", "Black wolf"),
+                List.of("rusted sword", "RUSTED SWORD")
+        );
+
+        assertThat(composer.compose(assets)).isEqualTo(
+                "subjects: Hunter, Black wolf; objects: rusted sword; setting: ruined station; "
+                        + "atmosphere: dramatic storybook scene; "
+                        + "composition: clear focal point, readable silhouettes, cinematic depth; "
+                        + "style[uctale-charcoal-v1]: rough charcoal sketch, high contrast black and white, "
+                        + "gritty paper texture, expressive pencil strokes, no colors, story concept art"
+        );
+    }
+
+    @Test
+    @DisplayName("시각 요소가 없으면 null이고 fallback도 동일 style 계약을 사용한다")
+    void emptyAssets_AndFallback() {
+        assertThat(composer.compose(assets(" ", List.of(), List.of()))).isNull();
+        assertThat(composer.composeFallback("zombie apocalypse"))
+                .startsWith("setting: zombie apocalypse;")
+                .contains("style[uctale-charcoal-v1]");
+    }
+
+    private NarrativeTurn.VisualAssets assets(String background, List<String> characters, List<String> objects) {
+        return new NarrativeTurn.VisualAssets(background, characters, objects);
+    }
+}

--- a/src/test/java/com/uctale/uctale/application/game/ImagePromptComposerTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/ImagePromptComposerTest.java
@@ -34,7 +34,7 @@ class ImagePromptComposerTest {
                 assets("desert ruins", List.of("explorer"), List.of("ancient key"))
         );
 
-        assertThat(fixtures).hasSizeBetween(15, 20);
+        assertThat(fixtures).hasSize(16);
         for (NarrativeTurn.VisualAssets fixture : fixtures) {
             String first = composer.compose(fixture);
             String second = composer.compose(fixture);

--- a/src/test/java/com/uctale/uctale/application/image/ImageAssetServiceCostControlTest.java
+++ b/src/test/java/com/uctale/uctale/application/image/ImageAssetServiceCostControlTest.java
@@ -38,12 +38,13 @@ class ImageAssetServiceCostControlTest {
     @Mock private ImageGenerator imageGenerator;
     @Mock private CostRateLimiter rateLimiter;
     @Mock private ProviderCallTelemetry telemetry;
+    @Mock private ImageGenerationPolicy generationPolicy;
 
     private ImageAssetService service;
 
     @BeforeEach
     void setUp() {
-        service = new ImageAssetService(repository, imageGenerator, rateLimiter, telemetry);
+        service = new ImageAssetService(repository, imageGenerator, rateLimiter, telemetry, generationPolicy);
     }
 
     @Test
@@ -59,7 +60,7 @@ class ImageAssetServiceCostControlTest {
 
         assertThat(result.bytes()).containsExactly(1, 2, 3);
         verify(rateLimiter, never()).check(any(), any());
-        verify(imageGenerator, never()).fetchImage(any(), any());
+        verify(imageGenerator, never()).fetchImage(any(ImageGenerator.GenerationRequest.class));
         verifyNoInteractions(telemetry);
     }
 
@@ -75,13 +76,32 @@ class ImageAssetServiceCostControlTest {
                 new CostRequestContext("r2", OWNER_KEY, "1.2.3.4", null, null, null), "asset-2"
         )).isInstanceOf(RateLimitExceededException.class);
 
-        verify(imageGenerator, never()).fetchImage(any(), any());
+        verify(imageGenerator, never()).fetchImage(any(ImageGenerator.GenerationRequest.class));
         verifyNoInteractions(telemetry);
+    }
+
+    @Test
+    @DisplayName("provider 최종 실패는 canonical turn과 분리된 정적 placeholder로 degrade한다")
+    void providerFailure_ReturnsPlaceholder() {
+        ImageAsset asset = asset("asset-3");
+        given(repository.findByIdAndGameSessionOwnerKey("asset-3", OWNER_KEY)).willReturn(Optional.of(asset));
+        given(telemetry.observe(eq("pollinations"), eq("image_generation"), any(), eq(0), any()))
+                .willThrow(new ImageGenerationException("provider failed"));
+
+        ImageAssetService.GeneratedAsset result = service.getOrGenerate(
+                new CostRequestContext("r3", OWNER_KEY, "1.2.3.4", null, null, null), "asset-3"
+        );
+
+        assertThat(result.contentType().toString()).isEqualTo("image/svg+xml");
+        assertThat(new String(result.bytes())).contains("UCTale scene unavailable");
+        verify(repository, never()).saveAndFlush(any());
     }
 
     private ImageAsset asset(String id) {
         GameSession session = new GameSession(OWNER_KEY, "world", "character");
         ReflectionTestUtils.setField(session, "id", 42L);
-        return new ImageAsset(id, session, 1, "prompt", "16:9");
+        return new ImageAsset(
+                id, session, 1, "prompt", "16:9", "flux", 1024, 576, 123, true, "uctale-charcoal-v1"
+        );
     }
 }

--- a/src/test/java/com/uctale/uctale/application/image/ImageAssetServiceCostControlTest.java
+++ b/src/test/java/com/uctale/uctale/application/image/ImageAssetServiceCostControlTest.java
@@ -17,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.Clock;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,7 +28,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
 class ImageAssetServiceCostControlTest {
@@ -37,13 +37,13 @@ class ImageAssetServiceCostControlTest {
     @Mock private ImageAssetRepository repository;
     @Mock private ImageGenerator imageGenerator;
     @Mock private CostRateLimiter rateLimiter;
-    @Mock private ProviderCallTelemetry telemetry;
     @Mock private ImageGenerationPolicy generationPolicy;
 
     private ImageAssetService service;
 
     @BeforeEach
     void setUp() {
+        ProviderCallTelemetry telemetry = new ProviderCallTelemetry(Clock.systemUTC(), event -> {});
         service = new ImageAssetService(repository, imageGenerator, rateLimiter, telemetry, generationPolicy);
     }
 
@@ -61,7 +61,6 @@ class ImageAssetServiceCostControlTest {
         assertThat(result.bytes()).containsExactly(1, 2, 3);
         verify(rateLimiter, never()).check(any(), any());
         verify(imageGenerator, never()).fetchImage(any(ImageGenerator.GenerationRequest.class));
-        verifyNoInteractions(telemetry);
     }
 
     @Test
@@ -77,7 +76,6 @@ class ImageAssetServiceCostControlTest {
         )).isInstanceOf(RateLimitExceededException.class);
 
         verify(imageGenerator, never()).fetchImage(any(ImageGenerator.GenerationRequest.class));
-        verifyNoInteractions(telemetry);
     }
 
     @Test
@@ -85,7 +83,7 @@ class ImageAssetServiceCostControlTest {
     void providerFailure_ReturnsPlaceholder() {
         ImageAsset asset = asset("asset-3");
         given(repository.findByIdAndGameSessionOwnerKey("asset-3", OWNER_KEY)).willReturn(Optional.of(asset));
-        given(telemetry.observe(eq("pollinations"), eq("image_generation"), any(), eq(0), any()))
+        given(imageGenerator.fetchImage(any(ImageGenerator.GenerationRequest.class)))
                 .willThrow(new ImageGenerationException("provider failed"));
 
         ImageAssetService.GeneratedAsset result = service.getOrGenerate(

--- a/src/test/java/com/uctale/uctale/application/image/ImageGenerationPolicyTest.java
+++ b/src/test/java/com/uctale/uctale/application/image/ImageGenerationPolicyTest.java
@@ -1,0 +1,46 @@
+package com.uctale.uctale.application.image;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.security.SecureRandom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ImageGenerationPolicyTest {
+
+    @Test
+    @DisplayName("asset 발급 시 model/size/safe/style과 seed를 한 번 확정한다")
+    void issue_FreezesGenerationSpec() {
+        SecureRandom random = new SecureRandom() {
+            @Override
+            public int nextInt(int bound) {
+                return 123456;
+            }
+        };
+        ImageGenerationPolicy policy = new ImageGenerationPolicy(
+                "flux", 1024, 576, 768, true, "uctale-charcoal-v1", random
+        );
+
+        ImageGenerationPolicy.GenerationSpec landscape = policy.issue("16:9");
+        ImageGenerationPolicy.GenerationSpec square = policy.issue("1:1");
+
+        assertThat(landscape.model()).isEqualTo("flux");
+        assertThat(landscape.width()).isEqualTo(1024);
+        assertThat(landscape.height()).isEqualTo(576);
+        assertThat(landscape.seed()).isEqualTo(123456);
+        assertThat(landscape.safe()).isTrue();
+        assertThat(landscape.styleVersion()).isEqualTo("uctale-charcoal-v1");
+        assertThat(square.width()).isEqualTo(768);
+        assertThat(square.height()).isEqualTo(768);
+    }
+
+    @Test
+    @DisplayName("잘못된 이미지 크기 설정은 애플리케이션 시작 전에 거부한다")
+    void invalidDimension_IsRejected() {
+        assertThatThrownBy(() -> new ImageGenerationPolicy(
+                "flux", 32, 576, 768, true, "uctale-charcoal-v1", new SecureRandom()
+        )).isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/uctale/uctale/application/image/ImageGenerationPolicyTest.java
+++ b/src/test/java/com/uctale/uctale/application/image/ImageGenerationPolicyTest.java
@@ -20,27 +20,27 @@ class ImageGenerationPolicyTest {
             }
         };
         ImageGenerationPolicy policy = new ImageGenerationPolicy(
-                "flux", 1024, 576, 768, true, "uctale-charcoal-v1", random
+                "flux", 768, 432, 512, true, "uctale-charcoal-v1", random
         );
 
         ImageGenerationPolicy.GenerationSpec landscape = policy.issue("16:9");
         ImageGenerationPolicy.GenerationSpec square = policy.issue("1:1");
 
         assertThat(landscape.model()).isEqualTo("flux");
-        assertThat(landscape.width()).isEqualTo(1024);
-        assertThat(landscape.height()).isEqualTo(576);
+        assertThat(landscape.width()).isEqualTo(768);
+        assertThat(landscape.height()).isEqualTo(432);
         assertThat(landscape.seed()).isEqualTo(123456);
         assertThat(landscape.safe()).isTrue();
         assertThat(landscape.styleVersion()).isEqualTo("uctale-charcoal-v1");
-        assertThat(square.width()).isEqualTo(768);
-        assertThat(square.height()).isEqualTo(768);
+        assertThat(square.width()).isEqualTo(512);
+        assertThat(square.height()).isEqualTo(512);
     }
 
     @Test
     @DisplayName("잘못된 이미지 크기 설정은 애플리케이션 시작 전에 거부한다")
     void invalidDimension_IsRejected() {
         assertThatThrownBy(() -> new ImageGenerationPolicy(
-                "flux", 32, 576, 768, true, "uctale-charcoal-v1", new SecureRandom()
+                "flux", 32, 432, 512, true, "uctale-charcoal-v1", new SecureRandom()
         )).isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/com/uctale/uctale/controller/GameOwnershipApiIntegrationTest.java
+++ b/src/test/java/com/uctale/uctale/controller/GameOwnershipApiIntegrationTest.java
@@ -159,7 +159,7 @@ class GameOwnershipApiIntegrationTest {
         private final AtomicInteger calls = new AtomicInteger();
 
         @Override
-        public GeneratedImage fetchImage(String prompt, String aspectRatio) {
+        public GeneratedImage fetchImage(GenerationRequest request) {
             calls.incrementAndGet();
             return new GeneratedImage("fake-image".getBytes(StandardCharsets.UTF_8), MediaType.IMAGE_JPEG);
         }

--- a/src/test/java/com/uctale/uctale/provider/image/PollinationsImageAdapterTest.java
+++ b/src/test/java/com/uctale/uctale/provider/image/PollinationsImageAdapterTest.java
@@ -91,8 +91,13 @@ class PollinationsImageAdapterTest {
             mockServer.expect(requestTo(url(seed))).andRespond(withStatus(HttpStatus.valueOf(status))
                     .contentType(MediaType.APPLICATION_JSON)
                     .body(error(status, "PERMANENT_" + status, "req-" + status)));
+        }
 
-            assertThatThrownBy(() -> adapter(2, 8_388_608).fetchImage(request(seed)))
+        PollinationsImageAdapter adapter = adapter(2, 8_388_608);
+        for (int i = 0; i < statuses.length; i++) {
+            int status = statuses[i];
+            int seed = 900 + i;
+            assertThatThrownBy(() -> adapter.fetchImage(request(seed)))
                     .isInstanceOf(PollinationsProviderException.class)
                     .satisfies(error -> assertThat(((PollinationsProviderException) error).status()).isEqualTo(status));
         }
@@ -103,14 +108,14 @@ class PollinationsImageAdapterTest {
     @DisplayName("빈 body와 허용되지 않은 MIME, 최대 크기 초과 응답을 거부한다")
     void invalidResponses_AreRejected() {
         mockServer.expect(requestTo(url(1001))).andRespond(withSuccess(new byte[0], MediaType.IMAGE_JPEG));
-        assertThatThrownBy(() -> adapter(0, 100).fetchImage(request(1001)))
-                .isInstanceOf(ImageGenerationException.class);
-
         mockServer.expect(requestTo(url(1002))).andRespond(withSuccess("not-image", MediaType.TEXT_PLAIN));
-        assertThatThrownBy(() -> adapter(0, 100).fetchImage(request(1002)))
-                .isInstanceOf(ImageGenerationException.class);
-
         mockServer.expect(requestTo(url(1003))).andRespond(withSuccess("1234", MediaType.IMAGE_PNG));
+
+        PollinationsImageAdapter normalLimitAdapter = adapter(0, 100);
+        assertThatThrownBy(() -> normalLimitAdapter.fetchImage(request(1001)))
+                .isInstanceOf(ImageGenerationException.class);
+        assertThatThrownBy(() -> normalLimitAdapter.fetchImage(request(1002)))
+                .isInstanceOf(ImageGenerationException.class);
         assertThatThrownBy(() -> adapter(0, 3).fetchImage(request(1003)))
                 .isInstanceOf(ImageGenerationException.class);
 

--- a/src/test/java/com/uctale/uctale/provider/image/PollinationsImageAdapterTest.java
+++ b/src/test/java/com/uctale/uctale/provider/image/PollinationsImageAdapterTest.java
@@ -1,0 +1,141 @@
+package com.uctale.uctale.provider.image;
+
+import com.uctale.uctale.application.image.ImageGenerationException;
+import com.uctale.uctale.application.image.ImageGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class PollinationsImageAdapterTest {
+
+    private RestClient.Builder builder;
+    private MockRestServiceServer mockServer;
+
+    @BeforeEach
+    void setUp() {
+        builder = RestClient.builder();
+        mockServer = MockRestServiceServer.bindTo(builder).build();
+    }
+
+    @Test
+    @DisplayName("secret은 Bearer header로만 전달하고 model/size/seed/safe를 명시한다")
+    void requestContract_UsesBearerAndExplicitGenerationParams() {
+        PollinationsImageAdapter adapter = adapter(0, 8_388_608);
+        String url = url(123);
+        mockServer.expect(requestTo(url))
+                .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer TEST_TOKEN"))
+                .andRespond(withSuccess("image", MediaType.IMAGE_JPEG));
+
+        ImageGenerator.GeneratedImage image = adapter.fetchImage(request(123));
+
+        assertThat(image.contentType()).isEqualTo(MediaType.IMAGE_JPEG);
+        assertThat(url).doesNotContain("key=", "nologo");
+        mockServer.verify();
+    }
+
+    @Test
+    @DisplayName("429는 Retry-After를 따르며 동일 URL과 seed로 bounded retry한다")
+    void rateLimited_RetriesSameRequest() {
+        PollinationsImageAdapter adapter = adapter(1, 8_388_608);
+        String url = url(456);
+        mockServer.expect(requestTo(url))
+                .andRespond(withStatus(HttpStatus.TOO_MANY_REQUESTS)
+                        .header(HttpHeaders.RETRY_AFTER, "0")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(error(429, "RATE_LIMITED", "req-429")));
+        mockServer.expect(requestTo(url))
+                .andRespond(withSuccess("image", MediaType.IMAGE_PNG));
+
+        ImageGenerator.GeneratedImage image = adapter.fetchImage(request(456));
+
+        assertThat(image.contentType()).isEqualTo(MediaType.IMAGE_PNG);
+        mockServer.verify();
+    }
+
+    @Test
+    @DisplayName("502와 503은 재시도 대상이다")
+    void transientProviderErrors_AreRetried() {
+        PollinationsImageAdapter adapter = adapter(2, 8_388_608);
+        String url = url(789);
+        mockServer.expect(requestTo(url)).andRespond(withStatus(HttpStatus.BAD_GATEWAY)
+                .contentType(MediaType.APPLICATION_JSON).body(error(502, "BAD_GATEWAY", "req-502")));
+        mockServer.expect(requestTo(url)).andRespond(withStatus(HttpStatus.SERVICE_UNAVAILABLE)
+                .header(HttpHeaders.RETRY_AFTER, "0")
+                .contentType(MediaType.APPLICATION_JSON).body(error(503, "SERVICE_UNAVAILABLE", "req-503")));
+        mockServer.expect(requestTo(url)).andRespond(withSuccess("image", MediaType.IMAGE_JPEG));
+
+        assertThat(adapter.fetchImage(request(789)).bytes()).isNotEmpty();
+        mockServer.verify();
+    }
+
+    @Test
+    @DisplayName("400/401/402/403/422는 자동 재시도하지 않는다")
+    void permanentErrors_AreNotRetried() {
+        int[] statuses = {400, 401, 402, 403, 422};
+        for (int i = 0; i < statuses.length; i++) {
+            int status = statuses[i];
+            int seed = 900 + i;
+            mockServer.expect(requestTo(url(seed))).andRespond(withStatus(HttpStatus.valueOf(status))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(error(status, "PERMANENT_" + status, "req-" + status)));
+
+            assertThatThrownBy(() -> adapter(2, 8_388_608).fetchImage(request(seed)))
+                    .isInstanceOf(PollinationsProviderException.class)
+                    .satisfies(error -> assertThat(((PollinationsProviderException) error).status()).isEqualTo(status));
+        }
+        mockServer.verify();
+    }
+
+    @Test
+    @DisplayName("빈 body와 허용되지 않은 MIME, 최대 크기 초과 응답을 거부한다")
+    void invalidResponses_AreRejected() {
+        mockServer.expect(requestTo(url(1001))).andRespond(withSuccess(new byte[0], MediaType.IMAGE_JPEG));
+        assertThatThrownBy(() -> adapter(0, 100).fetchImage(request(1001)))
+                .isInstanceOf(ImageGenerationException.class);
+
+        mockServer.expect(requestTo(url(1002))).andRespond(withSuccess("not-image", MediaType.TEXT_PLAIN));
+        assertThatThrownBy(() -> adapter(0, 100).fetchImage(request(1002)))
+                .isInstanceOf(ImageGenerationException.class);
+
+        mockServer.expect(requestTo(url(1003))).andRespond(withSuccess("1234", MediaType.IMAGE_PNG));
+        assertThatThrownBy(() -> adapter(0, 3).fetchImage(request(1003)))
+                .isInstanceOf(ImageGenerationException.class);
+
+        mockServer.verify();
+    }
+
+    private PollinationsImageAdapter adapter(int maxRetries, int maxBytes) {
+        return new PollinationsImageAdapter(
+                new ObjectMapper(), builder.build(), "TEST_TOKEN", maxRetries, 0, maxBytes, millis -> {}
+        );
+    }
+
+    private ImageGenerator.GenerationRequest request(int seed) {
+        return new ImageGenerator.GenerationRequest(
+                "castle gate", "flux", 1024, 576, seed, true, "uctale-charcoal-v1"
+        );
+    }
+
+    private String url(int seed) {
+        return "https://gen.pollinations.ai/image/castle%20gate?model=flux&width=1024&height=576&seed="
+                + seed + "&safe=true";
+    }
+
+    private String error(int status, String code, String requestId) {
+        return "{\"status\":" + status + ",\"success\":false,\"error\":{\"code\":\"" + code
+                + "\",\"message\":\"failed\",\"requestId\":\"" + requestId + "\"}}";
+    }
+}

--- a/src/test/java/com/uctale/uctale/service/GameServiceTest.java
+++ b/src/test/java/com/uctale/uctale/service/GameServiceTest.java
@@ -56,10 +56,7 @@ class GameServiceTest {
         choiceCodec = new ChoiceCodec(new ObjectMapper());
         Clock clock = Clock.systemUTC();
         gameService = new GameService(
-                narrativeGenerator,
-                imageAssetService,
-                gamePersistenceService,
-                choiceCodec,
+                narrativeGenerator, imageAssetService, gamePersistenceService, choiceCodec,
                 new ImagePromptComposer(),
                 new CostRateLimiter(new CostRateLimitPolicy(1_000, 1_000, 60), clock),
                 new ProviderCallTelemetry(clock, event -> {})
@@ -67,7 +64,7 @@ class GameServiceTest {
     }
 
     @Test
-    @DisplayName("게임 초기화는 서버 발급 image asset을 owner 세션 저장에 전달한다")
+    @DisplayName("게임 초기화는 versioned prompt로 서버 발급 image asset을 저장에 전달한다")
     void initGame_ReturnsFirstTurn() {
         GameInitRequest request = new GameInitRequest("좀비 아포칼립스", "김대리");
         NarrativeTurn opening = new NarrativeTurn(
@@ -78,11 +75,12 @@ class GameServiceTest {
         GameSession session = new GameSession(OWNER_KEY, request.worldSetting(), request.characterSetting());
         ReflectionTestUtils.setField(session, "id", 42L);
         ImageAssetService.AssetReference asset = new ImageAssetService.AssetReference(
-                "asset-id", "/api/game/image-assets/asset-id", "zombie, dark street", "16:9"
+                "asset-id", "/api/game/image-assets/asset-id", "prompt", "16:9",
+                "flux", 1024, 576, 123, true, "uctale-charcoal-v1"
         );
 
         given(narrativeGenerator.createOpening("좀비 아포칼립스", "김대리")).willReturn(opening);
-        given(imageAssetService.issue("zombie, dark street", "16:9")).willReturn(asset);
+        given(imageAssetService.issue(any(String.class), eq("16:9"))).willReturn(asset);
         given(gamePersistenceService.saveOpening(eq(OWNER_KEY), any(), any(), any(), any(), eq(asset))).willReturn(session);
 
         GameResponse response = gameService.initGame(OWNER_KEY, request);
@@ -90,7 +88,9 @@ class GameServiceTest {
         assertThat(response.sessionId()).isEqualTo(42L);
         assertThat(response.turnNumber()).isEqualTo(1);
         assertThat(response.mainImageUrl()).isEqualTo("/api/game/image-assets/asset-id");
-        verify(gamePersistenceService).saveOpening(eq(OWNER_KEY), any(), any(), any(), any(), eq(asset));
+        ArgumentCaptor<String> promptCaptor = ArgumentCaptor.forClass(String.class);
+        verify(imageAssetService).issue(promptCaptor.capture(), eq("16:9"));
+        assertThat(promptCaptor.getValue()).contains("subjects: zombie", "setting: dark street", "style[uctale-charcoal-v1]");
     }
 
     @Test


### PR DESCRIPTION
## 왜 필요한가요?

기존 Pollinations 연동은 provider 경계는 분리되어 있었지만 model/해상도/style이 코드에 고정되고, token이 query string으로 전달되며, retry 시 동일 생성 조건을 보장할 seed 계약과 provider 오류 분류가 없었습니다. 이미지 생성 실패가 장면 표시를 직접 실패시키는 구조도 운영 안정성 측면에서 보완이 필요했습니다.

- Closes #50

## 무엇이 바뀌나요?

### Server-issued image asset 생성 계약

- asset 발급 시 `model`, `width`, `height`, `seed`, `safe`, `styleVersion`을 한 번 확정합니다.
- V5 migration으로 생성 계약을 `image_asset`에 영속화합니다.
- 이미 발급된 asset은 이후 운영 설정이 바뀌어도 저장된 model/prompt/size/seed/safe/style로 재시도합니다.
- benchmark 결과에 따라 production 기본값은 `flux`, `768x432`를 유지합니다.
- 768px 원본을 데스크톱에서 800px까지 확대하던 CSS 최대 폭을 768px로 맞춥니다.

### Pollinations 요청 계약

- provider token을 query string에서 제거하고 `Authorization: Bearer` header로 전달합니다.
- `model`, `width`, `height`, `seed`, `safe`를 모든 요청에 명시합니다.
- 공식 최신 계약에 없는 `nologo` 옵션을 제거했습니다.
- connect/read timeout, max retry, retry delay, max response bytes를 환경설정으로 외부화했습니다.
- response는 non-empty JPEG/PNG와 최대 byte 크기를 검증합니다.

### 실패·재시도

- 네트워크/timeout, 429, 502, 503만 bounded retry합니다.
- 400, 401, 402, 403, 422는 동일 요청을 자동 retry하지 않습니다.
- `Retry-After` delta-seconds와 HTTP-date를 처리합니다.
- provider error의 code/requestId/Retry-After를 내부 진단 정보로 보존합니다.
- 최종 이미지 생성 실패 시 canonical game turn은 유지하고 정적 SVG placeholder를 반환합니다.
- asset은 미생성 상태로 남겨 이후 조회에서 다시 시도할 수 있습니다.

### Prompt / observability

- `ImagePromptComposer`를 subjects → objects → setting → atmosphere → composition → versioned charcoal style 순서의 deterministic composer로 변경했습니다.
- 공백/null/중복을 제거하고 prompt 길이를 제한합니다.
- raw prompt 대신 SHA-256 hash만 로그에 기록합니다.
- `image_provider_result`에 asset/session/turn, model/size/seed/style, latency, status/error code/requestId, MIME/bytes, 실제 retryCount를 기록합니다.
- #27의 `provider_call` telemetry에도 Pollinations 실제 retryCount를 전달하도록 확장했습니다.

### Benchmark 재현 도구

- 16개 대표 장면 fixture를 준비했습니다.
- `scripts/benchmark_pollinations_images.py`로 동일 prompt/seed에서 3개 model × 2개 resolution을 실행합니다.
- Python `urllib` 기본 User-Agent가 provider에서 403으로 차단되는 실측 문제를 확인해 명시적 User-Agent/Accept를 추가했습니다.
- 401/402/403은 fail-fast하고 provider 오류 본문은 민감정보를 제외해 진단할 수 있게 했습니다.
- raw latency/error/MIME/byte와 평균·P95/error rate를 기록합니다.

## 실제 benchmark 결과

2026-08-30 실제 Pollinations 계정으로 `16 fixtures × 3 models × 2 resolutions = 96` 요청을 실행했고 **96/96 성공**했습니다.

| Model | Resolution | Avg latency | P95 | Avg response | Error rate |
| --- | --- | ---: | ---: | ---: | ---: |
| flux | 768x432 | 7.63s | 9.36s | 210 KB | 0% |
| flux | 1024x576 | 8.13s | 9.15s | 323 KB | 0% |
| zimage | 768x432 | 8.13s | 8.95s | 155 KB | 0% |
| zimage | 1024x576 | 9.19s | 10.56s | 254 KB | 0% |
| dreamshaper | 768x432 | 6.53s | 7.45s | 46 KB | 0% |
| dreamshaper | 1024x576 | 6.42s | 7.15s | 47 KB | 0% |

모델/해상도 정보를 숨긴 A~F 시트로 다시 비교한 결과:

- **flux**: charcoal house style과 판타지/전투 장면 가독성의 균형이 가장 좋았습니다.
- **zimage**: 일상/공간 장면은 안정적이나 더 높은 단가와 지연을 상쇄할 만큼 일관된 품질 우위가 없었습니다.
- **dreamshaper**: 가장 빠르고 저렴하지만 cinematic/photorealistic 방향으로 치우쳐 UCTale charcoal style과 맞지 않았습니다.

실행 당시 registry 기준 96장 예상 비용은 약 `0.1952 Pollen`이었습니다.

### 최종 model / resolution 결정

production 기본값은 **`flux + 768x432` 유지**입니다.

- Flux 1024x576은 768x432 대비 평균 latency 약 6.6%, 평균 응답 크기 약 53.7% 증가했습니다.
- Z-Image 1024x576은 평균 latency 약 13.0%, 평균 응답 크기 약 64.0% 증가했습니다.
- 현재 프론트 최대 표시 폭이 768 CSS px이고 1024의 시각적 개선이 이 비용을 정당화할 정도로 크지 않았습니다.

세부 결과와 선택 근거는 `docs/benchmarks/pollinations-image-benchmark.md`에 기록했습니다.

## 설정

추가된 선택 환경변수:

- `GAME_IMAGE_MODEL` (default `flux`)
- `GAME_IMAGE_WIDTH` (default `768`)
- `GAME_IMAGE_HEIGHT` (default `432`)
- `GAME_IMAGE_SQUARE_SIZE` (default `512`)
- `GAME_IMAGE_SAFE` (default `true`)
- `GAME_IMAGE_STYLE_VERSION` (default `uctale-charcoal-v1`)
- `GAME_IMAGE_CONNECT_TIMEOUT_MS` (default `10000`)
- `GAME_IMAGE_READ_TIMEOUT_MS` (default `120000`)
- `GAME_IMAGE_MAX_RETRIES` (default `2`)
- `GAME_IMAGE_RETRY_BASE_DELAY_MS` (default `250`)
- `GAME_IMAGE_MAX_RESPONSE_BYTES` (default `8388608`)

새 secret은 없습니다. 기존 `POLLINATIONS_TOKEN`을 Bearer header로만 사용합니다.

## 자동 검증

- [x] server-issued asset에 생성 model/size/seed/safe/style 영속화 테스트
- [x] deterministic prompt golden test
- [x] 대표 장면 fixture 16개 결정성 테스트
- [x] Bearer auth + explicit model/size/seed/safe contract test
- [x] 동일 URL/seed 429 Retry-After 재시도 테스트
- [x] 502/503 retry 테스트
- [x] 400/401/402/403/422 no-retry 테스트
- [x] 빈 body / 잘못된 MIME / 최대 크기 초과 거부 테스트
- [x] provider 최종 실패 placeholder 회귀 테스트
- [x] 실제 retryCount의 공통 telemetry 전달 테스트
- [x] 외부 Pollinations 호출 없는 adapter contract test
- [x] 최종 PR CI (`Backend test and build`, `Frontend lint and build`) 성공

## 자체 비판적 리뷰 및 보완

PR 생성 전과 PR CI/실측 benchmark 과정에서 반복 검토했습니다.

1. **style version Spring 설정 선택 문제** → 설정 생성자를 명시적으로 autowire했습니다.
2. **Retry-After가 정수 초만 처리** → RFC HTTP-date도 처리했습니다.
3. **공통 telemetry retryCount가 0으로 남는 문제** → 실제 retry 횟수를 전달하도록 보완했습니다.
4. **asset/session/turn과 provider 진단을 한 이벤트에서 보기 어려움** → `image_provider_result`를 추가했습니다.
5. **benchmark 전 1024 기본값 변경은 근거 부족** → 768x432를 유지하고 CSS upscale만 제거했습니다.
6. **Spring 7 `ClientHttpResponse#getStatusCode()` IOException compile blocker** → 명시적으로 처리했습니다.
7. **provider URI String 재인코딩으로 `%20` → `%2520` 가능성** → String 대신 `URI`를 전달하도록 수정했습니다.
8. **Spring multiple constructor 선택 문제** → policy/adapter production 생성자를 명시했습니다.
9. **MockRestServiceServer expectation 등록 순서 오류** → 모든 expectation을 요청 전에 등록하도록 테스트를 수정했습니다.
10. **실제 benchmark에서 Python urllib 403 발견** → 명시적 User-Agent/Accept와 auth/billing fail-fast 진단을 추가했습니다.
11. **benchmark 결과 재검토** → 모델/해상도 이름을 숨긴 A~F 시트로 재평가했으며, 기본값 변경 근거가 부족함을 재확인했습니다.

현재 확인된 추가 merge blocker는 없습니다.

## 문서

- `docs/architecture/image-generation.md`
- `docs/architecture/cost-controls.md`
- `docs/benchmarks/pollinations-image-benchmark.md`