### PR TITLE
docs: M1 완료 상태와 M2 로드맵 최신화

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ UCTale은 사용자가 직접 입력한 세계관과 주인공 설정을 바탕�
 | 생성 이미지 예시 |
 | :---: |
 | <img src="./docs/images/monster.png" width="400"> |
-| Pollinations를 사용한 charcoal sketch 계열 이미지 |
+| Pollinations를 사용한 UCTale charcoal 계열 이미지 |
 
 ---
 
@@ -37,7 +37,7 @@ UCTale은 사용자가 직접 입력한 세계관과 주인공 설정을 바탕�
 3. 서버가 입력 내용을 바탕으로 첫 장면과 선택지를 생성합니다.
 4. 플레이어가 선택지를 고르면 다음 턴이 진행됩니다.
 5. 서버는 현재 턴과 게임 상태를 저장하고, 필요한 문맥만 Narrative Engine에 전달합니다.
-6. 시각적으로 표현할 장면이 있으면 별도의 이미지 생성 경로를 통해 삽화를 제공합니다.
+6. 시각적으로 표현할 장면이 있으면 서버가 발급한 image asset을 통해 삽화를 제공합니다.
 
 현재 플레이는 AI가 모든 게임 상태를 임의로 결정하는 방식이 아니라, 장기적으로 서버가 게임의 사실과 규칙을 소유하고 LLM은 그 결과를 이야기로 표현하는 구조를 목표로 개발하고 있습니다.
 
@@ -45,12 +45,15 @@ UCTale은 사용자가 직접 입력한 세계관과 주인공 설정을 바탕�
 
 ## 현재 구현된 내용
 
-### 공유 베타 접근 제어
+### 공유 베타 접근 제어와 세션 소유권
 
 - 비밀번호 검증 성공 시 서버가 서명한 단기 접근 세션을 HttpOnly 쿠키로 발급합니다.
-- 게임 시작, 턴 진행, 이미지 생성 API는 유효한 접근 세션이 있어야 호출할 수 있습니다.
+- 별도의 장기 owner key로 게임 세션 소유권을 서버와 DB에서 관리합니다.
+- 다른 owner는 session ID를 알아도 해당 세션을 조회하거나 진행할 수 없습니다.
+- 게임 시작, 턴 진행, 이미지 asset API는 유효한 접근 세션이 있어야 호출할 수 있습니다.
 - 운영 기본 CORS origin은 `https://uctale.vercel.app`만 허용하며, 허용 origin은 환경변수로 명시적으로 관리합니다.
 - 접근 세션이 만료되거나 유효하지 않으면 프론트엔드가 재인증 화면으로 전환합니다.
+- 공유 비밀번호 인증 실패는 별도의 IP 기반 rate limit으로 보호합니다.
 
 ### 이야기 생성과 선택지 진행
 
@@ -58,6 +61,7 @@ UCTale은 사용자가 직접 입력한 세계관과 주인공 설정을 바탕�
 - Gemini가 현재 문맥을 바탕으로 이야기와 다음 선택지를 생성합니다.
 - 클라이언트는 서버가 반환한 `sessionId`와 현재 턴을 기준으로 다음 진행 요청을 보냅니다.
 - 오래된 턴이나 중복 진행 요청은 서버에서 충돌로 처리합니다.
+- provider 응답의 필수 필드, 길이, 선택지 ID 중복 등을 저장 전에 검증합니다.
 
 ### GameState와 Story Memory
 
@@ -75,16 +79,39 @@ UCTale은 사용자가 직접 입력한 세계관과 주인공 설정을 바탕�
 
 ### 턴 저장과 무결성
 
-- 세션마다 현재 턴 번호와 version을 관리합니다.
+- 세션마다 현재 턴 번호와 optimistic-lock version을 관리합니다.
 - 진행 요청은 `expectedTurn`을 포함합니다.
 - 동일 세션에서 같은 턴이 중복 저장되지 않도록 DB 제약과 서버 검증을 함께 사용합니다.
-- AI 호출이 실패하면 불완전한 다음 턴이 저장되지 않도록 처리합니다.
+- AI 호출은 긴 DB transaction 밖에서 수행합니다.
+- AI 또는 저장 실패가 발생해도 불완전한 다음 턴이 남지 않도록 처리합니다.
+
+현재 M2에서는 여기서 더 나아가 idempotency key, turn reservation/lease, append-only committed-turn ledger와 PostgreSQL 동시성 회귀 검증을 추가하는 중입니다.
 
 ### 이미지 생성
 
 - Pollinations를 통해 게임 장면에 사용할 이미지를 생성합니다.
