### PR TITLE
fix(db): Neon scale-to-zero를 위한 connection pool 조정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, fix/neon-scale-to-zero-pool]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, fix/neon-scale-to-zero-pool]
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/docs/architecture/database-runtime.md
+++ b/docs/architecture/database-runtime.md
@@ -1,0 +1,61 @@
+# Database runtime policy
+
+UCTale production uses Neon PostgreSQL. The service is intentionally low traffic, so the database connection pool must cooperate with Neon's scale-to-zero behavior instead of keeping compute active while no user requests are being processed.
+
+## Why Hikari defaults are overridden
+
+Spring Boot 4.1.1 manages HikariCP 7.0.2. Without explicit configuration, Hikari keeps an idle pool and enables a periodic connection keepalive. Neon Free compute suspends after an inactivity window, so periodic application-level database traffic can prevent the compute endpoint from becoming inactive and continuously consume CU-hours.
+
+UCTale therefore uses these production defaults:
+
+| Setting | Default | Purpose |
+| --- | ---: | --- |
+| `spring.datasource.hikari.keepalive-time` | `0` | Disable Hikari application-level keepalive pings. |
+| `spring.datasource.hikari.minimum-idle` | `0` | Permit the pool to drain to zero idle connections. |
+| `spring.datasource.hikari.maximum-pool-size` | `3` | Bound concurrent database connections for the current low-traffic service. |
+| `spring.datasource.hikari.idle-timeout` | `60000` ms | Close idle connections well before Neon's five-minute inactivity window. |
+
+The values can be overridden without changing code:
+
+- `DATABASE_POOL_KEEPALIVE_TIME_MS`
+- `DATABASE_POOL_MINIMUM_IDLE`
+- `DATABASE_POOL_MAXIMUM_SIZE`
+- `DATABASE_POOL_IDLE_TIMEOUT_MS`
+
+The production defaults are a cost-control policy, not a throughput target. If real traffic grows, increase the maximum pool size only after measuring request concurrency and database saturation. Do not restore a periodic keepalive merely to hide cold-start latency, because doing so defeats scale-to-zero.
+
+## Cold starts
+
+After the Hikari pool drains and Neon suspends compute, the next database-backed request may pay both a new JDBC connection cost and a Neon compute resume cost. UCTale accepts this latency trade-off because the current priority is keeping an infrequently used portfolio service inside the free compute allowance.
+
+A cold start must not be worked around with cron requests, synthetic SQL pings, health checks that continuously query PostgreSQL, or Hikari keepalive traffic. Such workarounds would recreate the original CU-hour problem.
+
+## Production verification after deployment
+
+The code change can make scale-to-zero possible, but repository tests cannot prove that the live Neon endpoint actually suspends. After deploying this configuration:
+
+1. Stop manual game/API activity for at least 10–15 minutes.
+2. In Neon Console, verify that the compute endpoint transitions to inactive/suspended rather than remaining continuously active.
+3. Check `Active time` and CU-hour usage after metrics have had time to update. Neon metrics can be delayed.
+4. Repeat the observation across several idle windows, not only once.
+5. Confirm that the first game request after an idle period succeeds after the expected cold-start delay.
+
+Before the change, the observed usage was 45 / 100 CU-hours for the consumption period starting 2026-08-24. Treat this as a baseline only; traffic and Neon metric delay mean exact before/after rates are not directly comparable over a short interval.
+
+## If compute still does not suspend
+
+Do not assume Hikari is the only possible source of database activity. Investigate, in order:
+
+1. Render or another platform health check that reaches an endpoint performing SQL.
+2. External uptime monitors or scheduled requests that execute database queries.
+3. Application background jobs, scheduled tasks, or startup/reconnect loops.
+4. Multiple running backend instances using the same Neon endpoint.
+5. Neon project/compute settings and connection activity visible in Neon Console.
+
+The goal is not to force disconnects while useful work is active. The goal is simply that a truly idle UCTale deployment generates no periodic database traffic from its own connection pool.
+
+## Rollback
+
+If production exhibits unacceptable connection churn or failures, adjust the four `DATABASE_POOL_*` environment variables first. A code rollback should be unnecessary because every setting is externally overrideable.
+
+When changing these values, preserve the scale-to-zero invariant: no periodic keepalive and no permanently retained idle connection unless there is a measured operational reason to accept continuous Neon compute usage.

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,6 +30,10 @@ spring.datasource.url=${DATABASE_URL}
 spring.datasource.username=${DATABASE_USERNAME}
 spring.datasource.password=${DATABASE_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.hikari.keepalive-time=${DATABASE_POOL_KEEPALIVE_TIME_MS:0}
+spring.datasource.hikari.minimum-idle=${DATABASE_POOL_MINIMUM_IDLE:0}
+spring.datasource.hikari.maximum-pool-size=${DATABASE_POOL_MAXIMUM_SIZE:3}
+spring.datasource.hikari.idle-timeout=${DATABASE_POOL_IDLE_TIMEOUT_MS:60000}
 
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.open-in-view=false

--- a/src/test/java/com/uctale/uctale/persistence/DatabasePoolConfigurationTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/DatabasePoolConfigurationTest.java
@@ -1,0 +1,41 @@
+package com.uctale.uctale.persistence;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.sql.DataSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(properties = {
+        "spring.config.location=file:src/main/resources/application.properties",
+        "GOOGLE_AI_API_KEY=TEST_API_KEY",
+        "POLLINATIONS_TOKEN=TEST_TOKEN",
+        "GAME_ACCESS_PASSWORD=TEST_PASSWORD",
+        "GAME_ACCESS_SESSION_SECRET=TEST_SESSION_SECRET_0123456789_0123456789",
+        "DATABASE_URL=jdbc:h2:mem:poolconfig;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE",
+        "DATABASE_USERNAME=sa",
+        "DATABASE_PASSWORD=",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.jpa.hibernate.ddl-auto=none",
+        "spring.flyway.enabled=false"
+})
+class DatabasePoolConfigurationTest {
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Test
+    void productionDefaultsAllowIdlePoolToDrainBeforeNeonSuspendWindow() {
+        assertThat(dataSource).isInstanceOf(HikariDataSource.class);
+        HikariDataSource hikari = (HikariDataSource) dataSource;
+
+        assertThat(hikari.getKeepaliveTime()).isZero();
+        assertThat(hikari.getMinimumIdle()).isZero();
+        assertThat(hikari.getMaximumPoolSize()).isEqualTo(3);
+        assertThat(hikari.getIdleTimeout()).isEqualTo(60_000L);
+        assertThat(hikari.getIdleTimeout()).isLessThan(5 * 60_000L);
+    }
+}


### PR DESCRIPTION
## 요약

Neon Free compute가 idle 상태에서 scale-to-zero 할 수 있도록 HikariCP production 기본값을 UCTale의 저트래픽 운영 모델에 맞게 조정합니다.

Closes #79

## 배경

Neon Console에서 2026-08-31 기준 현재 consumption period(`Usage since Aug 24, 2026`)의 compute 사용량이 45 / 100 CU-hours까지 증가했습니다. 현재 사용량 패턴은 실제 게임 요청량보다 compute가 장시간 active 상태에 머무는 모습에 가깝습니다.

Spring Boot 4.1.1이 관리하는 HikariCP 7.0.2는 기본 minimum idle이 maximum pool size와 같아 idle connection을 유지하고, 6.2.1부터 기본 keepaliveTime이 2분으로 변경되었습니다. Neon Free의 scale-to-zero inactivity window는 5분이므로 이 기본값 조합은 저트래픽 서비스에서 compute suspend를 방해할 수 있습니다.

## 변경 사항

### Hikari production defaults

- `keepalive-time=0`
  - application-level keepalive 비활성화
- `minimum-idle=0`
  - idle pool이 0 connection까지 축소 가능
- `maximum-pool-size=3`
  - 현재 UCTale 트래픽에 맞게 DB connection 상한 축소
- `idle-timeout=60000`
  - Neon 5분 inactivity window 전에 유휴 connection 정리

모든 값은 다음 환경변수로 override 가능합니다.

- `DATABASE_POOL_KEEPALIVE_TIME_MS`
- `DATABASE_POOL_MINIMUM_IDLE`
- `DATABASE_POOL_MAXIMUM_SIZE`
- `DATABASE_POOL_IDLE_TIMEOUT_MS`

### 회귀 테스트

`DatabasePoolConfigurationTest`가 테스트 전용 복사값이 아니라 실제 `src/main/resources/application.properties`를 Spring context에 로드하고 최종 `HikariDataSource` 설정값을 검증합니다.

검증 항목:

- keepalive = 0
- minimum idle = 0
- maximum pool size = 3
- idle timeout = 60s
- idle timeout < Neon 5분 inactivity window

### 운영 문서

`docs/architecture/database-runtime.md` 추가:

- Neon scale-to-zero와 Hikari 설정의 관계
- cold-start latency trade-off
- 환경변수 override / rollback 정책
- 배포 후 Neon Console 검증 절차
- 수정 후에도 compute가 suspend되지 않을 경우 health check, monitor, background job, 다중 backend instance 등을 추가 조사하는 순서

## PR 전 자체 비판적 리뷰

### 1. `idle-timeout=60s`가 지나치게 공격적이지 않은가?

검토 결과 현재 UCTale은 저트래픽 포트폴리오 서비스이고 목표가 Neon Free compute의 확실한 idle 진입입니다. Hikari가 지원하는 최소 범위보다 충분히 크고 Neon 5분 window보다 명확히 짧습니다. 간헐적 요청에서는 connection 재생성 비용이 생기지만 현재 비용 리스크보다 작다고 판단해 유지했습니다.

### 2. `maximum-pool-size=3`이 임의적인 magic number 아닌가?

현재 트래픽에서는 기존 기본 10 connection이 과도합니다. 다만 향후 실제 동시성이 증가할 수 있으므로 코드 상수로 고정하지 않고 환경변수 override를 제공했습니다. 운영 부하 측정 없이 더 크게 잡지 않는 쪽이 현재 목적과 일치합니다.

### 3. Hikari 설정만으로 Neon suspend를 보장한다고 오인할 수 있지 않은가?

타당한 지적입니다. 이 변경은 scale-to-zero를 '가능하게' 할 뿐 실제 production endpoint의 inactivity를 증명하지 않습니다. 운영 문서에 배포 후 10~15분 idle 검증과 후속 원인 조사 목록을 명시했습니다.

### 4. 테스트가 production property를 실제로 검증하는가?

테스트 resource에 동일 숫자를 복사하면 의미가 약하므로 그렇게 하지 않았습니다. 테스트가 main `application.properties`를 직접 config location으로 로드한 뒤 실제 HikariDataSource binding 결과를 검증합니다.

### 5. CI 검증을 위해 workflow 변경이 PR에 섞이지 않는가?

PR 생성 전 branch push 검증을 위해 CI trigger를 일시 확장했고, 검증 완료 후 원래 main workflow와 동일하게 복구했습니다. 최종 compare에는 `.github/workflows/ci.yml` 변경이 없습니다.

## 검증

PR 생성 전 GitHub Actions run #137에서 모두 통과했습니다.

- Backend test: 통과
- PostgreSQL integration test: 통과
- Backend build: 통과
- Frontend test/lint/build: 통과

## 영향 및 후속 확인

배포 후 Neon Console에서 실제 compute가 idle/suspended 상태로 전환되는지 확인해야 합니다. CU-hour metric은 지연될 수 있으므로 단일 시점이 아니라 여러 idle window를 관찰합니다.

수정 후에도 usage가 계속 선형 증가한다면 Hikari 외 주기적 DB activity를 별도로 조사합니다.

이 PR은 열어둡니다. 머지는 별도로 진행합니다.