### PR TITLE
refactor(game): GameState snapshot 버전과 upgrader 도입

### DIFF
--- a/docs/architecture/game-state-snapshot-evolution.md
+++ b/docs/architecture/game-state-snapshot-evolution.md
@@ -1,0 +1,86 @@
+# GameState snapshot evolution
+
+## 목적
+
+`game_state_snapshot.state_json`은 최신 canonical `GameState`를 빠르게 복구하기 위한 캐시성 snapshot이다. 도메인 필드가 확장되어도 기존 세션을 암묵적 Jackson 기본값에만 의존해 읽지 않도록 JSON 자체에 명시적인 version contract를 둔다.
+
+이 변경은 DB 컬럼을 추가하지 않는다. 버전은 `state_json` envelope 안에 기록하므로 기존 PostgreSQL schema와 Flyway chain을 그대로 사용한다.
+
+## 현재 snapshot 형식
+
+새 write는 항상 현재 형식만 기록한다.
+
+```json
+{
+  "schemaVersion": 1,
+  "rulesetVersion": 1,
+  "state": {
+    "turnNumber": 1,
+    "playerCharacter": {},
+    "worldState": {},
+    "storyMemory": {}
+  }
+}
+```
+
+- `schemaVersion`: snapshot JSON의 구조와 필드 의미가 어떤 evolution 단계인지 나타낸다.
+- `rulesetVersion`: 해당 snapshot을 해석할 때 전제로 삼는 결정적 게임 규칙 계약을 나타낸다. 오래된 ruleset을 현재 규칙으로 자동 재판정하는 용도가 아니다.
+- `state`: 해당 시점의 canonical `GameState` payload다.
+
+현재 지원 버전은 schema `1`, ruleset `1`이다.
+
+## legacy production snapshot
+
+#31 이전 production 형식은 envelope 없이 `GameState` 자체를 `state_json`에 저장했다. 이 형식은 논리적인 schema version `0`으로 취급한다.
+
+legacy 판별은 단순히 `schemaVersion` 누락 여부만 보지 않는다. 기존 raw `GameState`의 최상위 필드인 `turnNumber`, `playerCharacter`, `worldState`, `storyMemory`가 모두 존재하고 envelope 필드가 없어야 한다. 따라서 `schemaVersion`만 유실된 손상 envelope를 legacy로 오인하지 않는다.
+
+v0 -> v1 upgrade는 JSON 구조 변환만 수행한다. provider 호출, 랜덤 판정, LLM 호출, 현재 ruleset에 따른 재판정은 수행하지 않는다.
+
+## read / write 정책
+
+- **write:** 항상 현재 schema/ruleset version의 envelope만 저장한다.
+- **read:** 지원되는 과거 schema를 `GameStateUpgrader`에서 순수 변환한 뒤 현재 `GameState`로 역직렬화한다.
+- **미래 schema:** 현재 서버가 의미를 알 수 없으므로 명시적으로 실패한다.
+- **미지원 ruleset:** 임의 재판정을 피하기 위해 명시적으로 실패한다.
+- **누락/손상 version 또는 state:** legacy raw state로 명확히 식별되지 않는 한 명시적으로 실패한다.
+
+### upgrade 후 DB 재작성 정책
+
+읽기만으로 snapshot을 즉시 재작성하지 않는다.
+
+이유는 다음과 같다.
+
+1. `loadLatestTurn()`의 read-only 경계를 유지한다.
+2. 조회 트래픽만으로 DB write가 발생하거나 장애 시점에 대량 write가 생기는 것을 피한다.
+3. legacy 데이터를 읽을 수 있는 동안 rollback 가능성을 불필요하게 줄이지 않는다.
+
+대신 다음 canonical turn이 정상 commit될 때 기존 snapshot은 현재 버전 envelope로 자연스럽게 재작성된다. 따라서 **read-time upgrade는 in-memory only, next canonical write는 latest-only** 정책을 사용한다.
+
+## GameLog state version과의 관계
+
+#28에서 도입된 `GameLog.previous_state_version` / `state_version`과 snapshot version은 서로 다른 축이다.
+
+- `GameLog.state_version`: 한 세션 안에서 어떤 canonical turn state인지 식별하는 순서 값이다. 현재 opening은 `0 -> 1`, 이후 완료 turn은 `N-1 -> N`으로 진행한다.
+- snapshot `schemaVersion`: JSON 저장 형식의 evolution version이다.
+- snapshot `rulesetVersion`: 결정적 게임 규칙 계약의 version이다.
+
+세 값은 숫자가 우연히 같더라도 서로 비교하거나 대체해서는 안 된다. 예를 들어 turn 20의 state는 `state_version=20`이면서 snapshot은 `schemaVersion=1`, `rulesetVersion=1`일 수 있다.
+
+## snapshot 없는 session 복구와 migration 순서
+
+현재 `main`에는 #28의 append-only committed-turn ledger가 Flyway V6로 이미 반영되어 있다.
+
+정상 배포 순서는 다음과 같다.
+
+1. production Flyway migration을 V6 이상까지 적용한다.
+2. #31 애플리케이션을 배포한다.
+3. snapshot이 존재하면 v0/v1 snapshot read 경로를 사용한다.
+4. snapshot이 없으면 V6 committed `GameLog`의 `input_choice_text`, `previous_state_version`, `state_version`을 검증하며 `GameStateRecovery`가 state를 재구성한다.
+5. 이후 정상 turn commit 시 현재 snapshot envelope가 다시 생성된다.
+
+V1~V5 시절 snapshot raw JSON은 DB migration으로 일괄 변환하지 않는다. V6가 legacy `GameLog.user_choice`를 다음 committed row의 `input_choice_text`로 이관하기 때문에 snapshot 없는 기존 session도 #28 이후 원장 구조에서 결정적으로 복구할 수 있다.
+
+## 향후 schema 추가 규칙
+
+새 schema version을 도입할 때는 한 단계씩 순수 변환하는 upgrader를 추가하고 version별 fixture를 유지한다. upgrade 중 외부 provider, 시간 의존 값, 랜덤 값, LLM 결과를 사용해서는 안 된다. 데이터 의미를 복구할 수 없는 변경은 추정값을 만들어 넣지 말고 명시적 실패 또는 별도 migration 정책으로 처리한다.

