### PR TITLE
refactor(persistence): GameLog 턴 원장 경계 강화

### DIFF
--- a/docs/architecture/game-log-ledger.md
+++ b/docs/architecture/game-log-ledger.md
@@ -36,11 +36,11 @@ Opening은 외부 입력이 없으므로 `input_choice_id`, `input_choice_text`�
 3. Narrative 결과를 검증한다.
 4. application/domain에서 다음 `GameState`를 확정한다.
 5. `GameTurnCommit`으로 입력, 이전/다음 state, narrative 결과를 persistence에 전달한다.
-6. persistence는 현재 session/log state version과 commit을 검증하고 새 `GameLog` 한 행과 snapshot/session을 원자적으로 저장한다.
+6. persistence는 현재 session/log state version, canonical previous state와 commit을 검증하고 새 `GameLog` 한 행과 snapshot/session을 원자적으로 저장한다.
 
-Persistence는 `userChoice + storyText`를 받아 `GameState.advance(...)`를 호출하지 않습니다. 상태 전이를 계산하는 책임은 persistence 바깥에 있습니다.
+`GamePersistenceService`는 `userChoice + storyText`를 받아 `GameState.advance(...)`를 호출하지 않습니다. 상태 전이를 계산하는 책임은 persistence 바깥에 있습니다. Snapshot이 없을 때의 기존 로그 복구 계산도 `GameStateRecovery`로 분리합니다.
 
-Commit된 기존 `GameLog`를 수정하는 domain method도 제공하지 않습니다.
+Commit된 기존 `GameLog`를 수정하는 domain method는 제공하지 않으며 entity는 Hibernate `@Immutable`로 dirty update 대상에서도 제외합니다.
 
 ## legacy V1~V5 migration
 
@@ -54,10 +54,12 @@ V1~V5에서는 선택 입력이 **선택이 발생한 행이 아니라 그 이�
 
 `previous_state_version`과 `state_version`은 기존 turn number에서 결정적으로 backfill합니다.
 
+기존 `user_choice` DB 컬럼은 즉시 drop하지 않습니다. 배포 롤백 시 이전 애플리케이션이 schema 자체 때문에 기동 불가해지는 위험을 줄이기 위한 **legacy compatibility column**으로 남겨 둡니다. V6 애플리케이션의 `GameLog` entity에는 매핑하지 않으며 새 commit에서는 읽거나 쓰지 않습니다. canonical ledger 의미는 새 `input_choice_*` 컬럼만 소유합니다.
+
 ## 복구
 
 Snapshot이 존재하면 최신 상태 복구는 snapshot을 우선 사용합니다.
 
-Snapshot이 없다면 `GameLog`를 turn 순서로 읽고 각 **행 자체의** `input_choice_text`, story, state version을 사용해 현재 `GameState`를 복구합니다. 더 이상 이전 행을 수정해 둔 `user_choice`에 의존하지 않습니다.
+Snapshot이 없다면 `GameLog`를 turn 순서로 읽고 각 **행 자체의** `input_choice_text`, story, state version을 사용해 `GameStateRecovery`가 현재 `GameState`를 복구합니다. 더 이상 이전 행을 수정해 둔 `user_choice`에 의존하지 않습니다.
 
 전체 event replay engine이나 Event Sourcing은 이 설계의 목표가 아닙니다.