-- Provider 토큰은 서버 내부에서만 사용합니다.
-- 클라이언트에는 Provider 비밀값 대신 서버 이미지 경로를 전달합니다.
+- 클라이언트는 임의 prompt를 provider에 전달할 수 없고, 서버가 발급한 session/turn-scoped image asset만 요청할 수 있습니다.
+- Provider 토큰과 내부 URL은 서버 밖으로 노출하지 않습니다.
+- 동일 asset은 저장된 model, prompt, size, seed, style version을 재사용합니다.
+- 기본 정책은 `flux`, `768x432`, `uctale-charcoal-v2`이며 환경 설정으로 변경할 수 있습니다.
+- provider 오류가 발생해도 canonical game turn은 유지되고, 이전 이미지 또는 fallback으로 게임을 계속 진행할 수 있습니다.
+
+### 비용 보호와 관측성
+
+- Narrative와 Image 비용 API는 owner/IP/session 기준의 in-process rate limit을 적용합니다.
+- Narrative와 Image quota는 독립적으로 조정할 수 있습니다.
+- provider 호출마다 provider, operation, session, turn, request ID, latency, outcome, retry count를 구조화 로그로 기록합니다.
+- prompt/응답 전문, 비밀번호, API key, access/owner token은 관측 로그에 남기지 않습니다.
+- 현재 limiter는 단일 애플리케이션 인스턴스 기준이며 multi-instance 환경에서는 전역 quota를 보장하지 않습니다.
+
+### 프론트엔드 UX
+
+- Charcoal Folio 기반의 narrative-first single-column UI를 사용합니다.
+- `system | light | dark` 테마와 SUIT Variable typography를 지원합니다.
+- API 오류는 browser `alert()` 대신 화면 문맥 안에서 표시하고 가능한 경우 retry를 제공합니다.
+- 진행 중 중복 요청을 막고, typewriter skip 및 `prefers-reduced-motion`을 지원합니다.
+- image loading/failure, keyboard focus 이동, live-region 등 공유 베타용 accessibility behavior를 보강했습니다.
+- Vercel Web Analytics를 통해 production page view를 확인할 수 있습니다.
 
 ---
 
@@ -95,7 +122,7 @@ UCTale은 사용자가 직접 입력한 세계관과 주인공 설정을 바탕�
 | Frontend | React 19, React Router 7, Vite 8, Axios |
 | Backend | Java 21, Spring Boot 4.1, Spring Web MVC, Spring Data JPA |
 | Database | PostgreSQL, Flyway |
-| Test Database | H2 |
+| Test Database | H2, PostgreSQL integration test 도입 예정(M2) |
 | Narrative AI | Google Gemini 2.5 Flash |
 | Image AI | Pollinations |
 | Deployment | Vercel, Render |
@@ -113,6 +140,7 @@ uctale/
 │   └── db/                   # Flyway migration
 ├── src/test/                 # 백엔드 테스트
 ├── docs/                     # 설계 문서와 이미지
+├── scripts/                  # benchmark/검증 도구
 ├── build.gradle
 └── README.md
 ```
@@ -127,7 +155,7 @@ uctale/
 - Provider 오류나 중복 요청이 저장된 게임 상태를 훼손하지 않도록 합니다.
 - API Key와 토큰은 프론트엔드나 공개 응답에 포함하지 않습니다.
 
-자세한 개발 원칙은 [CONTRIBUTING.md](./CONTRIBUTING.md)와 [GameState / Story Memory 설계 문서](./docs/architecture/game-state-story-memory.md)에서 확인할 수 있습니다.
+자세한 개발 원칙은 [CONTRIBUTING.md](./CONTRIBUTING.md), [GameState / Story Memory 설계 문서](./docs/architecture/game-state-story-memory.md), [비용 보호 문서](./docs/architecture/cost-controls.md), [이미지 생성 문서](./docs/architecture/image-generation.md)에서 확인할 수 있습니다.
 
 ---
 
@@ -156,6 +184,8 @@ DATABASE_PASSWORD=...
 ```
 
 `GAME_ACCESS_COOKIE_SECURE=false`는 로컬 HTTP 개발용입니다. 운영에서는 기본값 `true`를 사용해 `Secure; SameSite=None` HttpOnly 쿠키를 발급합니다. 운영 CORS 기본값은 `https://uctale.vercel.app`이며, 다른 origin을 허용해야 할 때만 `GAME_CORS_ALLOWED_ORIGINS`를 쉼표로 구분해 명시합니다.
+
+비용/인증/이미지 정책의 세부 환경변수는 `src/main/resources/application.properties`와 관련 architecture 문서를 기준으로 관리합니다.
 
 ### 백엔드 실행
 
