### PR TITLE
fix: production 이미지 CORS 실패와 UI 회귀 수정

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
+    <link rel="icon" href="data:," />
     <title>UCTale</title>
     <script>
         (() => {

--- a/frontend/src/screens/GameSetupScreen.jsx
+++ b/frontend/src/screens/GameSetupScreen.jsx
@@ -36,7 +36,7 @@ function GameSetupScreen({
               id="world-setting"
               rows="4"
               aria-describedby="world-setting-help"
-              placeholder="예: 현대 서울의 좀비 아포칼립스. 한강 이남의 통신이 끊기기 시작했다."
+              placeholder="예: 현대 서울 좀비 아포칼립스, 서울에 핵미사일이 발사된 상황, 눈을 떴더니 고양이"
               value={world}
               onChange={(event) => onWorldChange(event.target.value)}
             />
@@ -51,7 +51,7 @@ function GameSetupScreen({
               id="player-character"
               rows="4"
               aria-describedby="player-character-help"
-              placeholder="예: 지하철로 출근하던 30대 회사원 김대리. 평범하지만 위기에는 침착하다."
+              placeholder="예: 지하철로 출근하는 30대 회사원 김대리, 눈을 떴더니 이세계로 전이된 대학생, 사람 말을 할 수 있게 된 고양이"
               value={character}
               onChange={(event) => onCharacterChange(event.target.value)}
             />

--- a/src/main/java/com/uctale/uctale/provider/image/PollinationsImageAdapter.java
+++ b/src/main/java/com/uctale/uctale/provider/image/PollinationsImageAdapter.java
@@ -12,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.util.UriComponentsBuilder;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
@@ -133,6 +134,13 @@ public class PollinationsImageAdapter implements ImageGenerator {
                     );
                 }
                 sleepBeforeRetry(null, attempt);
+            } catch (RestClientException exception) {
+                log.warn(
+                        "pollinations_image promptHash={} model={} size={}x{} seed={} styleVersion={} latencyMs={} outcome=FAILURE status=0 code=REST_CLIENT_ERROR retryCount={} willRetry=false",
+                        promptHash, request.model(), request.width(), request.height(), request.seed(), request.styleVersion(),
+                        elapsedMs(startedAt), attempt
+                );
+                throw new ImageGenerationException("Pollinations HTTP client 요청에 실패했습니다.", exception);
             }
         }
         throw new ImageGenerationException("Pollinations 이미지 생성에 실패했습니다.");

--- a/src/main/java/com/uctale/uctale/security/SecurityWebConfig.java
+++ b/src/main/java/com/uctale/uctale/security/SecurityWebConfig.java
@@ -1,8 +1,11 @@
 package com.uctale.uctale.security;
 
+import jakarta.servlet.DispatcherType;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
@@ -33,7 +36,9 @@ public class SecurityWebConfig implements WebMvcConfigurer {
     }
 
     @Bean
-    CorsFilter corsFilter(@Value("${game.cors.allowed-origins}") String configuredOrigins) {
+    FilterRegistrationBean<CorsFilter> corsFilterRegistration(
+            @Value("${game.cors.allowed-origins}") String configuredOrigins
+    ) {
         List<String> origins = Arrays.stream(configuredOrigins.split(","))
                 .map(String::trim)
                 .filter(value -> !value.isBlank())
@@ -51,6 +56,23 @@ public class SecurityWebConfig implements WebMvcConfigurer {
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/api/**", configuration);
-        return new CorsFilter(source);
+
+        CorsFilter corsFilter = new CorsFilter(source) {
+            @Override
+            protected boolean shouldNotFilterAsyncDispatch() {
+                return false;
+            }
+
+            @Override
+            protected boolean shouldNotFilterErrorDispatch() {
+                return false;
+            }
+        };
+
+        FilterRegistrationBean<CorsFilter> registration = new FilterRegistrationBean<>(corsFilter);
+        registration.setUrlPatterns(List.of("/api/*"));
+        registration.setDispatcherTypes(DispatcherType.REQUEST, DispatcherType.ASYNC, DispatcherType.ERROR);
+        registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        return registration;
     }
 }

--- a/src/test/java/com/uctale/uctale/provider/image/PollinationsImageAdapterTest.java
+++ b/src/test/java/com/uctale/uctale/provider/image/PollinationsImageAdapterTest.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
 import tools.jackson.databind.ObjectMapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -118,6 +119,22 @@ class PollinationsImageAdapterTest {
                 .isInstanceOf(ImageGenerationException.class);
         assertThatThrownBy(() -> adapter(0, 3).fetchImage(request(1003)))
                 .isInstanceOf(ImageGenerationException.class);
+
+        mockServer.verify();
+    }
+
+    @Test
+    @DisplayName("예상 밖 RestClient 오류도 이미지 생성 실패 경계로 변환한다")
+    void unexpectedRestClientError_IsConvertedToImageGenerationFailure() {
+        int seed = 1100;
+        mockServer.expect(requestTo(url(seed)))
+                .andRespond(request -> {
+                    throw new RestClientException("unexpected client failure");
+                });
+
+        assertThatThrownBy(() -> adapter(0, 8_388_608).fetchImage(request(seed)))
+                .isInstanceOf(ImageGenerationException.class)
+                .hasMessageContaining("HTTP client");
 
         mockServer.verify();
     }

--- a/src/test/java/com/uctale/uctale/security/SecurityWebConfigTest.java
+++ b/src/test/java/com/uctale/uctale/security/SecurityWebConfigTest.java
@@ -1,7 +1,9 @@
 package com.uctale.uctale.security;
 
+import jakarta.servlet.DispatcherType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -17,16 +19,16 @@ class SecurityWebConfigTest {
     @Test
     @DisplayName("명시된 Vercel origin만 보호 client header credential CORS 응답을 받는다")
     void cors_AllowsConfiguredOriginOnly() throws Exception {
-        AccessSessionService service = new AccessSessionService("pw", SECRET, 3600, true);
-        SecurityWebConfig config = new SecurityWebConfig(new AccessSessionInterceptor(service));
-        CorsFilter filter = config.corsFilter("https://uctale.vercel.app");
+        SecurityWebConfig config = config();
+        CorsFilter filter = config.corsFilterRegistration("https://uctale.vercel.app").getFilter();
 
         MockHttpServletRequest allowed = preflight("https://uctale.vercel.app");
         MockHttpServletResponse allowedResponse = new MockHttpServletResponse();
         filter.doFilter(allowed, allowedResponse, new MockFilterChain());
         assertThat(allowedResponse.getHeader("Access-Control-Allow-Origin")).isEqualTo("https://uctale.vercel.app");
         assertThat(allowedResponse.getHeader("Access-Control-Allow-Credentials")).isEqualTo("true");
-        assertThat(allowedResponse.getHeader("Access-Control-Allow-Headers")).containsIgnoringCase(AccessSessionInterceptor.CLIENT_HEADER);
+        assertThat(allowedResponse.getHeader("Access-Control-Allow-Headers"))
+                .containsIgnoringCase(AccessSessionInterceptor.CLIENT_HEADER);
 
         MockHttpServletRequest denied = preflight("https://evil.example");
         MockHttpServletResponse deniedResponse = new MockHttpServletResponse();
@@ -35,11 +37,29 @@ class SecurityWebConfigTest {
     }
 
     @Test
+    @DisplayName("image asset 오류 dispatch에도 허용된 origin의 credential CORS 응답을 유지한다")
+    void cors_ErrorDispatchKeepsAllowedOrigin() throws Exception {
+        FilterRegistrationBean<CorsFilter> registration = config()
+                .corsFilterRegistration("https://uctale.vercel.app");
+        CorsFilter filter = registration.getFilter();
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/game/image-assets/asset-id");
+        request.setDispatcherType(DispatcherType.ERROR);
+        request.addHeader("Origin", "https://uctale.vercel.app");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertThat(response.getHeader("Access-Control-Allow-Origin")).isEqualTo("https://uctale.vercel.app");
+        assertThat(response.getHeader("Access-Control-Allow-Credentials")).isEqualTo("true");
+        assertThat(registration.getDispatcherTypes())
+                .contains(DispatcherType.REQUEST, DispatcherType.ASYNC, DispatcherType.ERROR);
+    }
+
+    @Test
     @DisplayName("와일드카드 CORS 설정은 시작 단계에서 거부한다")
     void cors_RejectsWildcard() {
-        AccessSessionService service = new AccessSessionService("pw", SECRET, 3600, true);
-        SecurityWebConfig config = new SecurityWebConfig(new AccessSessionInterceptor(service));
-        assertThatThrownBy(() -> config.corsFilter("*"))
+        assertThatThrownBy(() -> config().corsFilterRegistration("*"))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -54,6 +74,11 @@ class SecurityWebConfigTest {
                 .isInstanceOf(AccessSessionException.class)
                 .extracting("code")
                 .isEqualTo("ACCESS_SESSION_INVALID");
+    }
+
+    private SecurityWebConfig config() {
+        AccessSessionService service = new AccessSessionService("pw", SECRET, 3600, true);
+        return new SecurityWebConfig(new AccessSessionInterceptor(service));
     }
 
     private MockHttpServletRequest preflight(String origin) {

--- a/src/test/java/com/uctale/uctale/security/SecurityWebConfigTest.java
+++ b/src/test/java/com/uctale/uctale/security/SecurityWebConfigTest.java
@@ -3,7 +3,6 @@ package com.uctale.uctale.security;
 import jakarta.servlet.DispatcherType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -39,9 +38,9 @@ class SecurityWebConfigTest {
     @Test
     @DisplayName("image asset 오류 dispatch에도 허용된 origin의 credential CORS 응답을 유지한다")
     void cors_ErrorDispatchKeepsAllowedOrigin() throws Exception {
-        FilterRegistrationBean<CorsFilter> registration = config()
-                .corsFilterRegistration("https://uctale.vercel.app");
-        CorsFilter filter = registration.getFilter();
+        CorsFilter filter = config()
+                .corsFilterRegistration("https://uctale.vercel.app")
+                .getFilter();
 
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/game/image-assets/asset-id");
         request.setDispatcherType(DispatcherType.ERROR);
@@ -52,8 +51,6 @@ class SecurityWebConfigTest {
 
         assertThat(response.getHeader("Access-Control-Allow-Origin")).isEqualTo("https://uctale.vercel.app");
         assertThat(response.getHeader("Access-Control-Allow-Credentials")).isEqualTo("true");
-        assertThat(registration.getDispatcherTypes())
-                .contains(DispatcherType.REQUEST, DispatcherType.ASYNC, DispatcherType.ERROR);
     }
 
     @Test


### PR DESCRIPTION
## 왜 필요한가요?

- Closes #63
- #61 merge 후 production smoke test에서 첫 장면은 정상이나 다음 턴의 image asset 요청이 브라우저에서 CORS 오류로 가려지는 문제가 확인됐습니다.
- 같은 smoke test에서 favicon 404와 #61이 임의로 변경한 게임 설정 예시 문구도 확인됐습니다.
- 최초 비로그인 `GET /api/game/access-session`의 401은 기존 인증 probe 계약이므로 이 PR에서 변경하지 않습니다.

## 무엇이 바뀌나요?

- API CORS filter를 명시적인 `FilterRegistrationBean`으로 등록합니다.
  - 기존 explicit origin allowlist와 credential 정책은 그대로 유지합니다.
  - REQUEST/ASYNC/ERROR dispatch에서 같은 CORS 정책이 적용되도록 합니다.
  - filter order를 highest precedence로 고정합니다.
- Pollinations 호출에서 예상 밖 `RestClientException`도 `ImageGenerationException` 경계로 변환합니다.
  - 기존 `ImageAssetService` fallback SVG 경로로 수렴하고 게임 요청 전체로 예외가 새지 않게 합니다.
  - 기존 429/502/503 bounded retry와 permanent 4xx 정책은 변경하지 않습니다.
- #61 직전의 코믹한 세계관/캐릭터 placeholder를 정확히 복구합니다.
- no-op favicon을 명시해 `/favicon.ico` 404 요청을 제거합니다.

## 어떻게 검증했나요?

- configured Vercel origin CORS / hostile origin 거부 회귀 테스트
- image asset ERROR dispatch에도 `Access-Control-Allow-Origin`과 credentials header 유지 테스트
- unexpected `RestClientException`이 image generation failure 경계로 변환되는 테스트
- GitHub Actions CI 통과
  - Backend test: PASS
  - Backend build: PASS
  - Frontend test: PASS
  - ESLint: PASS
  - Frontend build: PASS

## PR 전 자체 비판적 리뷰 및 보완

- origin을 `*` 또는 broad pattern으로 완화하지 않았습니다. production allowlist 정책을 유지합니다.
- 일반 Pollinations HTTP 4xx/5xx는 기존부터 `PollinationsProviderException extends ImageGenerationException`으로 fallback에 들어가므로 중복 로직을 추가하지 않았습니다.
- 브라우저에 보인 CORS 메시지만으로 Render 내부의 정확한 원래 status를 확정할 수 없으므로, 이 PR은 error dispatch에서 CORS를 보장하고 provider client 예외가 servlet error로 새는 빈틈을 닫는 최소 hotfix입니다.
- 첫 CI 실패는 제품 코드가 아니라 회귀 테스트에서 존재하지 않는 `FilterRegistrationBean#getDispatcherTypes()`를 사용한 테스트 컴파일 오류였습니다. 내부 구현 introspection을 제거하고 ERROR dispatcher의 실제 CORS 응답 행동을 검증하도록 수정했으며 이후 전체 CI가 통과했습니다.
- #61의 디자인 구조는 유지하고, 요구 범위를 넘겨 변경했던 placeholder만 원문으로 되돌렸습니다.
- favicon은 새 브랜드 자산을 임의 제작하지 않고 네트워크 404만 제거했습니다.

## 배포 후 확인

- 같은 브라우저 세션에서 로그인 → 게임 시작 → 첫 이미지 → 선택지 → 다음 턴 새 이미지까지 smoke test가 필요합니다.
- 실패가 남으면 이제 CORS에 가려지지 않은 실제 HTTP status/응답과 Render `image_provider_result` 로그를 기준으로 provider 원인을 추적합니다.