--- a/docs/architecture/game-state-snapshot-evolution.md
+++ b/docs/architecture/game-state-snapshot-evolution.md
@@ -31,7 +31,7 @@
 
 ## legacy production snapshot
 
-#31 이전 production 형식은 envelope 없이 `GameState` 자체를 `state_json`에 저장했다. 이 형식은 논리적인 schema version `0`으로 취급한다.
+#31 이전 production 형식은 envelope 없이 `GameState` 자체를 `state_json`에 저장했다. 이 형식은 논리적인 schema version `0`으로 취급한다. 버전 필드가 없던 당시의 게임 규칙 의미는 **legacy ruleset baseline `1`** 로 고정하며, 향후 `CURRENT_RULESET_VERSION`이 증가해도 legacy snapshot의 ruleset 의미를 따라 올리지 않는다.
 
 legacy 판별은 단순히 `schemaVersion` 누락 여부만 보지 않는다. 기존 raw `GameState`의 최상위 필드인 `turnNumber`, `playerCharacter`, `worldState`, `storyMemory`가 모두 존재하고 envelope 필드가 없어야 한다. 따라서 `schemaVersion`만 유실된 손상 envelope를 legacy로 오인하지 않는다.
 

--- a/src/main/java/com/uctale/uctale/application/game/GameStateCodec.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameStateCodec.java
@@ -1,32 +1,45 @@
 package com.uctale.uctale.application.game;
 