@@ -210,20 +240,46 @@ npm run lint
 npm run build
 ```
 
+M2의 #73에서 실제 PostgreSQL 의미론을 검증하는 별도 integration-test task와 CI 실행 경계를 추가할 예정입니다.
+
 ---
 
 ## 개발 현황
 
-현재는 기본적인 이야기 생성과 턴 진행에서 한 단계 더 나아가, 서버가 게임 규칙을 직접 관리할 수 있도록 내부 구조를 정리하고 있습니다.
+### M1 — 공유 베타 운영 안전망
 
-진행 중인 주요 작업은 다음과 같습니다.
+**완료.** production smoke test까지 통과한 상태입니다.
 
-- 공유 베타 게임 세션 소유권
-- AI 및 이미지 호출에 대한 비용 보호와 관측성
-- 턴 idempotency와 동시 요청 처리 강화
-- GameState snapshot 버전 관리
-- 서버 주도 `AvailableAction`, `PlayerAction`, `GameResult` 도입
-- 캐릭터 능력치와 Skill Check
-- 이후 전투, 인벤토리, 퀘스트, NPC 관계 시스템 확장
+M1에서 완료한 주요 범위:
 
-아직 구현되지 않은 기능을 현재 기능처럼 문서에 표시하지 않고, 실제 코드와 완료된 작업을 기준으로 README를 갱신하는 것을 원칙으로 합니다.
+- 비용 발생 API validation과 안정적인 오류 계약
+- 공유 접근 세션, CORS allowlist, 게임 세션 소유권
+- 서버 발급 image asset과 Pollinations 생성 계약 보강
+- Narrative/Image rate limit과 provider 관측성
+- 공유 비밀번호 인증 시도 rate limit
+- Charcoal Folio UI foundation과 interaction/accessibility UX
+- Vercel Web Analytics
+- production smoke에서 발견된 CORS/UI/image style 회귀 보완
+
+### M2 — 턴 무결성·복구 기반
+
+핵심 목표는 **같은 사용자 행동이 retry/concurrency/crash 상황에서도 canonical game state에 한 번만 commit되고, 저장된 결과를 복구·감사할 수 있게 하는 것**입니다.
+
+권장 순서:
+
+1. **#73** PostgreSQL integration test harness와 CI 기반
+2. **#28** append-only committed-turn `GameLog` 원장
+3. **#31** GameState snapshot schema/ruleset version + upgrader — #28과 병렬 가능
+4. **#29** `/init`·`/progress` 게임 mutation idempotency
+5. **#30** turn reservation/lease로 정상 동시 요청의 중복 provider 실행 억제
+6. **#32** M2 PostgreSQL 동시성·migration·복구 최종 회귀 matrix
+
+운영 보강 트랙인 **#70 production post-deploy smoke 자동화**, **#71 전역 AI 비용 budget guard**는 위 핵심 체인의 선행조건이 아니므로 병렬 또는 후순위로 진행합니다.
+
+M2에서 strict external-provider exactly-once까지 약속하지는 않습니다. DB lease만으로는 provider 성공 직후 commit 전 프로세스 장애 같은 구간에서 재호출 가능성을 완전히 제거할 수 없기 때문에, **canonical commit exactly-once + 유효 reservation 구간의 중복 provider 억제 + bounded recovery**를 현실적인 보장 범위로 둡니다.
+
+### 이후
+
+M2가 안정되면 다음 단계에서 서버 주도 `AvailableAction`, `PlayerAction`, `GameResult`, 타입 안전한 캐릭터 능력치와 Skill Check를 연결하고, 이후 전투·인벤토리·퀘스트·NPC 관계 시스템으로 확장합니다.
+
+아직 구현되지 않은 기능을 현재 기능처럼 문서에 표시하지 않고, 실제 main 코드와 완료된 작업을 기준으로 README를 갱신하는 것을 원칙으로 합니다.


### PR DESCRIPTION
## 변경 내용

- 현재 main 기준으로 M1에서 완료된 접근 제어, 세션 소유권, image asset, rate limit/관측성, UI/accessibility, analytics 범위를 README에 반영했습니다.
- 이미 완료된 M1 작업이 `진행 중`처럼 보이던 내용을 제거했습니다.
- M2 핵심 목표를 턴 무결성·복구 기반으로 명확히 정리했습니다.
- 비판적 리뷰 후 조정한 권장 순서 `#73 → #28/#31 → #29 → #30 → #32`를 문서화했습니다.
- #70/#71은 핵심 턴 무결성 체인의 선행조건이 아닌 운영 보강 트랙으로 구분했습니다.
- DB lease만으로 외부 provider strict exactly-once를 보장할 수 없다는 한계를 README에 명시했습니다.

## 관련 이슈 정리

이번 리뷰에서 코드와 이슈 본문을 함께 검토한 뒤 다음을 별도로 반영했습니다.

- 신규 #73 PostgreSQL integration-test harness/CI 기반
- #28 GameLog를 append-only committed-turn ledger로 경계 명확화
- #29 `/init`과 `/progress`를 포함하는 게임 mutation idempotency로 확장
- #30 reservation/lease의 현실적인 보장 수준으로 수정
- #31 #28 불필요 선행 의존 제거, #73 기반으로 병렬 가능하게 조정
- #32 M2 최종 PostgreSQL 회귀 matrix 역할로 축소·명확화

## 자체 검토

- README 변경만 포함되는지 diff 확인: `README.md` 1개 파일
- main 대비 1 commit ahead / 0 behind 확인
- 아직 구현되지 않은 PostgreSQL integration test, idempotency, reservation, snapshot upgrader를 완료 기능처럼 기술하지 않았습니다.
- strict external-provider exactly-once를 과장해서 약속하지 않도록 문구를 재검토했습니다.

## 테스트

문서 변경만 포함되어 별도 코드 테스트는 실행하지 않았습니다.