### PR TITLE
test(persistence): PostgreSQL integration test 기반 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   backend:
     name: Backend test and build
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     steps:
       - name: Checkout repository
@@ -35,6 +35,9 @@ jobs:
 
       - name: Run backend tests
         run: ./gradlew clean test
+
+      - name: Run PostgreSQL integration tests
+        run: ./gradlew postgresIntegrationTest
 
       - name: Build backend
         run: ./gradlew build -x test

--- a/build.gradle
+++ b/build.gradle
@@ -40,10 +40,25 @@ dependencies {
     runtimeOnly 'org.flywaydb:flyway-database-postgresql'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.testcontainers:testcontainers-postgresql'
+    testImplementation 'org.testcontainers:testcontainers-junit-jupiter'
     testRuntimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {
-    useJUnitPlatform()
+    useJUnitPlatform {
+        excludeTags 'postgres'
+    }
+}
+
+tasks.register('postgresIntegrationTest', Test) {
+    group = 'verification'
+    description = 'Runs PostgreSQL integration tests with Testcontainers.'
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    useJUnitPlatform {
+        includeTags 'postgres'
+    }
+    shouldRunAfter tasks.named('test')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     runtimeOnly 'org.flywaydb:flyway-database-postgresql'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation platform('org.testcontainers:testcontainers-bom:2.0.5')
     testImplementation 'org.testcontainers:testcontainers-postgresql'
     testImplementation 'org.testcontainers:testcontainers-junit-jupiter'
     testRuntimeOnly 'com.h2database:h2'

--- a/docs/testing/postgresql-integration-tests.md
+++ b/docs/testing/postgresql-integration-tests.md
@@ -1,0 +1,66 @@
+# PostgreSQL integration tests
+
+UCTale의 기본 backend test suite는 빠른 회귀 검증을 위해 H2를 사용합니다. M2부터 persistence 계약을 변경하는 작업은 production PostgreSQL 의미론을 별도 integration suite에서 함께 검증합니다.
+
+## 실행 명령
+
+기본 unit / H2 suite:
+
+```bash
+./gradlew clean test
+```
+
+PostgreSQL integration suite:
+
+```bash
+./gradlew postgresIntegrationTest
+```
+
+PostgreSQL suite는 Testcontainers를 사용하므로 로컬에서 Docker-compatible container runtime이 실행 중이어야 합니다. production Neon DB나 별도 shared test DB에는 연결하지 않습니다.
+
+GitHub Actions도 같은 `./gradlew postgresIntegrationTest` 명령을 사용합니다. GitHub-hosted Ubuntu runner의 Docker daemon에서 ephemeral PostgreSQL container를 띄우므로 별도 database secret은 필요하지 않습니다.
+
+## 선택한 방식
+
+#73에서는 GitHub Actions의 PostgreSQL service container 대신 Testcontainers를 선택했습니다.
+
+이유:
+
+- 로컬과 CI가 동일한 Java test code와 동일한 database image를 사용합니다.
+- 포트, username, password를 CI workflow와 로컬 설정에 중복 정의하지 않습니다.
+- 후속 #28~#31 persistence tests가 공통 support class만 상속해 같은 환경을 재사용할 수 있습니다.
+- 테스트가 production Neon DB에 연결될 가능성을 구조적으로 줄입니다.
+
+Testcontainers version은 BOM `2.0.5`, PostgreSQL image는 `postgres:17.6-alpine`으로 고정합니다. 버전 변경은 일반 dependency/image update처럼 PR에서 검증한 뒤 반영합니다.
+
+## 테스트 경계
+
+JUnit tag `postgres`를 경계로 사용합니다.
+
+- `test`: `postgres` tag를 제외하고 기존 H2/unit suite를 실행합니다.
+- `postgresIntegrationTest`: `postgres` tag만 실행합니다.
+- PostgreSQL 테스트는 `PostgresIntegrationTestSupport`를 상속해 datasource/Flyway/JPA 설정을 공유합니다.
+
+현재 baseline은 다음 production 의미론을 검증합니다.
+
+- 빈 PostgreSQL에서 Flyway V1~V5 migration chain 적용
+- Hibernate `ddl-auto=validate`가 migration 결과와 현재 entity mapping을 검증
+- `uk_game_log_session_turn` unique constraint
+- `GameSession`의 `@Version` optimistic locking
+
+## 후속 이슈 규칙
+
+#28~#31에서 PostgreSQL에 의존하는 constraint, migration, locking 또는 recovery 동작을 추가할 경우 새 harness를 만들지 말고 기존 `PostgresIntegrationTestSupport`를 재사용합니다.
+
+#32에서는 이 기반 위에서 M2의 cross-feature concurrency/migration/recovery regression matrix를 완성합니다.
+
+## 실패 진단
+
+CI의 `Run PostgreSQL integration tests` step은 일반 backend test와 분리되어 있습니다. 따라서 실패 시 먼저 다음을 구분합니다.
+
+1. container startup / Docker 문제
+2. Flyway migration 실패
+3. Hibernate schema validation 실패
+4. PostgreSQL constraint / optimistic locking assertion 실패
+
+Testcontainers와 Spring Boot가 container 및 datasource 초기화 로그를 남기며, 테스트 이름은 실패한 contract를 직접 나타내도록 유지합니다. DB password는 ephemeral fixture 값이며 production credential이나 application secret을 사용하지 않습니다.

--- a/src/test/java/com/uctale/uctale/persistence/PostgresPersistenceBaselineTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/PostgresPersistenceBaselineTest.java
@@ -32,11 +32,12 @@ class PostgresPersistenceBaselineTest extends PostgresIntegrationTestSupport {
     }
 
     @Test
-    @DisplayName("빈 PostgreSQL에 production Flyway migration V1~V5가 적용된다")
+    @DisplayName("빈 PostgreSQL에 production Flyway migration이 모두 적용된다")
     void productionMigrationChain_IsAppliedToPostgres() {
+        assertThat(flyway.info().pending()).isEmpty();
         assertThat(flyway.info().applied())
                 .extracting(info -> info.getVersion().getVersion())
-                .containsExactly("1", "2", "3", "4", "5");
+                .contains("1", "2", "3", "4", "5");
 
         assertThat(tableExists("game_session")).isTrue();
         assertThat(tableExists("game_log")).isTrue();

--- a/src/test/java/com/uctale/uctale/persistence/PostgresPersistenceBaselineTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/PostgresPersistenceBaselineTest.java
@@ -1,0 +1,137 @@
+package com.uctale.uctale.persistence;
+
+import com.uctale.uctale.domain.GameSession;
+import com.uctale.uctale.support.PostgresIntegrationTestSupport;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.RollbackException;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+class PostgresPersistenceBaselineTest extends PostgresIntegrationTestSupport {
+
+    private static final String OWNER_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+    @Autowired private Flyway flyway;
+    @Autowired private JdbcTemplate jdbcTemplate;
+    @Autowired private EntityManagerFactory entityManagerFactory;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.execute("truncate table image_asset, game_state_snapshot, game_log, game_session restart identity cascade");
+    }
+
+    @Test
+    @DisplayName("빈 PostgreSQL에 production Flyway migration V1~V5가 적용된다")
+    void productionMigrationChain_IsAppliedToPostgres() {
+        assertThat(flyway.info().applied())
+                .extracting(info -> info.getVersion().getVersion())
+                .containsExactly("1", "2", "3", "4", "5");
+
+        assertThat(tableExists("game_session")).isTrue();
+        assertThat(tableExists("game_log")).isTrue();
+        assertThat(tableExists("game_state_snapshot")).isTrue();
+        assertThat(tableExists("image_asset")).isTrue();
+    }
+
+    @Test
+    @DisplayName("PostgreSQL이 동일 session turn의 중복 GameLog를 거부한다")
+    void gameLogTurnUniqueConstraint_IsEnforcedByPostgres() {
+        Long sessionId = insertSession();
+        insertGameLog(sessionId, 1);
+
+        assertThatThrownBy(() -> insertGameLog(sessionId, 1))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("PostgreSQL에서 GameSession optimistic locking이 stale update를 거부한다")
+    void gameSessionOptimisticLocking_IsEnforcedByPostgres() {
+        Long sessionId = insertSession();
+
+        EntityManager firstEntityManager = entityManagerFactory.createEntityManager();
+        EntityManager secondEntityManager = entityManagerFactory.createEntityManager();
+        try {
+            GameSession first = firstEntityManager.find(GameSession.class, sessionId);
+            GameSession stale = secondEntityManager.find(GameSession.class, sessionId);
+
+            firstEntityManager.getTransaction().begin();
+            first.advanceTurn();
+            firstEntityManager.getTransaction().commit();
+
+            secondEntityManager.getTransaction().begin();
+            stale.advanceTurn();
+
+            assertThatThrownBy(() -> secondEntityManager.getTransaction().commit())
+                    .isInstanceOf(RollbackException.class);
+        } finally {
+            rollbackIfActive(firstEntityManager);
+            rollbackIfActive(secondEntityManager);
+            firstEntityManager.close();
+            secondEntityManager.close();
+        }
+
+        Integer currentTurn = jdbcTemplate.queryForObject(
+                "select current_turn from game_session where id = ?",
+                Integer.class,
+                sessionId
+        );
+        Long version = jdbcTemplate.queryForObject(
+                "select version from game_session where id = ?",
+                Long.class,
+                sessionId
+        );
+
+        assertThat(currentTurn).isEqualTo(2);
+        assertThat(version).isEqualTo(1L);
+    }
+
+    private Long insertSession() {
+        return jdbcTemplate.queryForObject(
+                """
+                insert into game_session (
+                    owner_key, world_setting, character_setting, is_game_over, current_turn, version
+                ) values (?, ?, ?, false, 1, 0)
+                returning id
+                """,
+                Long.class,
+                OWNER_KEY,
+                "세계관",
+                "캐릭터"
+        );
+    }
+
+    private void insertGameLog(Long sessionId, int turnNumber) {
+        jdbcTemplate.update(
+                "insert into game_log (session_id, turn_number, story_text, choices_json) values (?, ?, ?, ?)",
+                sessionId,
+                turnNumber,
+                "이야기",
+                "[]"
+        );
+    }
+
+    private boolean tableExists(String tableName) {
+        return Boolean.TRUE.equals(jdbcTemplate.queryForObject(
+                "select to_regclass(?) is not null",
+                Boolean.class,
+                "public." + tableName
+        ));
+    }
+
+    private void rollbackIfActive(EntityManager entityManager) {
+        if (entityManager.getTransaction().isActive()) {
+            entityManager.getTransaction().rollback();
+        }
+    }
+}

--- a/src/test/java/com/uctale/uctale/support/PostgresIntegrationTestSupport.java
+++ b/src/test/java/com/uctale/uctale/support/PostgresIntegrationTestSupport.java
@@ -1,0 +1,30 @@
+package com.uctale.uctale.support;
+
+import org.junit.jupiter.api.Tag;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Tag("postgres")
+@Testcontainers(disabledWithoutDocker = true)
+public abstract class PostgresIntegrationTestSupport {
+
+    @Container
+    protected static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:17.6-alpine")
+            .withDatabaseName("uctale_test")
+            .withUsername("uctale")
+            .withPassword("uctale");
+
+    @DynamicPropertySource
+    static void configurePostgres(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+        registry.add("spring.flyway.enabled", () -> true);
+        registry.add("spring.flyway.validate-on-migrate", () -> true);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+    }
+}

--- a/src/test/java/com/uctale/uctale/support/PostgresIntegrationTestSupport.java
+++ b/src/test/java/com/uctale/uctale/support/PostgresIntegrationTestSupport.java
@@ -3,16 +3,16 @@ package com.uctale.uctale.support;
 import org.junit.jupiter.api.Tag;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 
 @Tag("postgres")
-@Testcontainers(disabledWithoutDocker = true)
+@Testcontainers
 public abstract class PostgresIntegrationTestSupport {
 
     @Container
-    protected static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:17.6-alpine")
+    protected static final PostgreSQLContainer POSTGRES = new PostgreSQLContainer("postgres:17.6-alpine")
             .withDatabaseName("uctale_test")
             .withUsername("uctale")
             .withPassword("uctale");


### PR DESCRIPTION
## 왜 필요한가요?

현재 backend의 Spring integration test는 H2 PostgreSQL compatibility mode를 사용하므로 production PostgreSQL의 migration, unique constraint, optimistic locking 의미론을 직접 검증하지 못합니다.

M2의 #28~#31이 persistence 계약을 본격적으로 변경하기 전에 로컬과 CI에서 동일하게 재사용할 수 있는 실제 PostgreSQL 검증 기반을 먼저 만듭니다.

- Closes #73

## 무엇이 바뀌나요?

### Testcontainers PostgreSQL harness

- Testcontainers BOM `2.0.5`와 `testcontainers-postgresql`, `testcontainers-junit-jupiter`를 test dependency로 추가했습니다.
- Testcontainers 2.x의 비-deprecated `org.testcontainers.postgresql.PostgreSQLContainer` API를 사용합니다.
- `postgres:17.6-alpine` image를 고정합니다.
- `PostgresIntegrationTestSupport`가 ephemeral database의 datasource/Flyway/JPA property를 공통 주입합니다.
- production Neon DB나 shared test DB에는 연결하지 않습니다.

### Gradle test 경계

- 기존 `test` task는 `postgres` JUnit tag를 제외해 H2/unit suite의 속도와 Docker 비의존성을 유지합니다.
- 새 `postgresIntegrationTest` task는 `postgres` tag만 실행합니다.
- 로컬과 CI 모두 동일하게 다음 명령을 사용합니다.

```bash
./gradlew postgresIntegrationTest
```

### PostgreSQL baseline regression

실제 PostgreSQL에서 다음을 고정합니다.

- 빈 DB에 현재 production Flyway migration이 모두 적용되고 pending migration이 없는지 검증
- 기존 V1~V5 baseline migration 존재 검증
- Hibernate `ddl-auto=validate` 통과
- `game_session`, `game_log`, `game_state_snapshot`, `image_asset` schema 존재
- `(session_id, turn_number)` GameLog unique constraint가 실제로 중복 insert를 거부
- `GameSession @Version` optimistic locking이 stale update를 거부

### CI

기존 backend job에 `Run PostgreSQL integration tests` step을 추가했습니다.

```bash
./gradlew clean test
./gradlew postgresIntegrationTest
./gradlew build -x test
```

별도 DB secret/service 설정 없이 GitHub-hosted runner의 Docker에서 ephemeral PostgreSQL을 실행합니다.

## 문서

- `docs/testing/postgresql-integration-tests.md`
  - H2 / PostgreSQL suite 책임 경계
  - 로컬/CI 실행 명령
  - Testcontainers 선택 이유
  - 후속 #28~#31 재사용 규칙
  - 실패 진단 기준

## PR 전/후 자체 비판적 리뷰 및 보완

1. **GitHub Actions service DB vs Testcontainers**
   - service DB는 CI 전용 설정과 로컬 설정이 갈라지므로 채택하지 않았습니다.
   - 같은 Java test와 같은 image를 로컬/CI에서 실행하는 Testcontainers를 선택했습니다.
2. **Testcontainers 2.x API 확인**
   - 구 `org.testcontainers.containers.PostgreSQLContainer`는 2.x에서 deprecated이므로 새 `org.testcontainers.postgresql.PostgreSQLContainer`를 사용하도록 보완했습니다.
3. **dependency version 암묵 의존 제거**
   - Spring dependency management에만 기대지 않고 Testcontainers BOM `2.0.5`를 명시했습니다.
4. **기존 suite에 Docker 의존성 전파 방지**
   - `test`에서는 `postgres` tag를 제외합니다. 기존 개발/CI 회귀 테스트는 Docker 없이 계속 실행됩니다.
5. **PostgreSQL suite의 조용한 skip 방지**
   - Docker가 없을 때 PostgreSQL 검증을 성공처럼 skip하지 않습니다. 전용 task가 실제 DB를 띄우지 못하면 실패해야 검증 의미가 유지됩니다.
6. **범위 과확장 방지**
   - #29 idempotency, #30 reservation/lease, #31 upgrader 및 #32 cross-feature matrix를 선제 구현하지 않았습니다.
7. **production credential 격리**
   - ephemeral fixture username/password만 사용하고 production Neon credential/secret은 필요하지 않습니다.
8. **후속 migration과의 불필요한 결합 제거**
   - 최초에는 적용 migration을 `V1~V5 containsExactly`로 검증했습니다.
   - 최종 diff 재검토에서 #28 등이 V6를 정상 추가할 때 harness 자체가 불필요하게 깨지는 문제를 발견했습니다.
   - `pending migration = 0`으로 현재 migration 전체 적용을 검증하고 V1~V5는 baseline 존재만 확인하도록 수정했습니다.

## 최종 검증

최신 commit `34e7fb9` 기준 GitHub Actions CI #125 전체 성공:

- [x] Backend H2/unit tests
- [x] **PostgreSQL Testcontainers integration tests**
- [x] Backend build
- [x] Frontend tests
- [x] ESLint
- [x] Frontend production build

PostgreSQL integration step은 실제 GitHub-hosted Docker 환경에서 실행되어 성공했습니다.

## 영향 범위

- runtime application code 변경 없음
- production Flyway migration 변경 없음
- production credential/secret 추가 없음
- 변경 파일 5개
- PR은 merge하지 않고 open 상태로 유지합니다.