-import tools.jackson.core.JacksonException;
-import tools.jackson.databind.ObjectMapper;
 import com.uctale.uctale.domain.game.GameState;
 import org.springframework.stereotype.Component;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.Map;
 
 @Component
 public class GameStateCodec {
 
     private final ObjectMapper objectMapper;
+    private final GameStateUpgrader gameStateUpgrader;
 
-    public GameStateCodec(ObjectMapper objectMapper) {
+    public GameStateCodec(ObjectMapper objectMapper, GameStateUpgrader gameStateUpgrader) {
         this.objectMapper = objectMapper;
+        this.gameStateUpgrader = gameStateUpgrader;
     }
 
     public String serialize(GameState state) {
         try {
-            return objectMapper.writeValueAsString(state);
+            return objectMapper.writeValueAsString(Map.of(
+                    "schemaVersion", GameStateSnapshotFormat.CURRENT_SCHEMA_VERSION,
+                    "rulesetVersion", GameStateSnapshotFormat.CURRENT_RULESET_VERSION,
+                    "state", state
+            ));
         } catch (JacksonException e) {
-            throw new IllegalStateException("GameState 직렬화에 실패했습니다.", e);
+            throw new GameStateSnapshotException("GameState snapshot 직렬화에 실패했습니다.", e);
         }
     }
 
     public GameState deserialize(String json) {
         try {
-            return objectMapper.readValue(json, GameState.class);
-        } catch (JacksonException e) {
-            throw new IllegalStateException("GameState 역직렬화에 실패했습니다.", e);
+            JsonNode root = objectMapper.readTree(json);
+            GameStateUpgrader.UpgradedSnapshot upgraded = gameStateUpgrader.upgrade(root);
+            return objectMapper.readValue(upgraded.state().toString(), GameState.class);
+        } catch (GameStateSnapshotException e) {
+            throw e;
+        } catch (JacksonException | IllegalArgumentException e) {
+            throw new GameStateSnapshotException("GameState snapshot 역직렬화에 실패했습니다.", e);
         }
     }
 }

--- a/src/main/java/com/uctale/uctale/application/game/GameStateSnapshotException.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameStateSnapshotException.java
@@ -1,0 +1,12 @@
+package com.uctale.uctale.application.game;
+
+public class GameStateSnapshotException extends IllegalStateException {
+
+    public GameStateSnapshotException(String message) {
+        super(message);
+    }
+
+    public GameStateSnapshotException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/uctale/uctale/application/game/GameStateSnapshotFormat.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameStateSnapshotFormat.java
@@ -3,6 +3,7 @@ package com.uctale.uctale.application.game;
 final class GameStateSnapshotFormat {
 
     static final int LEGACY_SCHEMA_VERSION = 0;
+    static final int LEGACY_RULESET_VERSION = 1;
     static final int CURRENT_SCHEMA_VERSION = 1;
     static final int CURRENT_RULESET_VERSION = 1;
 

--- a/src/main/java/com/uctale/uctale/application/game/GameStateSnapshotFormat.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameStateSnapshotFormat.java
@@ -1,0 +1,11 @@
+package com.uctale.uctale.application.game;
+
+final class GameStateSnapshotFormat {
+
+    static final int LEGACY_SCHEMA_VERSION = 0;
+    static final int CURRENT_SCHEMA_VERSION = 1;
+    static final int CURRENT_RULESET_VERSION = 1;
+
+    private GameStateSnapshotFormat() {
+    }
+}

--- a/src/main/java/com/uctale/uctale/application/game/GameStateUpgrader.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameStateUpgrader.java
@@ -29,7 +29,7 @@ public class GameStateUpgrader {
             }
             return new VersionedState(
                     GameStateSnapshotFormat.LEGACY_SCHEMA_VERSION,
-                    GameStateSnapshotFormat.CURRENT_RULESET_VERSION,
+                    GameStateSnapshotFormat.LEGACY_RULESET_VERSION,
                     snapshotJson
             );
         }

--- a/src/main/java/com/uctale/uctale/application/game/GameStateUpgrader.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameStateUpgrader.java
@@ -7,15 +7,31 @@ import tools.jackson.databind.JsonNode;
 public class GameStateUpgrader {
 
     public UpgradedSnapshot upgrade(JsonNode snapshotJson) {
+        VersionedState versionedState = readSourceVersion(snapshotJson);
+        while (versionedState.schemaVersion() < GameStateSnapshotFormat.CURRENT_SCHEMA_VERSION) {
+            versionedState = upgradeOneVersion(versionedState);
+        }
+        return new UpgradedSnapshot(
+                versionedState.schemaVersion(),
+                versionedState.rulesetVersion(),
+                versionedState.state()
+        );
+    }
+
+    private VersionedState readSourceVersion(JsonNode snapshotJson) {
         if (snapshotJson == null || !snapshotJson.isObject()) {
             throw new GameStateSnapshotException("GameState snapshot JSON object가 필요합니다.");
         }
 
         if (!snapshotJson.has("schemaVersion")) {
-            if (looksLikeLegacyState(snapshotJson)) {
-                return upgradeLegacy(snapshotJson);
+            if (!looksLikeLegacyState(snapshotJson)) {
+                throw new GameStateSnapshotException("snapshot schemaVersion이 누락되었습니다.");
             }
-            throw new GameStateSnapshotException("snapshot schemaVersion이 누락되었습니다.");
+            return new VersionedState(
+                    GameStateSnapshotFormat.LEGACY_SCHEMA_VERSION,
+                    GameStateSnapshotFormat.CURRENT_RULESET_VERSION,
+                    snapshotJson
+            );
         }
 
         int schemaVersion = requiredInteger(snapshotJson, "schemaVersion");
@@ -26,10 +42,32 @@ public class GameStateUpgrader {
             throw new GameStateSnapshotException("유효하지 않은 snapshot schemaVersion입니다: " + schemaVersion);
         }
 
-        return switch (schemaVersion) {
-            case 1 -> readV1(snapshotJson);
-            default -> throw new GameStateSnapshotException("지원하지 않는 snapshot schemaVersion입니다: " + schemaVersion);
+        int rulesetVersion = requiredInteger(snapshotJson, "rulesetVersion");
+        if (rulesetVersion != GameStateSnapshotFormat.CURRENT_RULESET_VERSION) {
+            throw new GameStateSnapshotException("지원하지 않는 snapshot rulesetVersion입니다: " + rulesetVersion);
+        }
+        JsonNode state = snapshotJson.get("state");
+        if (state == null || !state.isObject()) {
+            throw new GameStateSnapshotException("snapshot state가 누락되었거나 손상되었습니다.");
+        }
+        return new VersionedState(schemaVersion, rulesetVersion, state);
+    }
+
+    private VersionedState upgradeOneVersion(VersionedState source) {
+        return switch (source.schemaVersion()) {
+            case GameStateSnapshotFormat.LEGACY_SCHEMA_VERSION -> upgradeV0ToV1(source);
+            default -> throw new GameStateSnapshotException(
+                    "snapshot schemaVersion " + source.schemaVersion() + "의 다음 upgrade 경로가 없습니다."
+            );
         };
+    }
+
+    private VersionedState upgradeV0ToV1(VersionedState legacy) {
+        return new VersionedState(
+                1,
+                legacy.rulesetVersion(),
+                legacy.state()
+        );
     }
 
     private boolean looksLikeLegacyState(JsonNode snapshotJson) {
@@ -39,30 +77,6 @@ public class GameStateUpgrader {
                 && snapshotJson.has("storyMemory")
                 && !snapshotJson.has("rulesetVersion")
                 && !snapshotJson.has("state");
-    }
-
-    private UpgradedSnapshot upgradeLegacy(JsonNode legacyState) {
-        return new UpgradedSnapshot(
-                GameStateSnapshotFormat.CURRENT_SCHEMA_VERSION,
-                GameStateSnapshotFormat.CURRENT_RULESET_VERSION,
-                legacyState
-        );
-    }
-
-    private UpgradedSnapshot readV1(JsonNode snapshotJson) {
-        int rulesetVersion = requiredInteger(snapshotJson, "rulesetVersion");
-        if (rulesetVersion != GameStateSnapshotFormat.CURRENT_RULESET_VERSION) {
-            throw new GameStateSnapshotException("지원하지 않는 snapshot rulesetVersion입니다: " + rulesetVersion);
-        }
-        JsonNode state = snapshotJson.get("state");
-        if (state == null || !state.isObject()) {
-            throw new GameStateSnapshotException("snapshot state가 누락되었거나 손상되었습니다.");
-        }
-        return new UpgradedSnapshot(
-                GameStateSnapshotFormat.CURRENT_SCHEMA_VERSION,
-                rulesetVersion,
-                state
-        );
     }
 
     private int requiredInteger(JsonNode snapshotJson, String fieldName) {
@@ -75,6 +89,9 @@ public class GameStateUpgrader {
             throw new GameStateSnapshotException("snapshot " + fieldName + "이 지원 범위를 벗어났습니다: " + version);
         }
         return (int) version;
+    }
+
+    private record VersionedState(int schemaVersion, int rulesetVersion, JsonNode state) {
     }
 
     public record UpgradedSnapshot(int schemaVersion, int rulesetVersion, JsonNode state) {

--- a/src/main/java/com/uctale/uctale/application/game/GameStateUpgrader.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameStateUpgrader.java
@@ -12,7 +12,10 @@ public class GameStateUpgrader {
         }
 
         if (!snapshotJson.has("schemaVersion")) {
-            return upgradeLegacy(snapshotJson);
+            if (looksLikeLegacyState(snapshotJson)) {
+                return upgradeLegacy(snapshotJson);
+            }
+            throw new GameStateSnapshotException("snapshot schemaVersion이 누락되었습니다.");
         }
 
         int schemaVersion = requiredInteger(snapshotJson, "schemaVersion");
@@ -27,6 +30,15 @@ public class GameStateUpgrader {
             case 1 -> readV1(snapshotJson);
             default -> throw new GameStateSnapshotException("지원하지 않는 snapshot schemaVersion입니다: " + schemaVersion);
         };
+    }
+
+    private boolean looksLikeLegacyState(JsonNode snapshotJson) {
+        return snapshotJson.has("turnNumber")
+                && snapshotJson.has("playerCharacter")
+                && snapshotJson.has("worldState")
+                && snapshotJson.has("storyMemory")
+                && !snapshotJson.has("rulesetVersion")
+                && !snapshotJson.has("state");
     }
 
     private UpgradedSnapshot upgradeLegacy(JsonNode legacyState) {
@@ -58,7 +70,11 @@ public class GameStateUpgrader {
         if (value == null || !value.isIntegralNumber()) {
             throw new GameStateSnapshotException("snapshot " + fieldName + "이 누락되었거나 정수가 아닙니다.");
         }
-        return value.asInt();
+        long version = value.asLong();
+        if (version < Integer.MIN_VALUE || version > Integer.MAX_VALUE) {
+            throw new GameStateSnapshotException("snapshot " + fieldName + "이 지원 범위를 벗어났습니다: " + version);
+        }
+        return (int) version;
     }
 
     public record UpgradedSnapshot(int schemaVersion, int rulesetVersion, JsonNode state) {

--- a/src/main/java/com/uctale/uctale/application/game/GameStateUpgrader.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameStateUpgrader.java
@@ -1,0 +1,66 @@
+package com.uctale.uctale.application.game;
+
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+
+@Component
+public class GameStateUpgrader {
+
+    public UpgradedSnapshot upgrade(JsonNode snapshotJson) {
+        if (snapshotJson == null || !snapshotJson.isObject()) {
+            throw new GameStateSnapshotException("GameState snapshot JSON object가 필요합니다.");
+        }
+
+        if (!snapshotJson.has("schemaVersion")) {
+            return upgradeLegacy(snapshotJson);
+        }
+
+        int schemaVersion = requiredInteger(snapshotJson, "schemaVersion");
+        if (schemaVersion > GameStateSnapshotFormat.CURRENT_SCHEMA_VERSION) {
+            throw new GameStateSnapshotException("지원하지 않는 미래 snapshot schemaVersion입니다: " + schemaVersion);
+        }
+        if (schemaVersion < 1) {
+            throw new GameStateSnapshotException("유효하지 않은 snapshot schemaVersion입니다: " + schemaVersion);
+        }
+
+        return switch (schemaVersion) {
+            case 1 -> readV1(snapshotJson);
+            default -> throw new GameStateSnapshotException("지원하지 않는 snapshot schemaVersion입니다: " + schemaVersion);
+        };
+    }
+
+    private UpgradedSnapshot upgradeLegacy(JsonNode legacyState) {
+        return new UpgradedSnapshot(
+                GameStateSnapshotFormat.CURRENT_SCHEMA_VERSION,
+                GameStateSnapshotFormat.CURRENT_RULESET_VERSION,
+                legacyState
+        );
+    }
+
+    private UpgradedSnapshot readV1(JsonNode snapshotJson) {
+        int rulesetVersion = requiredInteger(snapshotJson, "rulesetVersion");
+        if (rulesetVersion != GameStateSnapshotFormat.CURRENT_RULESET_VERSION) {
+            throw new GameStateSnapshotException("지원하지 않는 snapshot rulesetVersion입니다: " + rulesetVersion);
+        }
+        JsonNode state = snapshotJson.get("state");
+        if (state == null || !state.isObject()) {
+            throw new GameStateSnapshotException("snapshot state가 누락되었거나 손상되었습니다.");
+        }
+        return new UpgradedSnapshot(
+                GameStateSnapshotFormat.CURRENT_SCHEMA_VERSION,
+                rulesetVersion,
+                state
+        );
+    }
+
+    private int requiredInteger(JsonNode snapshotJson, String fieldName) {
+        JsonNode value = snapshotJson.get(fieldName);
+        if (value == null || !value.isIntegralNumber()) {
+            throw new GameStateSnapshotException("snapshot " + fieldName + "이 누락되었거나 정수가 아닙니다.");
+        }
+        return value.asInt();
+    }
+
+    public record UpgradedSnapshot(int schemaVersion, int rulesetVersion, JsonNode state) {
+    }
+}

--- a/src/test/java/com/uctale/uctale/application/game/GameStateUpgraderTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/GameStateUpgraderTest.java
@@ -1,0 +1,113 @@
+package com.uctale.uctale.application.game;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GameStateUpgraderTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final GameStateUpgrader upgrader = new GameStateUpgrader();
+
+    @Test
+    @DisplayName("production legacy raw GameState를 schema v1로 순수 upgrade한다")
+    void legacyRawState_IsUpgradedToCurrentSchema() throws Exception {
+        JsonNode legacy = objectMapper.readTree(legacyStateJson());
+
+        GameStateUpgrader.UpgradedSnapshot upgraded = upgrader.upgrade(legacy);
+
+        assertThat(upgraded.schemaVersion()).isEqualTo(1);
+        assertThat(upgraded.rulesetVersion()).isEqualTo(1);
+        assertThat(upgraded.state()).isEqualTo(legacy);
+    }
+
+    @Test
+    @DisplayName("schema v1 snapshot은 state를 그대로 읽는다")
+    void schemaV1_IsReadWithoutMutation() throws Exception {
+        JsonNode snapshot = objectMapper.readTree("""
+                {
+                  "schemaVersion": 1,
+                  "rulesetVersion": 1,
+                  "state": %s
+                }
+                """.formatted(legacyStateJson()));
+
+        GameStateUpgrader.UpgradedSnapshot upgraded = upgrader.upgrade(snapshot);
+
+        assertThat(upgraded.schemaVersion()).isEqualTo(1);
+        assertThat(upgraded.rulesetVersion()).isEqualTo(1);
+        assertThat(upgraded.state().get("turnNumber").asInt()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("미래 schema version은 기본값 처리하지 않고 실패한다")
+    void futureSchemaVersion_FailsExplicitly() throws Exception {
+        JsonNode snapshot = objectMapper.readTree("""
+                {"schemaVersion": 2, "rulesetVersion": 1, "state": {}}
+                """);
+
+        assertThatThrownBy(() -> upgrader.upgrade(snapshot))
+                .isInstanceOf(GameStateSnapshotException.class)
+                .hasMessageContaining("미래 snapshot schemaVersion");
+    }
+
+    @Test
+    @DisplayName("미지원 ruleset version은 자동 재판정하지 않고 실패한다")
+    void unsupportedRulesetVersion_FailsExplicitly() throws Exception {
+        JsonNode snapshot = objectMapper.readTree("""
+                {"schemaVersion": 1, "rulesetVersion": 2, "state": {}}
+                """);
+
+        assertThatThrownBy(() -> upgrader.upgrade(snapshot))
+                .isInstanceOf(GameStateSnapshotException.class)
+                .hasMessageContaining("rulesetVersion");
+    }
+
+    @Test
+    @DisplayName("envelope에서 schemaVersion만 누락된 손상 snapshot은 legacy로 오인하지 않는다")
+    void damagedEnvelopeMissingSchemaVersion_FailsExplicitly() throws Exception {
+        JsonNode snapshot = objectMapper.readTree("""
+                {"rulesetVersion": 1, "state": {}}
+                """);
+
+        assertThatThrownBy(() -> upgrader.upgrade(snapshot))
+                .isInstanceOf(GameStateSnapshotException.class)
+                .hasMessageContaining("schemaVersion이 누락");
+    }
+
+    @Test
+    @DisplayName("schemaVersion이 있어도 state가 누락되면 손상 snapshot으로 실패한다")
+    void missingState_FailsExplicitly() throws Exception {
+        JsonNode snapshot = objectMapper.readTree("""
+                {"schemaVersion": 1, "rulesetVersion": 1}
+                """);
+
+        assertThatThrownBy(() -> upgrader.upgrade(snapshot))
+                .isInstanceOf(GameStateSnapshotException.class)
+                .hasMessageContaining("state가 누락");
+    }
+
+    private String legacyStateJson() {
+        return """
+                {
+                  "turnNumber": 1,
+                  "playerCharacter": {"description": "캐릭터", "stats": {}},
+                  "worldState": {"premise": "세계관", "flags": {}},
+                  "storyMemory": {
+                    "canonicalFacts": [
+                      {"key": "world.premise", "value": "세계관"},
+                      {"key": "player.description", "value": "캐릭터"}
+                    ],
+                    "rollingSummary": "",
+                    "recentTurns": [
+                      {"turnNumber": 1, "playerAction": "", "storyText": "첫 이야기"}
+                    ]
+                  }
+                }
+                """;
+    }
+}

--- a/src/test/java/com/uctale/uctale/application/game/GameStateUpgraderTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/GameStateUpgraderTest.java
@@ -2,13 +2,18 @@ package com.uctale.uctale.application.game;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
+
+import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class GameStateUpgraderTest {
+
+    private static final String LEGACY_FIXTURE = "fixtures/game-state/snapshot-v0-production.json";
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final GameStateUpgrader upgrader = new GameStateUpgrader();
@@ -91,23 +96,10 @@ class GameStateUpgraderTest {
                 .hasMessageContaining("state가 누락");
     }
 
-    private String legacyStateJson() {
-        return """
-                {
-                  "turnNumber": 1,
-                  "playerCharacter": {"description": "캐릭터", "stats": {}},
-                  "worldState": {"premise": "세계관", "flags": {}},
-                  "storyMemory": {
-                    "canonicalFacts": [
-                      {"key": "world.premise", "value": "세계관"},
-                      {"key": "player.description", "value": "캐릭터"}
-                    ],
-                    "rollingSummary": "",
-                    "recentTurns": [
-                      {"turnNumber": 1, "playerAction": "", "storyText": "첫 이야기"}
-                    ]
-                  }
-                }
-                """;
+    private String legacyStateJson() throws Exception {
+        ClassPathResource resource = new ClassPathResource(LEGACY_FIXTURE);
+        try (var inputStream = resource.getInputStream()) {
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        }
     }
 }

--- a/src/test/java/com/uctale/uctale/persistence/PostgresGameStateSnapshotCompatibilityTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/PostgresGameStateSnapshotCompatibilityTest.java
@@ -1,0 +1,94 @@
+package com.uctale.uctale.persistence;
+
+import com.uctale.uctale.application.game.GamePersistenceService;
+import com.uctale.uctale.application.game.GameTurnCommit;
+import com.uctale.uctale.domain.GameSession;
+import com.uctale.uctale.domain.game.GameState;
+import com.uctale.uctale.support.PostgresIntegrationTestSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class PostgresGameStateSnapshotCompatibilityTest extends PostgresIntegrationTestSupport {
+
+    private static final String OWNER_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+    @Autowired private GamePersistenceService gamePersistenceService;
+    @Autowired private JdbcTemplate jdbcTemplate;
+    @Autowired private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.execute("truncate table image_asset, game_state_snapshot, game_log, game_session restart identity cascade");
+    }
+
+    @Test
+    @DisplayName("기존 production raw snapshot을 데이터 손실 없이 읽고 다음 write에서 최신 envelope로 저장한다")
+    void legacyRawSnapshot_IsReadAndRewrittenOnNextCanonicalWrite() throws Exception {
+        GameSession session = gamePersistenceService.saveOpening(
+                OWNER_KEY, "세계관", "캐릭터", "첫 이야기", "[]", null
+        );
+        GameState initialState = gamePersistenceService.loadLatestTurn(OWNER_KEY, session.getId(), 1).gameState();
+        String legacyRawJson = objectMapper.writeValueAsString(initialState);
+        jdbcTemplate.update(
+                "update game_state_snapshot set state_json = ? where session_id = ?",
+                legacyRawJson,
+                session.getId()
+        );
+
+        GameState recovered = gamePersistenceService.loadLatestTurn(OWNER_KEY, session.getId(), 1).gameState();
+
+        assertThat(recovered).isEqualTo(initialState);
+        assertThat(jdbcTemplate.queryForObject(
+                "select state_json from game_state_snapshot where session_id = ?",
+                String.class,
+                session.getId()
+        )).isEqualTo(legacyRawJson);
+
+        GameState nextState = recovered.advance("진행", "두 번째 이야기");
+        gamePersistenceService.saveNextTurn(
+                OWNER_KEY,
+                session.getId(),
+                new GameTurnCommit(1, 1, "진행", recovered, nextState, "두 번째 이야기", "[]", null)
+        );
+
+        String rewrittenJson = jdbcTemplate.queryForObject(
+                "select state_json from game_state_snapshot where session_id = ?",
+                String.class,
+                session.getId()
+        );
+        JsonNode rewritten = objectMapper.readTree(rewrittenJson);
+        assertThat(rewritten.get("schemaVersion").asInt()).isEqualTo(1);
+        assertThat(rewritten.get("rulesetVersion").asInt()).isEqualTo(1);
+        assertThat(rewritten.get("state").get("turnNumber").asInt()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("snapshot 없는 기존 session은 append-only GameLog 원장에서 현재 GameState를 복구한다")
+    void snapshotlessSession_RecoversFromCommittedTurnLedger() {
+        GameSession session = gamePersistenceService.saveOpening(
+                OWNER_KEY, "세계관", "캐릭터", "첫 이야기", "[]", null
+        );
+        GameState initialState = gamePersistenceService.loadLatestTurn(OWNER_KEY, session.getId(), 1).gameState();
+        GameState nextState = initialState.advance("진행", "두 번째 이야기");
+        gamePersistenceService.saveNextTurn(
+                OWNER_KEY,
+                session.getId(),
+                new GameTurnCommit(1, 1, "진행", initialState, nextState, "두 번째 이야기", "[]", null)
+        );
+        jdbcTemplate.update("delete from game_state_snapshot where session_id = ?", session.getId());
+
+        GameState recovered = gamePersistenceService.loadLatestTurn(OWNER_KEY, session.getId(), 2).gameState();
+
+        assertThat(recovered).isEqualTo(nextState);
+        assertThat(recovered.storyMemory().recentTurns().getLast().playerAction()).isEqualTo("진행");
+    }
+}

--- a/src/test/java/com/uctale/uctale/persistence/PostgresGameStateSnapshotCompatibilityTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/PostgresGameStateSnapshotCompatibilityTest.java
@@ -10,9 +10,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.jdbc.core.JdbcTemplate;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
+
+import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -20,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class PostgresGameStateSnapshotCompatibilityTest extends PostgresIntegrationTestSupport {
 
     private static final String OWNER_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    private static final String LEGACY_FIXTURE = "fixtures/game-state/snapshot-v0-production.json";
 
     @Autowired private GamePersistenceService gamePersistenceService;
     @Autowired private JdbcTemplate jdbcTemplate;
@@ -47,7 +51,7 @@ class PostgresGameStateSnapshotCompatibilityTest extends PostgresIntegrationTest
         assertThat(openingSnapshot.get("state").get("turnNumber").asInt()).isEqualTo(1);
 
         GameState initialState = gamePersistenceService.loadLatestTurn(OWNER_KEY, session.getId(), 1).gameState();
-        String legacyRawJson = objectMapper.writeValueAsString(initialState);
+        String legacyRawJson = legacyStateJson();
         jdbcTemplate.update(
                 "update game_state_snapshot set state_json = ? where session_id = ?",
                 legacyRawJson,
@@ -100,5 +104,12 @@ class PostgresGameStateSnapshotCompatibilityTest extends PostgresIntegrationTest
 
         assertThat(recovered).isEqualTo(nextState);
         assertThat(recovered.storyMemory().recentTurns().getLast().playerAction()).isEqualTo("진행");
+    }
+
+    private String legacyStateJson() throws Exception {
+        ClassPathResource resource = new ClassPathResource(LEGACY_FIXTURE);
+        try (var inputStream = resource.getInputStream()) {
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        }
     }
 }

--- a/src/test/java/com/uctale/uctale/persistence/PostgresGameStateSnapshotCompatibilityTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/PostgresGameStateSnapshotCompatibilityTest.java
@@ -36,6 +36,16 @@ class PostgresGameStateSnapshotCompatibilityTest extends PostgresIntegrationTest
         GameSession session = gamePersistenceService.saveOpening(
                 OWNER_KEY, "세계관", "캐릭터", "첫 이야기", "[]", null
         );
+        String openingSnapshotJson = jdbcTemplate.queryForObject(
+                "select state_json from game_state_snapshot where session_id = ?",
+                String.class,
+                session.getId()
+        );
+        JsonNode openingSnapshot = objectMapper.readTree(openingSnapshotJson);
+        assertThat(openingSnapshot.get("schemaVersion").asInt()).isEqualTo(1);
+        assertThat(openingSnapshot.get("rulesetVersion").asInt()).isEqualTo(1);
+        assertThat(openingSnapshot.get("state").get("turnNumber").asInt()).isEqualTo(1);
+
         GameState initialState = gamePersistenceService.loadLatestTurn(OWNER_KEY, session.getId(), 1).gameState();
         String legacyRawJson = objectMapper.writeValueAsString(initialState);
         jdbcTemplate.update(

--- a/src/test/java/com/uctale/uctale/support/PostgresIntegrationTestSupport.java
+++ b/src/test/java/com/uctale/uctale/support/PostgresIntegrationTestSupport.java
@@ -3,19 +3,19 @@ package com.uctale.uctale.support;
 import org.junit.jupiter.api.Tag;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.postgresql.PostgreSQLContainer;
 
 @Tag("postgres")
-@Testcontainers
 public abstract class PostgresIntegrationTestSupport {
 
-    @Container
     protected static final PostgreSQLContainer POSTGRES = new PostgreSQLContainer("postgres:17.6-alpine")
             .withDatabaseName("uctale_test")
             .withUsername("uctale")
             .withPassword("uctale");
+
+    static {
+        POSTGRES.start();
+    }
 
     @DynamicPropertySource
     static void configurePostgres(DynamicPropertyRegistry registry) {

--- a/src/test/resources/fixtures/game-state/snapshot-v0-production.json
+++ b/src/test/resources/fixtures/game-state/snapshot-v0-production.json
@@ -1,0 +1,31 @@
+{
+  "turnNumber": 1,
+  "playerCharacter": {
+    "description": "캐릭터",
+    "stats": {}
+  },
+  "worldState": {
+    "premise": "세계관",
+    "flags": {}
+  },
+  "storyMemory": {
+    "canonicalFacts": [
+      {
+        "key": "world.premise",
+        "value": "세계관"
+      },
+      {
+        "key": "player.description",
+        "value": "캐릭터"
+      }
+    ],
+    "rollingSummary": "",
+    "recentTurns": [
+      {
+        "turnNumber": 1,
+        "playerAction": "",
+        "storyText": "첫 이야기"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## 왜 필요한가요?

현재 `game_state_snapshot.state_json`은 `GameState`를 raw JSON으로 저장하고 있어 필드가 추가·변경될 때 Jackson의 암묵적 기본값에 의존하게 됩니다. 장기 세션과 저장 데이터 호환성을 위해 snapshot 자체에 명시적인 schema/ruleset version을 기록하고, 과거 production JSON을 순수한 upgrader 경계에서 현재 모델로 복구할 수 있게 합니다.

- Closes #31

## 무엇이 바뀌나요?

- 게임 규칙·상태:
  - snapshot envelope에 `schemaVersion=1`, `rulesetVersion=1`, `state`를 기록합니다.
  - #31 이전 raw `GameState` JSON은 논리적 schema v0, legacy ruleset baseline 1로 고정합니다.
  - `GameStateUpgrader`가 source version을 판별하고 한 단계씩 순차 upgrade합니다.
  - 미래 schema, 미지원 ruleset, 누락/손상 version/state는 명시적으로 실패합니다.
- Backend / API / DB:
  - API 계약 변경은 없습니다.
  - DB 컬럼/Flyway migration은 추가하지 않습니다. version contract는 기존 `state_json` 내부 envelope에 저장합니다.
  - read-time upgrade는 메모리에서만 수행하고 DB를 즉시 재작성하지 않습니다.
  - 다음 canonical turn commit 시 snapshot을 최신 envelope로 재작성합니다.
  - snapshot이 없으면 #28/V6 append-only `GameLog` 원장에서 기존 `GameStateRecovery`로 복구합니다.
- AI narrative / prompt:
  - 변경 없음. upgrader는 LLM/provider를 호출하지 않습니다.
- Image generation:
  - 변경 없음.
- Frontend / UX:
  - 변경 없음.
- Build / deploy / docs:
  - `docs/architecture/game-state-snapshot-evolution.md`에 version 의미, read/write 정책, #28 `state_version`과의 차이, migration 순서를 문서화했습니다.
  - production v0 snapshot을 고정 fixture로 추가했습니다.

## 책임 경계

- **서버가 결정하는 사실:** snapshot schema/ruleset 지원 여부, deterministic upgrade 경로, canonical `GameState` 복구와 저장 형식
- **LLM이 서술하는 내용:** 기존 narrative 생성 책임 그대로 유지
- **LLM이 변경하면 안 되는 사실:** snapshot version, ruleset version, canonical state와 GameLog state transition

## 어떻게 검증했나요?

PR 생성 전 코드/설계 비판적 리뷰를 수행했고 발견 사항을 먼저 보완했습니다. CI는 이 PR에서 실행해 최종 확인합니다.

- [x] `./gradlew clean test`
- [x] `./gradlew postgresIntegrationTest`
- [x] `./gradlew build`
- [x] `cd frontend && npm ci && npm test && npm run lint && npm run build`
- [x] 정상 snapshot write/read 흐름을 테스트로 추가했습니다.
- [x] 잘못된 미래 schema / 미지원 ruleset / 손상 envelope 실패 흐름을 unit test로 추가했습니다.
- [x] 기존 production raw snapshot fixture를 PostgreSQL에서 복구하고 read만으로 DB가 rewrite되지 않음을 검증하는 테스트를 추가했습니다.
- [x] legacy snapshot이 다음 canonical write에서 최신 envelope로 전환되는 테스트를 추가했습니다.
- [x] snapshot 없는 session의 append-only GameLog 복구 테스트를 추가했습니다.

## 게임 상태·AI 안전성

- [x] 게임의 결정적 상태는 서버에서 검증·저장됩니다.
- [x] LLM 출력만으로 HP, 보상, 성공/실패 등 결정적 상태가 임의 변경되지 않습니다. 이번 변경은 LLM 경계를 수정하지 않습니다.
- [x] AI 요청에 전달하는 문맥 변경 없음.
- [x] AI 응답 파싱/provider 오류 경계 변경 없음.
- [x] 기존 저장 데이터 호환성을 frozen production v0 fixture와 PostgreSQL integration test로 검증하도록 추가했습니다.

## 보안·비용

- [x] API Key, 토큰, 비밀번호를 추가하지 않았습니다.
- [x] 외부 AI/Image 호출 횟수 변경 없음.
- [x] 사용자 입력 길이/외부 API 비용 증가 없음.
- [x] CORS/public endpoint 변경 없음.

## API·DB·운영 영향

- [x] API 계약 변경 없음.
- [x] DB physical schema 변경 없음. 기존 `state_json` 내부 형식만 versioned envelope로 evolution합니다.
- [x] 환경변수 변경 없음.
- [x] 배포 후 기존 세션 load 및 새 turn commit을 smoke test 대상으로 문서화할 수 있는 정책을 정의했습니다.

### 배포/migration 순서

1. production Flyway를 V6 이상까지 적용
2. #31 애플리케이션 배포
3. snapshot 존재 시 v0/v1 read + in-memory upgrade
4. snapshot 부재 시 V6 committed GameLog로 recovery
5. 다음 정상 turn commit에서 최신 snapshot envelope 저장

## PR 전 자체 비판적 리뷰 및 보완

1. **초기 upgrader가 v0/v1 분기만 있고 실제 순차 chain 구조가 아님**
   - 향후 v2에서 `v0 -> v2` 같은 우회 구현이 생길 위험이 있었습니다.
   - source version을 읽은 뒤 `upgradeOneVersion()`을 반복하는 구조로 변경해 `v0 -> v1 -> ... -> current` 경계를 코드에 고정했습니다.
2. **legacy 테스트가 현재 ObjectMapper로 과거 JSON을 즉석 생성하는 자기참조 문제**
   - 현재 모델이 변하면 ‘과거 production format’ fixture도 같이 변해 회귀를 잡지 못합니다.
   - `src/test/resources/fixtures/game-state/snapshot-v0-production.json`을 frozen fixture로 고정하고 unit/PostgreSQL 테스트가 동일 fixture를 사용하게 했습니다.
3. **legacy v0에 CURRENT ruleset을 부여하는 미래 의미 오염 문제**
   - 향후 current ruleset이 2가 되면 과거 version 없는 snapshot을 ruleset 2로 잘못 해석할 수 있었습니다.
   - `LEGACY_RULESET_VERSION=1`을 별도로 고정하고 v0 upgrade가 그 의미를 보존하도록 변경했습니다.
4. **schemaVersion만 유실된 손상 envelope를 legacy로 오인할 위험**
   - `schemaVersion` 누락만으로 legacy 처리하지 않고 raw GameState의 필수 최상위 shape와 envelope 필드 부재를 함께 확인합니다.
5. **조회 시 자동 DB rewrite 여부**
   - `loadLatestTurn()`의 read-only 경계, rollback 가능성, read amplification을 고려해 즉시 rewrite하지 않습니다.
   - read는 in-memory upgrade only, 다음 canonical write에서 latest-only로 저장합니다.
6. **#28 state version과 snapshot version 혼동 가능성**
   - `GameLog.state_version`은 세션 내 canonical turn state 식별자이고 `schemaVersion`/`rulesetVersion`은 저장 형식/규칙 계약이라는 별도 축임을 문서에 명시했습니다.

## 화면 / 응답 예시

UI/API 응답 변경 없음.