--- a/docs/architecture/game-log-ledger.md
+++ b/docs/architecture/game-log-ledger.md
@@ -1,0 +1,63 @@
+# GameLog committed-turn ledger
+
+## 책임
+
+UCTale의 persistence는 `GameLog`와 `GameStateSnapshot`을 서로 다른 목적으로 사용합니다.
+
+- `GameLog`: 이미 commit된 canonical turn의 append-only 감사 원장
+- `GameStateSnapshot`: 최신 `GameState`를 빠르게 복구하기 위한 materialized snapshot
+
+`GameLog`는 request attempt, `PROCESSING`, `FAILED`, lease 같은 실행 상태를 저장하지 않습니다. 해당 책임은 M2의 idempotency/reservation 이슈(#29, #30)가 별도 request record로 소유합니다.
+
+## 한 turn record의 의미
+
+Opening을 제외한 새 `GameLog` 한 행은 해당 turn을 만든 입력과 결과를 자기 행 안에 함께 저장합니다.
+
+- `turn_number`
+- `input_choice_id`
+- `input_choice_text`
+- `previous_state_version`
+- `state_version`
+- `story_text`
+- `choices_json`
+- `image_url`
+- `created_at` (`committedAt`)
+
+Opening은 외부 입력이 없으므로 `input_choice_id`, `input_choice_text`가 `null`이고 state transition은 `0 -> 1`입니다.
+
+현재 ruleset에서 state version은 canonical `GameState.turnNumber`와 동일합니다. 이 값은 snapshot schema/ruleset version(#31)과 다른 개념입니다. `state_version`은 **어느 canonical turn state를 이 행이 commit했는지** 식별하고, snapshot version은 **JSON 형식과 ruleset evolution**을 식별합니다.
+
+## append-only 경계
+
+기존 구조는 turn N을 진행할 때 turn N의 `user_choice`를 뒤늦게 수정했습니다. V6 이후 application은 다음 순서를 사용합니다.
+
+1. 현재 turn과 `GameState`를 읽는다.
+2. 선택지 ID를 검증하고 표시 텍스트를 확정한다.
+3. Narrative 결과를 검증한다.
+4. application/domain에서 다음 `GameState`를 확정한다.
+5. `GameTurnCommit`으로 입력, 이전/다음 state, narrative 결과를 persistence에 전달한다.
+6. persistence는 현재 session/log state version과 commit을 검증하고 새 `GameLog` 한 행과 snapshot/session을 원자적으로 저장한다.
+
+Persistence는 `userChoice + storyText`를 받아 `GameState.advance(...)`를 호출하지 않습니다. 상태 전이를 계산하는 책임은 persistence 바깥에 있습니다.
+
+Commit된 기존 `GameLog`를 수정하는 domain method도 제공하지 않습니다.
+
+## legacy V1~V5 migration
+
+V1~V5에서는 선택 입력이 **선택이 발생한 행이 아니라 그 이전 행의 `user_choice`**에 저장되어 있었습니다. V6 migration은 이를 다음 committed turn 행의 `input_choice_text`로 이동합니다.
+
+과거 schema에는 실제 `choiceId`가 저장되지 않았습니다. `choices_json`과 선택 텍스트를 조합해 추정할 수 있는 경우도 있지만, 중복 문구·과거 데이터 손상 가능성을 고려하면 migration이 ID를 만들어내는 것은 canonical history를 조작할 위험이 있습니다. 따라서:
+
+- legacy `input_choice_text`: 정확히 이관
+- legacy `input_choice_id`: `null` = historical unknown
+- V6 이후 새 non-opening commit: application contract에서 ID와 text를 모두 필수 기록
+
+`previous_state_version`과 `state_version`은 기존 turn number에서 결정적으로 backfill합니다.
+
+## 복구
+
+Snapshot이 존재하면 최신 상태 복구는 snapshot을 우선 사용합니다.
+
+Snapshot이 없다면 `GameLog`를 turn 순서로 읽고 각 **행 자체의** `input_choice_text`, story, state version을 사용해 현재 `GameState`를 복구합니다. 더 이상 이전 행을 수정해 둔 `user_choice`에 의존하지 않습니다.
+
+전체 event replay engine이나 Event Sourcing은 이 설계의 목표가 아닙니다.

--- a/src/main/java/com/uctale/uctale/application/game/GamePersistenceService.java
+++ b/src/main/java/com/uctale/uctale/application/game/GamePersistenceService.java
@@ -15,8 +15,6 @@ import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 @Service
 public class GamePersistenceService {
 
@@ -28,19 +26,22 @@ public class GamePersistenceService {
     private final GameStateSnapshotRepository gameStateSnapshotRepository;
     private final ImageAssetRepository imageAssetRepository;
     private final GameStateCodec gameStateCodec;
+    private final GameStateRecovery gameStateRecovery;
 
     public GamePersistenceService(
             GameSessionRepository gameSessionRepository,
             GameLogRepository gameLogRepository,
             GameStateSnapshotRepository gameStateSnapshotRepository,
             ImageAssetRepository imageAssetRepository,
-            GameStateCodec gameStateCodec
+            GameStateCodec gameStateCodec,
+            GameStateRecovery gameStateRecovery
     ) {
         this.gameSessionRepository = gameSessionRepository;
         this.gameLogRepository = gameLogRepository;
         this.gameStateSnapshotRepository = gameStateSnapshotRepository;
         this.imageAssetRepository = imageAssetRepository;
         this.gameStateCodec = gameStateCodec;
+        this.gameStateRecovery = gameStateRecovery;
     }
 
     @Transactional
@@ -109,6 +110,11 @@ public class GamePersistenceService {
             if (previousLog.getTurnNumber() != commit.expectedTurn()
                     || previousLog.getStateVersion() != commit.previousStateVersion()) {
                 throw new IllegalStateException("세션 턴과 저장된 로그의 state version이 일치하지 않습니다.");
+            }
+
+            GameState canonicalPreviousState = loadOrRecoverState(session);
+            if (!canonicalPreviousState.equals(commit.previousState())) {
+                throw new TurnConflictException("commit의 이전 상태가 현재 canonical state와 일치하지 않습니다.");
             }
 
             session.advanceTurn();
@@ -203,36 +209,10 @@ public class GamePersistenceService {
     private GameState loadOrRecoverState(GameSession session) {
         return gameStateSnapshotRepository.findById(session.getId())
                 .map(snapshot -> gameStateCodec.deserialize(snapshot.getStateJson()))
-                .orElseGet(() -> recoverState(session));
-    }
-
-    private GameState recoverState(GameSession session) {
-        List<GameLog> logs = gameLogRepository.findByGameSessionOrderByTurnNumberAsc(session);
-        if (logs.isEmpty()) {
-            throw new IllegalStateException("GameState를 복구할 게임 로그가 없습니다.");
-        }
-
-        GameLog opening = logs.getFirst();
-        if (opening.getStateVersion() != 1) {
-            throw new IllegalStateException("Opening GameLog의 state version이 올바르지 않습니다.");
-        }
-
-        GameState state = GameState.initial(
-                session.getWorldSetting(),
-                session.getCharacterSetting(),
-                opening.getStoryText()
-        );
-        for (int i = 1; i < logs.size(); i++) {
-            GameLog log = logs.get(i);
-            if (log.getPreviousStateVersion() != state.turnNumber()
-                    || log.getStateVersion() != state.turnNumber() + 1
-                    || log.getInputChoiceText() == null
-                    || log.getInputChoiceText().isBlank()) {
-                throw new IllegalStateException("GameLog state transition을 복구할 수 없습니다.");
-            }
-            state = state.advance(log.getInputChoiceText(), log.getStoryText());
-        }
-        return state;
+                .orElseGet(() -> gameStateRecovery.recover(
+                        session,
+                        gameLogRepository.findByGameSessionOrderByTurnNumberAsc(session)
+                ));
     }
 
     private void flushAll() {

--- a/src/main/java/com/uctale/uctale/application/game/GamePersistenceService.java
+++ b/src/main/java/com/uctale/uctale/application/game/GamePersistenceService.java
@@ -57,11 +57,8 @@ public class GamePersistenceService {
             String imageUrl = persistImageAsset(session, 1, imageAsset);
             GameState initialState = GameState.initial(worldSetting, characterSetting, storyText);
             gameStateSnapshotRepository.save(new GameStateSnapshot(session, gameStateCodec.serialize(initialState)));
-            gameLogRepository.save(new GameLog(session, 1, storyText, choicesJson, imageUrl));
-            imageAssetRepository.flush();
-            gameLogRepository.flush();
-            gameStateSnapshotRepository.flush();
-            gameSessionRepository.flush();
+            gameLogRepository.save(GameLog.opening(session, storyText, choicesJson, imageUrl));
+            flushAll();
             return session;
         } catch (DataIntegrityViolationException exception) {
             throw new PersistenceOperationException("게임 시작 상태를 저장할 수 없습니다.", exception);
@@ -84,8 +81,8 @@ public class GamePersistenceService {
         }
 
         GameState gameState = loadOrRecoverState(session);
-        if (gameState.turnNumber() != expectedTurn) {
-            throw new IllegalStateException("세션 턴과 GameState가 일치하지 않습니다.");
+        if (gameState.turnNumber() != expectedTurn || lastLog.getStateVersion() != expectedTurn) {
+            throw new IllegalStateException("세션 턴과 canonical state version이 일치하지 않습니다.");
         }
 
         return new LoadedTurn(
@@ -101,61 +98,44 @@ public class GamePersistenceService {
     }
 
     @Transactional
-    public int saveNextTurn(
-            String ownerKey,
-            Long sessionId,
-            int expectedTurn,
-            String userChoice,
-            String storyText,
-            String choicesJson,
-            ImageAssetService.AssetReference imageAsset
-    ) {
+    public int saveNextTurn(String ownerKey, Long sessionId, GameTurnCommit commit) {
         try {
             GameSession session = findOwnedSession(ownerKey, sessionId);
-
-            if (session.getCurrentTurn() != expectedTurn) {
-                throw new TurnConflictException("이미 처리되었거나 오래된 턴 요청입니다.");
-            }
+            validateCommitAgainstSession(session, commit);
 
             GameLog previousLog = gameLogRepository.findTopByGameSessionOrderByTurnNumberDesc(session)
                     .orElseThrow(() -> new IllegalStateException("게임 로그가 없습니다."));
 
-            if (previousLog.getTurnNumber() != expectedTurn) {
-                throw new IllegalStateException("세션 턴과 저장된 로그가 일치하지 않습니다.");
+            if (previousLog.getTurnNumber() != commit.expectedTurn()
+                    || previousLog.getStateVersion() != commit.previousStateVersion()) {
+                throw new IllegalStateException("세션 턴과 저장된 로그의 state version이 일치하지 않습니다.");
             }
 
-            GameState currentState = loadOrRecoverState(session);
-            if (currentState.turnNumber() != expectedTurn) {
-                throw new IllegalStateException("세션 턴과 GameState가 일치하지 않습니다.");
-            }
-            GameState nextState = currentState.advance(userChoice, storyText);
-
-            previousLog.updateUserChoice(userChoice);
             session.advanceTurn();
 
-            String imageUrl = imageAsset == null
+            String imageUrl = commit.imageAsset() == null
                     ? previousLog.getImageUrl()
-                    : persistImageAsset(session, expectedTurn + 1, imageAsset);
+                    : persistImageAsset(session, commit.nextStateVersion(), commit.imageAsset());
 
-            gameLogRepository.save(previousLog);
             gameSessionRepository.save(session);
-            gameLogRepository.save(new GameLog(
+            gameLogRepository.save(GameLog.committedTurn(
                     session,
-                    expectedTurn + 1,
-                    storyText,
-                    choicesJson,
+                    commit.nextStateVersion(),
+                    commit.inputChoiceId(),
+                    commit.inputChoiceText(),
+                    commit.previousStateVersion(),
+                    commit.nextStateVersion(),
+                    commit.storyText(),
+                    commit.choicesJson(),
                     imageUrl
             ));
 
             GameStateSnapshot snapshot = gameStateSnapshotRepository.findById(sessionId)
-                    .orElseGet(() -> new GameStateSnapshot(session, gameStateCodec.serialize(currentState)));
-            snapshot.updateStateJson(gameStateCodec.serialize(nextState));
+                    .orElseGet(() -> new GameStateSnapshot(session, gameStateCodec.serialize(commit.previousState())));
+            snapshot.updateStateJson(gameStateCodec.serialize(commit.nextState()));
             gameStateSnapshotRepository.save(snapshot);
 
-            imageAssetRepository.flush();
-            gameLogRepository.flush();
-            gameStateSnapshotRepository.flush();
-            gameSessionRepository.flush();
+            flushAll();
             return session.getCurrentTurn();
         } catch (ObjectOptimisticLockingFailureException exception) {
             throw new TurnConflictException("동시에 처리된 턴 요청과 충돌했습니다.", exception);
@@ -164,6 +144,18 @@ public class GamePersistenceService {
                 throw new TurnConflictException("동시에 처리된 턴 요청과 충돌했습니다.", exception);
             }
             throw new PersistenceOperationException("게임 진행 상태를 저장할 수 없습니다.", exception);
+        }
+    }
+
+    private void validateCommitAgainstSession(GameSession session, GameTurnCommit commit) {
+        if (session.getCurrentTurn() != commit.expectedTurn()) {
+            throw new TurnConflictException("이미 처리되었거나 오래된 턴 요청입니다.");
+        }
+        if (commit.previousStateVersion() != commit.expectedTurn()) {
+            throw new IllegalArgumentException("commit의 이전 state version이 expectedTurn과 일치하지 않습니다.");
+        }
+        if (commit.nextStateVersion() != commit.expectedTurn() + 1) {
+            throw new IllegalArgumentException("commit의 다음 state version이 올바르지 않습니다.");
         }
     }
 
@@ -220,16 +212,34 @@ public class GamePersistenceService {
             throw new IllegalStateException("GameState를 복구할 게임 로그가 없습니다.");
         }
 
+        GameLog opening = logs.getFirst();
+        if (opening.getStateVersion() != 1) {
+            throw new IllegalStateException("Opening GameLog의 state version이 올바르지 않습니다.");
+        }
+
         GameState state = GameState.initial(
                 session.getWorldSetting(),
                 session.getCharacterSetting(),
-                logs.get(0).getStoryText()
+                opening.getStoryText()
         );
         for (int i = 1; i < logs.size(); i++) {
-            String action = logs.get(i - 1).getUserChoice();
-            state = state.advance(action, logs.get(i).getStoryText());
+            GameLog log = logs.get(i);
+            if (log.getPreviousStateVersion() != state.turnNumber()
+                    || log.getStateVersion() != state.turnNumber() + 1
+                    || log.getInputChoiceText() == null
+                    || log.getInputChoiceText().isBlank()) {
+                throw new IllegalStateException("GameLog state transition을 복구할 수 없습니다.");
+            }
+            state = state.advance(log.getInputChoiceText(), log.getStoryText());
         }
         return state;
+    }
+
+    private void flushAll() {
+        imageAssetRepository.flush();
+        gameLogRepository.flush();
+        gameStateSnapshotRepository.flush();
+        gameSessionRepository.flush();
     }
 
     public record LoadedTurn(

--- a/src/main/java/com/uctale/uctale/application/game/GameStateRecovery.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameStateRecovery.java
@@ -1,0 +1,41 @@
+package com.uctale.uctale.application.game;
+
+import com.uctale.uctale.domain.GameLog;
+import com.uctale.uctale.domain.GameSession;
+import com.uctale.uctale.domain.game.GameState;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class GameStateRecovery {
+
+    public GameState recover(GameSession session, List<GameLog> logs) {
+        if (logs.isEmpty()) {
+            throw new IllegalStateException("GameState를 복구할 게임 로그가 없습니다.");
+        }
+
+        GameLog opening = logs.getFirst();
+        if (opening.getTurnNumber() != 1 || opening.getPreviousStateVersion() != 0 || opening.getStateVersion() != 1) {
+            throw new IllegalStateException("Opening GameLog의 state transition이 올바르지 않습니다.");
+        }
+
+        GameState state = GameState.initial(
+                session.getWorldSetting(),
+                session.getCharacterSetting(),
+                opening.getStoryText()
+        );
+        for (int i = 1; i < logs.size(); i++) {
+            GameLog log = logs.get(i);
+            if (log.getTurnNumber() != state.turnNumber() + 1
+                    || log.getPreviousStateVersion() != state.turnNumber()
+                    || log.getStateVersion() != state.turnNumber() + 1
+                    || log.getInputChoiceText() == null
+                    || log.getInputChoiceText().isBlank()) {
+                throw new IllegalStateException("GameLog state transition을 복구할 수 없습니다.");
+            }
+            state = state.advance(log.getInputChoiceText(), log.getStoryText());
+        }
+        return state;
+    }
+}

--- a/src/main/java/com/uctale/uctale/application/game/GameTurnCommit.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameTurnCommit.java
@@ -1,0 +1,50 @@
+package com.uctale.uctale.application.game;
+
+import com.uctale.uctale.application.image.ImageAssetService;
+import com.uctale.uctale.domain.game.GameState;
+
+public record GameTurnCommit(
+        int expectedTurn,
+        int inputChoiceId,
+        String inputChoiceText,
+        GameState previousState,
+        GameState nextState,
+        String storyText,
+        String choicesJson,
+        ImageAssetService.AssetReference imageAsset
+) {
+    public GameTurnCommit {
+        if (expectedTurn < 1) {
+            throw new IllegalArgumentException("expectedTurn은 1 이상이어야 합니다.");
+        }
+        if (inputChoiceId < 1) {
+            throw new IllegalArgumentException("inputChoiceId는 1 이상이어야 합니다.");
+        }
+        if (inputChoiceText == null || inputChoiceText.isBlank()) {
+            throw new IllegalArgumentException("inputChoiceText는 비어 있을 수 없습니다.");
+        }
+        if (previousState == null || nextState == null) {
+            throw new IllegalArgumentException("state transition은 null일 수 없습니다.");
+        }
+        if (previousState.turnNumber() != expectedTurn) {
+            throw new IllegalArgumentException("previousState turn과 expectedTurn이 일치해야 합니다.");
+        }
+        if (nextState.turnNumber() != expectedTurn + 1) {
+            throw new IllegalArgumentException("nextState는 expectedTurn의 다음 turn이어야 합니다.");
+        }
+        if (storyText == null || storyText.isBlank()) {
+            throw new IllegalArgumentException("storyText는 비어 있을 수 없습니다.");
+        }
+        if (choicesJson == null) {
+            throw new IllegalArgumentException("choicesJson은 null일 수 없습니다.");
+        }
+    }
+
+    public int previousStateVersion() {
+        return previousState.turnNumber();
+    }
+
+    public int nextStateVersion() {
+        return nextState.turnNumber();
+    }
+}

--- a/src/main/java/com/uctale/uctale/domain/GameLog.java
+++ b/src/main/java/com/uctale/uctale/domain/GameLog.java
@@ -39,6 +39,18 @@ public class GameLog {
     @Column(nullable = false)
     private int turnNumber;
 
+    @Column(name = "input_choice_id")
+    private Integer inputChoiceId;
+
+    @Column(name = "input_choice_text")
+    private String inputChoiceText;
+
+    @Column(name = "previous_state_version", nullable = false)
+    private int previousStateVersion;
+
+    @Column(name = "state_version", nullable = false)
+    private int stateVersion;
+
     @Column(columnDefinition = "TEXT")
     private String storyText;
 
@@ -48,20 +60,72 @@ public class GameLog {
     @Column(columnDefinition = "TEXT")
     private String imageUrl;
 
-    private String userChoice;
-
     @CreatedDate
-    private LocalDateTime createdAt;
+    @Column(name = "created_at")
+    private LocalDateTime committedAt;
 
-    public GameLog(GameSession gameSession, int turnNumber, String storyText, String choicesJson, String imageUrl) {
+    public static GameLog opening(
+            GameSession gameSession,
+            String storyText,
+            String choicesJson,
+            String imageUrl
+    ) {
+        return new GameLog(
+                gameSession,
+                1,
+                null,
+                null,
+                0,
+                1,
+                storyText,
+                choicesJson,
+                imageUrl
+        );
+    }
+
+    public static GameLog committedTurn(
+            GameSession gameSession,
+            int turnNumber,
+            int inputChoiceId,
+            String inputChoiceText,
+            int previousStateVersion,
+            int stateVersion,
+            String storyText,
+            String choicesJson,
+            String imageUrl
+    ) {
+        return new GameLog(
+                gameSession,
+                turnNumber,
+                inputChoiceId,
+                inputChoiceText,
+                previousStateVersion,
+                stateVersion,
+                storyText,
+                choicesJson,
+                imageUrl
+        );
+    }
+
+    private GameLog(
+            GameSession gameSession,
+            int turnNumber,
+            Integer inputChoiceId,
+            String inputChoiceText,
+            int previousStateVersion,
+            int stateVersion,
+            String storyText,
+            String choicesJson,
+            String imageUrl
+    ) {
         this.gameSession = gameSession;
         this.turnNumber = turnNumber;
+        this.inputChoiceId = inputChoiceId;
+        this.inputChoiceText = inputChoiceText;
+        this.previousStateVersion = previousStateVersion;
+        this.stateVersion = stateVersion;
         this.storyText = storyText;
         this.choicesJson = choicesJson;
         this.imageUrl = imageUrl;
-    }
-
-    public void updateUserChoice(String userChoice) {
-        this.userChoice = userChoice;
     }
 }

--- a/src/main/java/com/uctale/uctale/domain/GameLog.java
+++ b/src/main/java/com/uctale/uctale/domain/GameLog.java
@@ -13,12 +13,14 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Immutable;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @Entity
+@Immutable
 @Table(uniqueConstraints = @UniqueConstraint(
         name = "uk_game_log_session_turn",
         columnNames = {"session_id", "turn_number"}

--- a/src/main/java/com/uctale/uctale/service/GameService.java
+++ b/src/main/java/com/uctale/uctale/service/GameService.java
@@ -6,12 +6,14 @@ import com.uctale.uctale.application.cost.CostRequestContext;
 import com.uctale.uctale.application.cost.ProviderCallTelemetry;
 import com.uctale.uctale.application.game.ChoiceCodec;
 import com.uctale.uctale.application.game.GamePersistenceService;
+import com.uctale.uctale.application.game.GameTurnCommit;
 import com.uctale.uctale.application.game.ImagePromptComposer;
 import com.uctale.uctale.application.image.ImageAssetService;
 import com.uctale.uctale.application.narrative.InvalidNarrativeResponseException;
 import com.uctale.uctale.application.narrative.NarrativeContext;
 import com.uctale.uctale.application.narrative.NarrativeGenerator;
 import com.uctale.uctale.application.narrative.NarrativeTurn;
+import com.uctale.uctale.domain.game.GameState;
 import com.uctale.uctale.dto.GameChoice;
 import com.uctale.uctale.dto.GameInitRequest;
 import com.uctale.uctale.dto.GameProgressRequest;
@@ -111,9 +113,22 @@ public class GameService {
             log.info("시각적 변화 없음 -> 이전 이미지 asset 재사용");
         }
 
+        GameState nextState = loadedTurn.gameState().advance(userChoiceText, nextTurn.storyText());
+        GameTurnCommit commit = new GameTurnCommit(
+                request.expectedTurn(),
+                request.choiceId(),
+                userChoiceText,
+                loadedTurn.gameState(),
+                nextState,
+                nextTurn.storyText(),
+                choiceCodec.serialize(choices),
+                imageAsset
+        );
+
         int savedTurn = gamePersistenceService.saveNextTurn(
-                costContext.ownerKey(), loadedTurn.sessionId(), request.expectedTurn(), userChoiceText,
-                nextTurn.storyText(), choiceCodec.serialize(choices), imageAsset
+                costContext.ownerKey(),
+                loadedTurn.sessionId(),
+                commit
         );
 
         return toResponse(loadedTurn.sessionId(), savedTurn, nextTurn, choices, imageUrl);

--- a/src/main/resources/db/migration/V6__make_game_log_append_only_ledger.sql
+++ b/src/main/resources/db/migration/V6__make_game_log_append_only_ledger.sql
@@ -1,0 +1,35 @@
+alter table game_log
+    add column input_choice_id integer;
+
+alter table game_log
+    add column input_choice_text varchar(255);
+
+alter table game_log
+    add column previous_state_version integer;
+
+alter table game_log
+    add column state_version integer;
+
+update game_log
+set input_choice_text = (
+    select previous_log.user_choice
+    from game_log previous_log
+    where previous_log.session_id = game_log.session_id
+      and previous_log.turn_number = game_log.turn_number - 1
+);
+
+update game_log
+set previous_state_version = case
+    when turn_number = 1 then 0
+    else turn_number - 1
+end,
+    state_version = turn_number;
+
+alter table game_log
+    alter column previous_state_version set not null;
+
+alter table game_log
+    alter column state_version set not null;
+
+alter table game_log
+    drop column user_choice;

--- a/src/main/resources/db/migration/V6__make_game_log_append_only_ledger.sql
+++ b/src/main/resources/db/migration/V6__make_game_log_append_only_ledger.sql
@@ -30,6 +30,3 @@ alter table game_log
 
 alter table game_log
     alter column state_version set not null;
-
-alter table game_log
-    drop column user_choice;

--- a/src/test/java/com/uctale/uctale/application/game/GamePersistenceIntegrityTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/GamePersistenceIntegrityTest.java
@@ -26,6 +26,7 @@ class GamePersistenceIntegrityTest {
     @Mock private GameStateSnapshotRepository gameStateSnapshotRepository;
     @Mock private ImageAssetRepository imageAssetRepository;
     @Mock private GameStateCodec gameStateCodec;
+    @Mock private GameStateRecovery gameStateRecovery;
 
     private GamePersistenceService persistenceService;
     private GameTurnCommit commit;
@@ -37,7 +38,8 @@ class GamePersistenceIntegrityTest {
                 gameLogRepository,
                 gameStateSnapshotRepository,
                 imageAssetRepository,
-                gameStateCodec
+                gameStateCodec,
+                gameStateRecovery
         );
         GameState previousState = GameState.initial("세계관", "캐릭터", "첫 이야기");
         commit = new GameTurnCommit(

--- a/src/test/java/com/uctale/uctale/application/game/GamePersistenceIntegrityTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/GamePersistenceIntegrityTest.java
@@ -1,5 +1,6 @@
 package com.uctale.uctale.application.game;
 
+import com.uctale.uctale.domain.game.GameState;
 import com.uctale.uctale.repository.GameLogRepository;
 import com.uctale.uctale.repository.GameSessionRepository;
 import com.uctale.uctale.repository.GameStateSnapshotRepository;
@@ -27,6 +28,7 @@ class GamePersistenceIntegrityTest {
     @Mock private GameStateCodec gameStateCodec;
 
     private GamePersistenceService persistenceService;
+    private GameTurnCommit commit;
 
     @BeforeEach
     void setUp() {
@@ -37,6 +39,17 @@ class GamePersistenceIntegrityTest {
                 imageAssetRepository,
                 gameStateCodec
         );
+        GameState previousState = GameState.initial("세계관", "캐릭터", "첫 이야기");
+        commit = new GameTurnCommit(
+                1,
+                1,
+                "선택",
+                previousState,
+                previousState.advance("선택", "본문"),
+                "본문",
+                "[]",
+                null
+        );
     }
 
     @Test
@@ -45,9 +58,8 @@ class GamePersistenceIntegrityTest {
         given(gameSessionRepository.findByIdAndOwnerKey(42L, OWNER_KEY))
                 .willThrow(new DataIntegrityViolationException("not-null constraint violation"));
 
-        assertThatThrownBy(() -> persistenceService.saveNextTurn(
-                OWNER_KEY, 42L, 1, "선택", "본문", "[]", null
-        )).isInstanceOf(PersistenceOperationException.class)
+        assertThatThrownBy(() -> persistenceService.saveNextTurn(OWNER_KEY, 42L, commit))
+                .isInstanceOf(PersistenceOperationException.class)
                 .isNotInstanceOf(TurnConflictException.class);
     }
 
@@ -57,9 +69,8 @@ class GamePersistenceIntegrityTest {
         given(gameSessionRepository.findByIdAndOwnerKey(42L, OWNER_KEY))
                 .willThrow(new DataIntegrityViolationException("constraint uk_game_log_session_turn violated"));
 
-        assertThatThrownBy(() -> persistenceService.saveNextTurn(
-                OWNER_KEY, 42L, 1, "선택", "본문", "[]", null
-        )).isInstanceOf(TurnConflictException.class);
+        assertThatThrownBy(() -> persistenceService.saveNextTurn(OWNER_KEY, 42L, commit))
+                .isInstanceOf(TurnConflictException.class);
     }
 
     @Test
@@ -68,8 +79,7 @@ class GamePersistenceIntegrityTest {
         given(gameSessionRepository.findByIdAndOwnerKey(42L, OWNER_KEY))
                 .willThrow(new DataIntegrityViolationException("constraint uk_image_asset_session_turn violated"));
 
-        assertThatThrownBy(() -> persistenceService.saveNextTurn(
-                OWNER_KEY, 42L, 1, "선택", "본문", "[]", null
-        )).isInstanceOf(TurnConflictException.class);
+        assertThatThrownBy(() -> persistenceService.saveNextTurn(OWNER_KEY, 42L, commit))
+                .isInstanceOf(TurnConflictException.class);
     }
 }

--- a/src/test/java/com/uctale/uctale/application/game/GamePersistenceServiceTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/GamePersistenceServiceTest.java
@@ -1,8 +1,10 @@
 package com.uctale.uctale.application.game;
 
 import com.uctale.uctale.application.image.ImageAssetService;
+import com.uctale.uctale.domain.GameLog;
 import com.uctale.uctale.domain.GameSession;
 import com.uctale.uctale.domain.ImageAsset;
+import com.uctale.uctale.domain.game.GameState;
 import com.uctale.uctale.repository.GameLogRepository;
 import com.uctale.uctale.repository.GameSessionRepository;
 import com.uctale.uctale.repository.GameStateSnapshotRepository;
@@ -12,6 +14,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -35,23 +39,53 @@ class GamePersistenceServiceTest {
         GameSession session = gamePersistenceService.saveOpening(
                 OWNER_A, "세계관", "캐릭터", "첫 이야기", "[{\"id\":1,\"text\":\"진행\"}]", null
         );
+        GameState initialState = gamePersistenceService.loadLatestTurn(OWNER_A, session.getId(), 1).gameState();
+        GameTurnCommit commit = commit(initialState, 1, "진행", "두 번째 이야기", "[{\"id\":1,\"text\":\"계속\"}]");
 
         assertThat(gameSessionRepository.findById(session.getId()).orElseThrow().getOwnerKey()).isEqualTo(OWNER_A);
-        assertThat(gamePersistenceService.loadLatestTurn(OWNER_A, session.getId(), 1).sessionId()).isEqualTo(session.getId());
         assertThatThrownBy(() -> gamePersistenceService.loadLatestTurn(OWNER_B, session.getId(), 1))
                 .isInstanceOf(GameSessionNotFoundException.class);
-        assertThatThrownBy(() -> gamePersistenceService.saveNextTurn(
-                OWNER_B, session.getId(), 1, "진행", "침입", "[]", null
-        )).isInstanceOf(GameSessionNotFoundException.class);
+        assertThatThrownBy(() -> gamePersistenceService.saveNextTurn(OWNER_B, session.getId(), commit))
+                .isInstanceOf(GameSessionNotFoundException.class);
 
-        int savedTurn = gamePersistenceService.saveNextTurn(
-                OWNER_A, session.getId(), 1, "진행", "두 번째 이야기",
-                "[{\"id\":1,\"text\":\"계속\"}]", null
-        );
+        int savedTurn = gamePersistenceService.saveNextTurn(OWNER_A, session.getId(), commit);
 
         assertThat(savedTurn).isEqualTo(2);
         assertThat(gameLogRepository.count()).isEqualTo(2);
         assertThat(gameSessionRepository.findById(session.getId()).orElseThrow().getCurrentTurn()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("새 완료 turn은 입력·state version·결과를 자기 행에 한 번에 기록한다")
+    void saveNextTurn_AppendsSelfContainedCommittedTurn() {
+        GameSession session = gamePersistenceService.saveOpening(
+                OWNER_A, "세계관", "캐릭터", "첫 이야기", "[{\"id\":7,\"text\":\"문을 연다\"}]", null
+        );
+        GameState initialState = gamePersistenceService.loadLatestTurn(OWNER_A, session.getId(), 1).gameState();
+
+        gamePersistenceService.saveNextTurn(
+                OWNER_A,
+                session.getId(),
+                commit(initialState, 7, "문을 연다", "두 번째 이야기", "[{\"id\":3,\"text\":\"살핀다\"}]")
+        );
+
+        List<GameLog> logs = gameLogRepository.findByGameSessionOrderByTurnNumberAsc(session);
+        assertThat(logs).hasSize(2);
+
+        GameLog opening = logs.getFirst();
+        assertThat(opening.getInputChoiceId()).isNull();
+        assertThat(opening.getInputChoiceText()).isNull();
+        assertThat(opening.getPreviousStateVersion()).isZero();
+        assertThat(opening.getStateVersion()).isEqualTo(1);
+
+        GameLog committed = logs.get(1);
+        assertThat(committed.getInputChoiceId()).isEqualTo(7);
+        assertThat(committed.getInputChoiceText()).isEqualTo("문을 연다");
+        assertThat(committed.getPreviousStateVersion()).isEqualTo(1);
+        assertThat(committed.getStateVersion()).isEqualTo(2);
+        assertThat(committed.getStoryText()).isEqualTo("두 번째 이야기");
+        assertThat(committed.getChoicesJson()).contains("살핀다");
+        assertThat(committed.getCommittedAt()).isNotNull();
     }
 
     @Test
@@ -82,13 +116,16 @@ class GamePersistenceServiceTest {
     }
 
     @Test
-    @DisplayName("스냅샷이 없는 동일 owner 세션은 저장된 로그에서 GameState를 복구한다")
-    void loadLatestTurn_RecoversLegacySnapshotForOwnedSession() {
+    @DisplayName("snapshot이 없으면 append-only 로그의 자기 행 입력으로 GameState를 복구한다")
+    void loadLatestTurn_RecoversStateFromCommittedTurnLedger() {
         GameSession session = gamePersistenceService.saveOpening(
                 OWNER_A, "세계관", "캐릭터", "첫 이야기", "[]", null
         );
+        GameState initialState = gamePersistenceService.loadLatestTurn(OWNER_A, session.getId(), 1).gameState();
         gamePersistenceService.saveNextTurn(
-                OWNER_A, session.getId(), 1, "진행", "두 번째 이야기", "[]", null
+                OWNER_A,
+                session.getId(),
+                commit(initialState, 1, "진행", "두 번째 이야기", "[]")
         );
         gameStateSnapshotRepository.deleteById(session.getId());
         gameStateSnapshotRepository.flush();
@@ -97,10 +134,11 @@ class GamePersistenceServiceTest {
 
         assertThat(loaded.gameState().turnNumber()).isEqualTo(2);
         assertThat(loaded.gameState().storyMemory().recentTurns()).hasSize(2);
+        assertThat(loaded.gameState().storyMemory().recentTurns().getLast().playerAction()).isEqualTo("진행");
     }
 
     @Test
-    @DisplayName("동일 owner의 최신 턴 snapshot은 세션과 로그 상태가 일치한다")
+    @DisplayName("동일 owner의 최신 턴 snapshot은 세션과 로그 state version이 일치한다")
     void loadLatestTurn_ReturnsConsistentSnapshot() {
         GameSession session = gamePersistenceService.saveOpening(
                 OWNER_A, "세계관", "캐릭터", "첫 이야기", "[]", null
@@ -112,5 +150,26 @@ class GamePersistenceServiceTest {
         assertThat(loaded.turnNumber()).isEqualTo(1);
         assertThat(loaded.storyText()).isEqualTo("첫 이야기");
         assertThat(loaded.gameState().storyMemory().canonicalFacts()).hasSize(2);
+        assertThat(gameLogRepository.findTopByGameSessionOrderByTurnNumberDesc(session).orElseThrow().getStateVersion())
+                .isEqualTo(loaded.gameState().turnNumber());
+    }
+
+    private GameTurnCommit commit(
+            GameState previousState,
+            int choiceId,
+            String choiceText,
+            String storyText,
+            String choicesJson
+    ) {
+        return new GameTurnCommit(
+                previousState.turnNumber(),
+                choiceId,
+                choiceText,
+                previousState,
+                previousState.advance(choiceText, storyText),
+                storyText,
+                choicesJson,
+                null
+        );
     }
 }

--- a/src/test/java/com/uctale/uctale/persistence/PostgresGameLogMigrationTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/PostgresGameLogMigrationTest.java
@@ -89,14 +89,10 @@ class PostgresGameLogMigrationTest extends PostgresIntegrationTestSupport {
             }
 
             try (ResultSet legacyColumn = statement.executeQuery("""
-                    select count(*)
-                    from information_schema.columns
-                    where table_schema = 'game_log_v6_legacy'
-                      and table_name = 'game_log'
-                      and column_name = 'user_choice'
+                    select user_choice from game_log where turn_number = 1
                     """)) {
                 assertThat(legacyColumn.next()).isTrue();
-                assertThat(legacyColumn.getInt(1)).isZero();
+                assertThat(legacyColumn.getString("user_choice")).isEqualTo("문을 연다");
             }
         }
     }

--- a/src/test/java/com/uctale/uctale/persistence/PostgresGameLogMigrationTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/PostgresGameLogMigrationTest.java
@@ -1,0 +1,103 @@
+package com.uctale.uctale.persistence;
+
+import com.uctale.uctale.support.PostgresIntegrationTestSupport;
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationVersion;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PostgresGameLogMigrationTest extends PostgresIntegrationTestSupport {
+
+    @Test
+    @DisplayName("V5 legacy GameLog 선택 텍스트를 다음 committed turn 자기 행으로 이관한다")
+    void v6_MigratesLegacyUserChoiceIntoCommittedTurnRow() throws Exception {
+        String schema = "game_log_v6_legacy";
+        Flyway legacyFlyway = Flyway.configure()
+                .dataSource(POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword())
+                .schemas(schema)
+                .defaultSchema(schema)
+                .target(MigrationVersion.fromVersion("5"))
+                .load();
+        legacyFlyway.migrate();
+
+        try (Connection connection = DriverManager.getConnection(
+                POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
+             Statement statement = connection.createStatement()) {
+            statement.execute("set search_path to " + schema);
+            statement.executeUpdate("""
+                    insert into game_session (
+                        owner_key, world_setting, character_setting, is_game_over, current_turn, version
+                    ) values (
+                        'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', '세계관', '캐릭터', false, 2, 1
+                    )
+                    """);
+            statement.executeUpdate("""
+                    insert into game_log (
+                        session_id, turn_number, story_text, choices_json, user_choice
+                    ) values (
+                        1, 1, '첫 이야기', '[{"id":7,"text":"문을 연다"}]', '문을 연다'
+                    )
+                    """);
+            statement.executeUpdate("""
+                    insert into game_log (
+                        session_id, turn_number, story_text, choices_json, user_choice
+                    ) values (
+                        1, 2, '두 번째 이야기', '[{"id":3,"text":"살핀다"}]', null
+                    )
+                    """);
+        }
+
+        Flyway latestFlyway = Flyway.configure()
+                .dataSource(POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword())
+                .schemas(schema)
+                .defaultSchema(schema)
+                .load();
+        latestFlyway.migrate();
+
+        try (Connection connection = DriverManager.getConnection(
+                POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
+             Statement statement = connection.createStatement()) {
+            statement.execute("set search_path to " + schema);
+
+            try (ResultSet opening = statement.executeQuery("""
+                    select input_choice_id, input_choice_text, previous_state_version, state_version
+                    from game_log where turn_number = 1
+                    """)) {
+                assertThat(opening.next()).isTrue();
+                assertThat(opening.getObject("input_choice_id")).isNull();
+                assertThat(opening.getString("input_choice_text")).isNull();
+                assertThat(opening.getInt("previous_state_version")).isZero();
+                assertThat(opening.getInt("state_version")).isEqualTo(1);
+            }
+
+            try (ResultSet secondTurn = statement.executeQuery("""
+                    select input_choice_id, input_choice_text, previous_state_version, state_version
+                    from game_log where turn_number = 2
+                    """)) {
+                assertThat(secondTurn.next()).isTrue();
+                assertThat(secondTurn.getObject("input_choice_id")).isNull();
+                assertThat(secondTurn.getString("input_choice_text")).isEqualTo("문을 연다");
+                assertThat(secondTurn.getInt("previous_state_version")).isEqualTo(1);
+                assertThat(secondTurn.getInt("state_version")).isEqualTo(2);
+            }
+
+            try (ResultSet legacyColumn = statement.executeQuery("""
+                    select count(*)
+                    from information_schema.columns
+                    where table_schema = 'game_log_v6_legacy'
+                      and table_name = 'game_log'
+                      and column_name = 'user_choice'
+                    """)) {
+                assertThat(legacyColumn.next()).isTrue();
+                assertThat(legacyColumn.getInt(1)).isZero();
+            }
+        }
+    }
+}

--- a/src/test/java/com/uctale/uctale/persistence/PostgresPersistenceBaselineTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/PostgresPersistenceBaselineTest.java
@@ -37,7 +37,7 @@ class PostgresPersistenceBaselineTest extends PostgresIntegrationTestSupport {
         assertThat(flyway.info().pending()).isEmpty();
         assertThat(flyway.info().applied())
                 .extracting(info -> info.getVersion().getVersion())
-                .contains("1", "2", "3", "4", "5");
+                .contains("1", "2", "3", "4", "5", "6");
 
         assertThat(tableExists("game_session")).isTrue();
         assertThat(tableExists("game_log")).isTrue();
@@ -114,8 +114,14 @@ class PostgresPersistenceBaselineTest extends PostgresIntegrationTestSupport {
 
     private void insertGameLog(Long sessionId, int turnNumber) {
         jdbcTemplate.update(
-                "insert into game_log (session_id, turn_number, story_text, choices_json) values (?, ?, ?, ?)",
+                """
+                insert into game_log (
+                    session_id, turn_number, previous_state_version, state_version, story_text, choices_json
+                ) values (?, ?, ?, ?, ?, ?)
+                """,
                 sessionId,
+                turnNumber,
+                turnNumber - 1,
                 turnNumber,
                 "이야기",
                 "[]"

--- a/src/test/java/com/uctale/uctale/service/GameServiceTest.java
+++ b/src/test/java/com/uctale/uctale/service/GameServiceTest.java
@@ -6,6 +6,7 @@ import com.uctale.uctale.application.cost.CostRateLimiter;
 import com.uctale.uctale.application.cost.ProviderCallTelemetry;
 import com.uctale.uctale.application.game.ChoiceCodec;
 import com.uctale.uctale.application.game.GamePersistenceService;
+import com.uctale.uctale.application.game.GameTurnCommit;
 import com.uctale.uctale.application.game.ImagePromptComposer;
 import com.uctale.uctale.application.game.TurnConflictException;
 import com.uctale.uctale.application.image.ImageAssetService;
@@ -33,7 +34,6 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
@@ -96,9 +96,9 @@ class GameServiceTest {
     }
 
     @Test
-    @DisplayName("시각적 변화가 없으면 이전 image asset을 재사용한다")
-    void progressGame_UsesCanonicalGameState() {
-        String choicesJson = choiceCodec.serialize(List.of(new GameChoice(1, "문을 잠근다")));
+    @DisplayName("progress는 persistence 전에 입력과 다음 canonical state를 확정한다")
+    void progressGame_PreparesCommittedStateTransitionBeforePersistence() {
+        String choicesJson = choiceCodec.serialize(List.of(new GameChoice(7, "문을 잠근다")));
         GamePersistenceService.LoadedTurn loadedTurn = loadedTurn(choicesJson);
         NarrativeTurn nextTurn = new NarrativeTurn(
                 "다음 장면", "다음 스토리",
@@ -108,20 +108,27 @@ class GameServiceTest {
 
         given(gamePersistenceService.loadLatestTurn(OWNER_KEY, 42L, 1)).willReturn(loadedTurn);
         given(narrativeGenerator.createNextTurn(any(NarrativeContext.class))).willReturn(nextTurn);
-        given(gamePersistenceService.saveNextTurn(
-                OWNER_KEY, 42L, 1, "문을 잠근다", "다음 스토리",
-                "[{\"id\":1,\"text\":\"기다린다\"}]", null
-        )).willReturn(2);
+        given(gamePersistenceService.saveNextTurn(eq(OWNER_KEY), eq(42L), any(GameTurnCommit.class))).willReturn(2);
 
-        GameResponse response = gameService.progressGame(OWNER_KEY, new GameProgressRequest(42L, 1, 1));
+        GameResponse response = gameService.progressGame(OWNER_KEY, new GameProgressRequest(42L, 7, 1));
 
         assertThat(response.turnNumber()).isEqualTo(2);
         assertThat(response.mainImageUrl()).isEqualTo("/api/game/image-assets/old-asset");
+
         ArgumentCaptor<NarrativeContext> contextCaptor = ArgumentCaptor.forClass(NarrativeContext.class);
         verify(narrativeGenerator).createNextTurn(contextCaptor.capture());
         assertThat(contextCaptor.getValue().playerAction()).isEqualTo("문을 잠근다");
+
+        ArgumentCaptor<GameTurnCommit> commitCaptor = ArgumentCaptor.forClass(GameTurnCommit.class);
+        verify(gamePersistenceService).saveNextTurn(eq(OWNER_KEY), eq(42L), commitCaptor.capture());
+        GameTurnCommit commit = commitCaptor.getValue();
+        assertThat(commit.inputChoiceId()).isEqualTo(7);
+        assertThat(commit.inputChoiceText()).isEqualTo("문을 잠근다");
+        assertThat(commit.previousStateVersion()).isEqualTo(1);
+        assertThat(commit.nextStateVersion()).isEqualTo(2);
+        assertThat(commit.nextState().storyMemory().recentTurns()).hasSize(2);
+        assertThat(commit.storyText()).isEqualTo("다음 스토리");
         verify(imageAssetService, never()).issue(any(), any());
-        verify(gamePersistenceService).saveNextTurn(eq(OWNER_KEY), eq(42L), eq(1), any(), any(), any(), eq(null));
     }
 
     @Test
@@ -135,7 +142,7 @@ class GameServiceTest {
 
         verify(narrativeGenerator, never()).createNextTurn(any(NarrativeContext.class));
         verify(imageAssetService, never()).issue(any(), any());
-        verify(gamePersistenceService, never()).saveNextTurn(any(), any(), anyInt(), any(), any(), any(), any());
+        verify(gamePersistenceService, never()).saveNextTurn(any(), any(), any(GameTurnCommit.class));
     }
 
     private GamePersistenceService.LoadedTurn loadedTurn(String choicesJson) {


### PR DESCRIPTION
## 왜 필요한가요?

현재 `GameLog`는 turn N을 저장한 뒤, 다음 turn이 진행될 때 turn N의 `userChoice`를 뒤늦게 수정합니다. 이 구조에서는 한 행만 보고 해당 완료 turn을 만든 입력과 결과를 감사하기 어렵고 persistence가 `userChoice + storyText`로 다음 `GameState`까지 계산하고 있습니다.

M2의 idempotency/reservation과 이후 typed action/rule pipeline을 도입하기 전에 `GameLog`를 **commit된 canonical turn만 담는 append-only 원장**으로 고정합니다.

- Closes #28

## 무엇이 바뀌나요?

### GameLog committed-turn ledger

새 non-opening `GameLog` 한 행이 자기 turn의 입력과 결과를 함께 소유합니다.

- `input_choice_id`
- `input_choice_text`
- `previous_state_version`
- `state_version`
- story / choices / image asset reference
- 기존 `created_at`을 entity에서 `committedAt` 의미로 사용

Opening은 외부 입력이 없으므로 input choice가 null이고 state transition은 `0 -> 1`입니다.

기존 `updateUserChoice()`를 제거하고 `GameLog` entity를 Hibernate `@Immutable`로 지정했습니다. 새 turn 저장 시 이전 GameLog를 save/update하지 않습니다.

### 확정 state transition 경계

`GameTurnCommit`을 추가했습니다.

`GameService`가 Narrative 결과 검증 뒤 현재 state에서 다음 state를 확정하고 다음 정보를 persistence에 전달합니다.

- expected turn
- input choice ID/text
- previous / next `GameState`
- narrative story / choices
- image asset reference

`GamePersistenceService.saveNextTurn()`은 더 이상 `GameState.advance(userChoice, storyText)`를 호출하지 않습니다. 대신:

1. session/current turn 확인
2. 이전 GameLog state version 확인
3. DB의 canonical previous state와 commit.previousState 동일성 확인
4. 새 GameLog + snapshot + session + image asset을 원자적으로 저장

Snapshot이 없는 legacy 복구 계산은 별도 `GameStateRecovery`로 분리했습니다.

### V6 migration / legacy 호환

V1~V5의 `user_choice`는 실제로 다음 turn을 만든 입력인데 이전 행에 저장돼 있었습니다.

V6는:

- 이전 행의 `user_choice`를 다음 행의 `input_choice_text`로 이관
- `previous_state_version`, `state_version`을 turn number로 결정적으로 backfill
- 과거에 저장되지 않았던 `choiceId`는 임의 추정하지 않고 `null = historical unknown`으로 보존
- 새 V6 non-opening commit부터는 choice ID/text를 모두 필수 기록

`user_choice` 물리 컬럼은 즉시 drop하지 않습니다. 롤백 시 이전 앱이 schema missing으로 기동하지 못하는 위험을 줄이기 위한 legacy compatibility column으로 남기되, V6 `GameLog` entity에는 매핑하지 않아 새 코드는 읽거나 쓰지 않습니다.

### snapshot / log 역할

- Snapshot: 최신 state 빠른 복구
- GameLog: commit된 canonical turn 감사·진단
- request processing/idempotency/lease 상태는 GameLog에 넣지 않고 #29/#30의 별도 record가 소유

세부 설계는 `docs/architecture/game-log-ledger.md`에 기록했습니다.

## 테스트

### 기존 H2 / Spring integration

- opening ledger의 `0 -> 1` state version
- 완료 turn의 choice ID/text + previous/next version + narrative 결과 자기 행 저장
- 이전 row mutation 없이 2개 turn row 유지
- snapshot 삭제 시 각 committed row 자체의 input으로 state 복구
- snapshot / session / latest GameLog state version 일치
- 기존 ownership / image asset / integrity exception 회귀
- GameService가 persistence 전에 다음 canonical state를 확정하는지 검증

### PostgreSQL (#73 harness)

- production Flyway chain에 V6 포함
- 기존 unique / optimistic locking baseline 유지
- 별도 schema를 V5까지만 migrate한 뒤 legacy fixture 삽입 → V6 최신 migration 수행
- legacy turn1 `user_choice`가 turn2 `input_choice_text`로 정확히 이동
- historical choice ID는 null 유지
- state version backfill 검증
- legacy `user_choice` 물리 컬럼/값은 rollback compatibility를 위해 유지

## PR 전 자체 비판적 리뷰 및 보완

1. **legacy row 의미를 단순 rename하면 틀림**
   - 기존 `user_choice`는 같은 행이 아니라 다음 turn의 입력입니다.
   - V6에서 다음 행의 `input_choice_text`로 shift하도록 migration을 설계했습니다.
2. **과거 choice ID를 추정해서 채울지 검토**
   - 기존 schema에는 실제 selected ID가 없고 text만 있습니다.
   - choices JSON에서 추정값을 만들어 canonical history를 변조하지 않고 `null = historical unknown`으로 보존했습니다.
3. **persistence가 prepared state를 맹신하는 문제 발견**
   - 첫 구현은 previous/next turn number만 검증했습니다.
   - 최종 구현은 DB snapshot/log로 얻은 canonical previous state와 commit.previousState 전체 equality까지 검증합니다.
4. **state recovery 계산이 persistence service에 남는 문제**
   - snapshot 없는 기존 복구의 `advance()`도 별도 `GameStateRecovery`로 이동했습니다.
5. **V6에서 legacy column 즉시 drop 문제**
   - 최초 초안은 `user_choice`를 drop했습니다.
   - append-only 구현에 필요하지 않으면서 rollback 호환성만 악화하므로 물리 컬럼은 유지하고 새 entity mapping만 제거했습니다.
6. **append-only를 convention에만 의존하지 않음**
   - mutation method 제거 외에 Hibernate `@Immutable`을 적용해 ORM dirty update도 억제합니다.
7. **#29/#30 책임 침범 방지**
   - request attempt / PROCESSING / FAILED / lease/idempotency 필드는 GameLog에 추가하지 않았습니다.
8. **#31 version과 의미 충돌 방지**
   - 이번 `state_version`은 canonical turn state 식별자이며 snapshot schema/ruleset version과 다른 개념임을 문서화했습니다.

## 최종 검증

최신 PR commit 기준 GitHub Actions CI #128 전체 성공:

- [x] Backend H2/unit/integration tests
- [x] **PostgreSQL Testcontainers migration/repository tests**
- [x] Backend build
- [x] Frontend tests
- [x] ESLint
- [x] Frontend production build

## 영향 범위

- API request/response shape 변경 없음
- V6 Flyway migration 추가
- production secret/env 변경 없음
- provider 호출 계약 변경 없음
- frontend 변경 없음
- GameLog write semantics와 GameService → persistence 내부 application contract 변경

PR은 merge하지 않고 open 상태로 유지합니다.