### PR TITLE
feat(game): 턴 reservation으로 중복 AI 호출 억제

### DIFF
--- a/docs/architecture/game-turn-reservation.md
+++ b/docs/architecture/game-turn-reservation.md
@@ -1,0 +1,45 @@
+# Game Turn Reservation Lease
+
+## Goal
+
+`PROGRESS` 요청은 Narrative provider를 호출하기 전에 `(session_id, expected_turn)` reservation을 획득해야 한다. 활성 lease는 PostgreSQL의 단일 primary key row로 표현하며, 정상 동시 요청에서는 한 요청만 provider 호출 구간에 진입한다.
+
+## Request states
+
+`game_mutation_request`는 idempotency 이력을 보관한다.
+
+- `PROCESSING`: 최초 요청이 처리 중이다. 같은 `Idempotency-Key`의 동시 재요청은 `409 MUTATION_IN_PROGRESS`와 `Retry-After`를 받는다.
+- `COMPLETED`: 저장된 canonical 결과를 replay한다.
+- `FAILED`: 같은 key/payload로 재시도할 수 있다.
+
+## Turn reservation
+
+`game_turn_reservation`은 활성 turn lease만 담당한다.
+
+- key: `(session_id, expected_turn)`
+- owner: `request_id` + 매 시도마다 새로 생성되는 `lease_owner`
+- 기본 lease: 90초 (`app.game.turn-reservation.lease-seconds`)
+- 최대 provider 시도: 같은 turn reservation row 기준 3회
+
+서로 다른 idempotency key가 같은 turn을 요청해도 lease가 유효하면 후발 요청은 provider를 호출하지 않고 `409 MUTATION_IN_PROGRESS`를 받는다.
+
+## Transaction boundaries
+
+Reservation 획득은 짧은 DB transaction에서 끝난다. Gemini 네트워크 호출 동안 DB transaction이나 row lock을 유지하지 않는다.
+
+Provider 응답을 받은 뒤 canonical commit transaction에서 다음을 다시 검증한다.
+
+1. `(session_id, expected_turn)` reservation row가 존재한다.
+2. 현재 `lease_owner`가 provider를 실행한 시도의 owner와 동일하다.
+3. session `expectedTurn`과 optimistic version이 그대로다.
+4. GameLog/state snapshot의 이전 version이 canonical state와 일치한다.
+
+검증 후 canonical state와 GameLog를 한 transaction에서 저장하고 reservation을 해제한다.
+
+## Failure and crash semantics
+
+Provider 또는 commit 전 단계에서 예외가 발생하면 mutation request를 `FAILED`로 바꾸고 lease를 즉시 만료시켜 재시도를 허용한다.
+
+프로세스가 provider 성공 직후 DB commit 전에 죽으면 실패 처리를 실행할 수 없다. 이 경우 lease가 만료된 뒤 다른 요청이 reservation을 회수할 수 있고 provider가 다시 호출될 수 있다. 따라서 외부 provider 호출은 strict exactly-once가 아니라 **bounded at-least-once**이며, reservation row의 `attempt_count`로 turn당 최대 3번까지 제한한다.
+
+반면 canonical state와 GameLog는 reservation owner 재검증, expected turn 검증, optimistic locking, turn unique constraint를 함께 사용하므로 이중 commit을 허용하지 않는다.

--- a/src/main/java/com/uctale/uctale/application/game/GameMutationRequestService.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameMutationRequestService.java
@@ -67,7 +67,9 @@ public class GameMutationRequestService {
                     request.getId(), request.getResultSessionId(), request.getResultTurn(), request.getResultTitle()
             );
         }
-        if (inserted == 0 && request.getStatus() == GameMutationRequest.Status.PROCESSING) {
+
+        boolean existingProcessing = inserted == 0 && request.getStatus() == GameMutationRequest.Status.PROCESSING;
+        if (existingProcessing && !PROGRESS.equals(operation)) {
             throw new MutationInProgressException("동일한 idempotency 요청이 이미 처리 중입니다.", leaseSeconds);
         }
         if (request.getStatus() == GameMutationRequest.Status.FAILED) {
@@ -88,8 +90,10 @@ public class GameMutationRequestService {
         int acquired = acquireReservation(sessionId, expectedTurn, request.getId(), leaseOwner, now, expiresAt);
 
         if (acquired == 0) {
-            request.fail();
-            repository.save(request);
+            if (!existingProcessing) {
+                request.fail();
+                repository.save(request);
+            }
             long retryAfter = currentRetryAfterSeconds(sessionId, expectedTurn, now);
             throw new MutationInProgressException("같은 턴이 이미 처리 중이거나 재시도 한도에 도달했습니다.", retryAfter);
         }
@@ -98,14 +102,31 @@ public class GameMutationRequestService {
 
     @Transactional
     public void markFailed(Long requestId) {
+        markFailed(requestId, null);
+    }
+
+    @Transactional
+    public void markFailed(Long requestId, String reservationOwner) {
+        if (reservationOwner != null) {
+            int expired = jdbcTemplate.update("""
+                    UPDATE game_turn_reservation
+                    SET lease_expires_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+                    WHERE request_id = ? AND lease_owner = ?
+                    """, requestId, reservationOwner);
+            if (expired == 0) {
+                return;
+            }
+        }
         repository.findById(requestId).ifPresent(request -> {
             request.fail();
             repository.save(request);
-            jdbcTemplate.update("""
-                    UPDATE game_turn_reservation
-                    SET lease_expires_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
-                    WHERE request_id = ?
-                    """, requestId);
+            if (reservationOwner == null) {
+                jdbcTemplate.update("""
+                        UPDATE game_turn_reservation
+                        SET lease_expires_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+                        WHERE request_id = ?
+                        """, requestId);
+            }
         });
     }
 

--- a/src/main/java/com/uctale/uctale/application/game/GameMutationRequestService.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameMutationRequestService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
@@ -25,6 +26,9 @@ public class GameMutationRequestService {
     private final JdbcTemplate jdbcTemplate;
     private final Clock clock;
     private final long leaseSeconds;
+
+    @Value("${spring.datasource.driver-class-name:org.postgresql.Driver}")
+    private String datasourceDriverClassName;
 
     public GameMutationRequestService(
             GameMutationRequestRepository repository,
@@ -49,7 +53,7 @@ public class GameMutationRequestService {
     ) {
         validateKey(idempotencyKey);
 
-        int inserted = repository.insertIfAbsent(
+        int inserted = insertMutationRequestIfAbsent(
                 ownerKey, operation, idempotencyKey, sessionId, expectedTurn, fingerprint
         );
         GameMutationRequest request = repository.findForUpdate(ownerKey, idempotencyKey)
@@ -81,20 +85,7 @@ public class GameMutationRequestService {
         String leaseOwner = UUID.randomUUID().toString();
         LocalDateTime now = LocalDateTime.now(clock);
         LocalDateTime expiresAt = now.plusSeconds(leaseSeconds);
-        int acquired = jdbcTemplate.update("""
-                INSERT INTO game_turn_reservation (
-                    session_id, expected_turn, request_id, lease_owner, lease_expires_at, attempt_count,
-                    created_at, updated_at
-                ) VALUES (?, ?, ?, ?, ?, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
-                ON CONFLICT (session_id, expected_turn) DO UPDATE SET
-                    request_id = EXCLUDED.request_id,
-                    lease_owner = EXCLUDED.lease_owner,
-                    lease_expires_at = EXCLUDED.lease_expires_at,
-                    attempt_count = game_turn_reservation.attempt_count + 1,
-                    updated_at = CURRENT_TIMESTAMP
-                WHERE game_turn_reservation.lease_expires_at <= ?
-                  AND game_turn_reservation.attempt_count < ?
-                """, sessionId, expectedTurn, request.getId(), leaseOwner, expiresAt, now, MAX_RESERVATION_ATTEMPTS);
+        int acquired = acquireReservation(sessionId, expectedTurn, request.getId(), leaseOwner, now, expiresAt);
 
         if (acquired == 0) {
             request.fail();
@@ -118,6 +109,87 @@ public class GameMutationRequestService {
         });
     }
 
+    private int insertMutationRequestIfAbsent(
+            String ownerKey,
+            String operation,
+            String idempotencyKey,
+            Long sessionId,
+            Integer expectedTurn,
+            String fingerprint
+    ) {
+        if (!isH2()) {
+            return repository.insertIfAbsent(
+                    ownerKey, operation, idempotencyKey, sessionId, expectedTurn, fingerprint
+            );
+        }
+        if (repository.findByOwnerKeyAndIdempotencyKey(ownerKey, idempotencyKey).isPresent()) {
+            return 0;
+        }
+        repository.saveAndFlush(new GameMutationRequest(
+                ownerKey, operation, idempotencyKey, sessionId, expectedTurn, fingerprint
+        ));
+        return 1;
+    }
+
+    private int acquireReservation(
+            Long sessionId,
+            int expectedTurn,
+            Long requestId,
+            String leaseOwner,
+            LocalDateTime now,
+            LocalDateTime expiresAt
+    ) {
+        if (!isH2()) {
+            return jdbcTemplate.update("""
+                    INSERT INTO game_turn_reservation (
+                        session_id, expected_turn, request_id, lease_owner, lease_expires_at, attempt_count,
+                        created_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                    ON CONFLICT (session_id, expected_turn) DO UPDATE SET
+                        request_id = EXCLUDED.request_id,
+                        lease_owner = EXCLUDED.lease_owner,
+                        lease_expires_at = EXCLUDED.lease_expires_at,
+                        attempt_count = game_turn_reservation.attempt_count + 1,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE game_turn_reservation.lease_expires_at <= ?
+                      AND game_turn_reservation.attempt_count < ?
+                    """, sessionId, expectedTurn, requestId, leaseOwner, expiresAt, now, MAX_RESERVATION_ATTEMPTS);
+        }
+
+        List<ReservationState> reservations = jdbcTemplate.query(
+                """
+                        SELECT lease_expires_at, attempt_count
+                        FROM game_turn_reservation
+                        WHERE session_id = ? AND expected_turn = ?
+                        """,
+                (rs, rowNum) -> new ReservationState(
+                        rs.getTimestamp("lease_expires_at").toLocalDateTime(),
+                        rs.getInt("attempt_count")
+                ),
+                sessionId, expectedTurn
+        );
+        if (reservations.isEmpty()) {
+            return jdbcTemplate.update("""
+                    INSERT INTO game_turn_reservation (
+                        session_id, expected_turn, request_id, lease_owner, lease_expires_at, attempt_count,
+                        created_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                    """, sessionId, expectedTurn, requestId, leaseOwner, expiresAt);
+        }
+
+        ReservationState reservation = reservations.getFirst();
+        if (reservation.leaseExpiresAt().isAfter(now) || reservation.attemptCount() >= MAX_RESERVATION_ATTEMPTS) {
+            return 0;
+        }
+        return jdbcTemplate.update("""
+                UPDATE game_turn_reservation
+                SET request_id = ?, lease_owner = ?, lease_expires_at = ?,
+                    attempt_count = attempt_count + 1, updated_at = CURRENT_TIMESTAMP
+                WHERE session_id = ? AND expected_turn = ?
+                  AND lease_expires_at <= ? AND attempt_count < ?
+                """, requestId, leaseOwner, expiresAt, sessionId, expectedTurn, now, MAX_RESERVATION_ATTEMPTS);
+    }
+
     private long currentRetryAfterSeconds(Long sessionId, int expectedTurn, LocalDateTime now) {
         return jdbcTemplate.query(
                 "SELECT lease_expires_at FROM game_turn_reservation WHERE session_id = ? AND expected_turn = ?",
@@ -128,6 +200,10 @@ public class GameMutationRequestService {
         );
     }
 
+    private boolean isH2() {
+        return datasourceDriverClassName != null && datasourceDriverClassName.contains("h2.Driver");
+    }
+
     private void validateKey(String idempotencyKey) {
         if (idempotencyKey == null || !IDEMPOTENCY_KEY_PATTERN.matcher(idempotencyKey).matches()) {
             throw new IllegalArgumentException(
@@ -135,6 +211,8 @@ public class GameMutationRequestService {
             );
         }
     }
+
+    private record ReservationState(LocalDateTime leaseExpiresAt, int attemptCount) {}
 
     public record BeginResult(
             Long requestId,

--- a/src/main/java/com/uctale/uctale/application/game/GameMutationRequestService.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameMutationRequestService.java
@@ -2,9 +2,15 @@ package com.uctale.uctale.application.game;
 
 import com.uctale.uctale.domain.GameMutationRequest;
 import com.uctale.uctale.repository.GameMutationRequestRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
 import java.util.regex.Pattern;
 
 @Service
@@ -12,15 +18,27 @@ public class GameMutationRequestService {
 
     public static final String INIT = "INIT";
     public static final String PROGRESS = "PROGRESS";
+    private static final int MAX_RESERVATION_ATTEMPTS = 3;
     private static final Pattern IDEMPOTENCY_KEY_PATTERN = Pattern.compile("[A-Za-z0-9._:-]{8,128}");
 
     private final GameMutationRequestRepository repository;
+    private final JdbcTemplate jdbcTemplate;
+    private final Clock clock;
+    private final long leaseSeconds;
 
-    public GameMutationRequestService(GameMutationRequestRepository repository) {
+    public GameMutationRequestService(
+            GameMutationRequestRepository repository,
+            JdbcTemplate jdbcTemplate,
+            Clock clock,
+            @Value("${app.game.turn-reservation.lease-seconds:90}") long leaseSeconds
+    ) {
         this.repository = repository;
+        this.jdbcTemplate = jdbcTemplate;
+        this.clock = clock;
+        this.leaseSeconds = Math.max(10, leaseSeconds);
     }
 
-    @Transactional
+    @Transactional(noRollbackFor = MutationInProgressException.class)
     public BeginResult begin(
             String ownerKey,
             String operation,
@@ -31,28 +49,60 @@ public class GameMutationRequestService {
     ) {
         validateKey(idempotencyKey);
 
-        GameMutationRequest request = repository
-                .findByOwnerKeyAndIdempotencyKey(ownerKey, idempotencyKey)
-                .orElseGet(() -> repository.save(new GameMutationRequest(
-                        ownerKey, operation, idempotencyKey, sessionId, expectedTurn, fingerprint
-                )));
+        int inserted = repository.insertIfAbsent(
+                ownerKey, operation, idempotencyKey, sessionId, expectedTurn, fingerprint
+        );
+        GameMutationRequest request = repository.findForUpdate(ownerKey, idempotencyKey)
+                .orElseThrow(() -> new IllegalStateException("mutation request를 찾을 수 없습니다."));
 
         if (!request.matches(operation, fingerprint)) {
             throw new IdempotencyConflictException("같은 Idempotency-Key가 다른 요청 payload에 재사용되었습니다.");
         }
-
         if (request.getStatus() == GameMutationRequest.Status.COMPLETED) {
             return BeginResult.replay(
-                    request.getId(),
-                    request.getResultSessionId(),
-                    request.getResultTurn(),
-                    request.getResultTitle()
+                    request.getId(), request.getResultSessionId(), request.getResultTurn(), request.getResultTitle()
             );
         }
+        if (inserted == 0 && request.getStatus() == GameMutationRequest.Status.PROCESSING) {
+            throw new MutationInProgressException("동일한 idempotency 요청이 이미 처리 중입니다.", leaseSeconds);
+        }
+        if (request.getStatus() == GameMutationRequest.Status.FAILED) {
+            request.restart();
+            repository.save(request);
+        }
 
-        request.restart();
-        repository.save(request);
-        return BeginResult.process(request.getId());
+        if (!PROGRESS.equals(operation)) {
+            return BeginResult.process(request.getId(), null);
+        }
+        if (sessionId == null || expectedTurn == null) {
+            throw new IllegalArgumentException("progress reservation에는 sessionId와 expectedTurn이 필요합니다.");
+        }
+
+        String leaseOwner = UUID.randomUUID().toString();
+        LocalDateTime now = LocalDateTime.now(clock);
+        LocalDateTime expiresAt = now.plusSeconds(leaseSeconds);
+        int acquired = jdbcTemplate.update("""
+                INSERT INTO game_turn_reservation (
+                    session_id, expected_turn, request_id, lease_owner, lease_expires_at, attempt_count,
+                    created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                ON CONFLICT (session_id, expected_turn) DO UPDATE SET
+                    request_id = EXCLUDED.request_id,
+                    lease_owner = EXCLUDED.lease_owner,
+                    lease_expires_at = EXCLUDED.lease_expires_at,
+                    attempt_count = game_turn_reservation.attempt_count + 1,
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE game_turn_reservation.lease_expires_at <= ?
+                  AND game_turn_reservation.attempt_count < ?
+                """, sessionId, expectedTurn, request.getId(), leaseOwner, expiresAt, now, MAX_RESERVATION_ATTEMPTS);
+
+        if (acquired == 0) {
+            request.fail();
+            repository.save(request);
+            long retryAfter = currentRetryAfterSeconds(sessionId, expectedTurn, now);
+            throw new MutationInProgressException("같은 턴이 이미 처리 중이거나 재시도 한도에 도달했습니다.", retryAfter);
+        }
+        return BeginResult.process(request.getId(), leaseOwner);
     }
 
     @Transactional
@@ -60,7 +110,22 @@ public class GameMutationRequestService {
         repository.findById(requestId).ifPresent(request -> {
             request.fail();
             repository.save(request);
+            jdbcTemplate.update("""
+                    UPDATE game_turn_reservation
+                    SET lease_expires_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+                    WHERE request_id = ?
+                    """, requestId);
         });
+    }
+
+    private long currentRetryAfterSeconds(Long sessionId, int expectedTurn, LocalDateTime now) {
+        return jdbcTemplate.query(
+                "SELECT lease_expires_at FROM game_turn_reservation WHERE session_id = ? AND expected_turn = ?",
+                rs -> rs.next()
+                        ? Math.max(1, ChronoUnit.SECONDS.between(now, rs.getTimestamp(1).toLocalDateTime()))
+                        : 1,
+                sessionId, expectedTurn
+        );
     }
 
     private void validateKey(String idempotencyKey) {
@@ -76,14 +141,19 @@ public class GameMutationRequestService {
             boolean replay,
             Long resultSessionId,
             Integer resultTurn,
-            String resultTitle
+            String resultTitle,
+            String reservationOwner
     ) {
-        static BeginResult process(Long requestId) {
-            return new BeginResult(requestId, false, null, null, null);
+        public BeginResult(Long requestId, boolean replay, Long resultSessionId, Integer resultTurn, String resultTitle) {
+            this(requestId, replay, resultSessionId, resultTurn, resultTitle, null);
+        }
+
+        static BeginResult process(Long requestId, String reservationOwner) {
+            return new BeginResult(requestId, false, null, null, null, reservationOwner);
         }
 
         static BeginResult replay(Long requestId, Long sessionId, Integer turn, String title) {
-            return new BeginResult(requestId, true, sessionId, turn, title);
+            return new BeginResult(requestId, true, sessionId, turn, title, null);
         }
     }
 }

--- a/src/main/java/com/uctale/uctale/application/game/GamePersistenceService.java
+++ b/src/main/java/com/uctale/uctale/application/game/GamePersistenceService.java
@@ -103,7 +103,7 @@ public class GamePersistenceService {
     public int saveNextTurn(String ownerKey, Long sessionId, GameTurnCommit commit, Long mutationRequestId,
             String resultTitle, String reservationOwner) {
         try {
-            if (mutationRequestId != null) verifyReservation(sessionId, commit.expectedTurn(), reservationOwner);
+            if (reservationOwner != null) verifyReservation(sessionId, commit.expectedTurn(), reservationOwner);
             GameSession session = findOwnedSession(ownerKey, sessionId);
             validateCommitAgainstSession(session, commit);
             GameLog previousLog = gameLogRepository.findTopByGameSessionOrderByTurnNumberDesc(session)
@@ -127,7 +127,7 @@ public class GamePersistenceService {
             snapshot.updateStateJson(gameStateCodec.serialize(commit.nextState()));
             gameStateSnapshotRepository.save(snapshot);
             completeMutationRequest(mutationRequestId, session.getId(), session.getCurrentTurn(), resultTitle);
-            if (mutationRequestId != null) {
+            if (reservationOwner != null) {
                 int released = gameMutationRequestRepository.releaseReservation(sessionId, commit.expectedTurn(), mutationRequestId, reservationOwner);
                 if (released != 1) throw new TurnConflictException("턴 reservation 소유권이 변경되었습니다.");
             }

--- a/src/main/java/com/uctale/uctale/application/game/GamePersistenceService.java
+++ b/src/main/java/com/uctale/uctale/application/game/GamePersistenceService.java
@@ -19,7 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class GamePersistenceService {
-
     private static final String GAME_LOG_TURN_UNIQUE_CONSTRAINT = "uk_game_log_session_turn";
     private static final String IMAGE_ASSET_TURN_UNIQUE_CONSTRAINT = "uk_image_asset_session_turn";
 
@@ -31,15 +30,10 @@ public class GamePersistenceService {
     private final GameStateCodec gameStateCodec;
     private final GameStateRecovery gameStateRecovery;
 
-    public GamePersistenceService(
-            GameSessionRepository gameSessionRepository,
-            GameLogRepository gameLogRepository,
-            GameStateSnapshotRepository gameStateSnapshotRepository,
-            ImageAssetRepository imageAssetRepository,
-            GameMutationRequestRepository gameMutationRequestRepository,
-            GameStateCodec gameStateCodec,
-            GameStateRecovery gameStateRecovery
-    ) {
+    public GamePersistenceService(GameSessionRepository gameSessionRepository, GameLogRepository gameLogRepository,
+            GameStateSnapshotRepository gameStateSnapshotRepository, ImageAssetRepository imageAssetRepository,
+            GameMutationRequestRepository gameMutationRequestRepository, GameStateCodec gameStateCodec,
+            GameStateRecovery gameStateRecovery) {
         this.gameSessionRepository = gameSessionRepository;
         this.gameLogRepository = gameLogRepository;
         this.gameStateSnapshotRepository = gameStateSnapshotRepository;
@@ -50,28 +44,14 @@ public class GamePersistenceService {
     }
 
     @Transactional
-    public GameSession saveOpening(
-            String ownerKey,
-            String worldSetting,
-            String characterSetting,
-            String storyText,
-            String choicesJson,
-            ImageAssetService.AssetReference imageAsset
-    ) {
+    public GameSession saveOpening(String ownerKey, String worldSetting, String characterSetting, String storyText,
+            String choicesJson, ImageAssetService.AssetReference imageAsset) {
         return saveOpening(ownerKey, worldSetting, characterSetting, storyText, choicesJson, imageAsset, null, null);
     }
 
     @Transactional
-    public GameSession saveOpening(
-            String ownerKey,
-            String worldSetting,
-            String characterSetting,
-            String storyText,
-            String choicesJson,
-            ImageAssetService.AssetReference imageAsset,
-            Long mutationRequestId,
-            String resultTitle
-    ) {
+    public GameSession saveOpening(String ownerKey, String worldSetting, String characterSetting, String storyText,
+            String choicesJson, ImageAssetService.AssetReference imageAsset, Long mutationRequestId, String resultTitle) {
         try {
             GameSession session = gameSessionRepository.save(new GameSession(ownerKey, worldSetting, characterSetting));
             String imageUrl = persistImageAsset(session, 1, imageAsset);
@@ -89,33 +69,16 @@ public class GamePersistenceService {
     @Transactional(readOnly = true)
     public LoadedTurn loadLatestTurn(String ownerKey, Long sessionId, int expectedTurn) {
         GameSession session = findOwnedSession(ownerKey, sessionId);
-
-        if (session.getCurrentTurn() != expectedTurn) {
-            throw new TurnConflictException("이미 처리되었거나 오래된 턴 요청입니다.");
-        }
-
+        if (session.getCurrentTurn() != expectedTurn) throw new TurnConflictException("이미 처리되었거나 오래된 턴 요청입니다.");
         GameLog lastLog = gameLogRepository.findTopByGameSessionOrderByTurnNumberDesc(session)
                 .orElseThrow(() -> new IllegalStateException("게임 로그가 없습니다."));
-
-        if (lastLog.getTurnNumber() != expectedTurn) {
-            throw new IllegalStateException("세션 턴과 저장된 로그가 일치하지 않습니다.");
-        }
-
+        if (lastLog.getTurnNumber() != expectedTurn) throw new IllegalStateException("세션 턴과 저장된 로그가 일치하지 않습니다.");
         GameState gameState = loadOrRecoverState(session);
         if (gameState.turnNumber() != expectedTurn || lastLog.getStateVersion() != expectedTurn) {
             throw new IllegalStateException("세션 턴과 canonical state version이 일치하지 않습니다.");
         }
-
-        return new LoadedTurn(
-                session.getId(),
-                session.getCurrentTurn(),
-                session.getWorldSetting(),
-                session.getCharacterSetting(),
-                lastLog.getStoryText(),
-                lastLog.getChoicesJson(),
-                lastLog.getImageUrl(),
-                gameState
-        );
+        return new LoadedTurn(session.getId(), session.getCurrentTurn(), session.getWorldSetting(),
+                session.getCharacterSetting(), lastLog.getStoryText(), lastLog.getChoicesJson(), lastLog.getImageUrl(), gameState);
     }
 
     @Transactional(readOnly = true)
@@ -128,75 +91,65 @@ public class GamePersistenceService {
 
     @Transactional
     public int saveNextTurn(String ownerKey, Long sessionId, GameTurnCommit commit) {
-        return saveNextTurn(ownerKey, sessionId, commit, null, null);
+        return saveNextTurn(ownerKey, sessionId, commit, null, null, null);
     }
 
     @Transactional
-    public int saveNextTurn(
-            String ownerKey,
-            Long sessionId,
-            GameTurnCommit commit,
-            Long mutationRequestId,
-            String resultTitle
-    ) {
+    public int saveNextTurn(String ownerKey, Long sessionId, GameTurnCommit commit, Long mutationRequestId, String resultTitle) {
+        return saveNextTurn(ownerKey, sessionId, commit, mutationRequestId, resultTitle, null);
+    }
+
+    @Transactional
+    public int saveNextTurn(String ownerKey, Long sessionId, GameTurnCommit commit, Long mutationRequestId,
+            String resultTitle, String reservationOwner) {
         try {
+            if (mutationRequestId != null) verifyReservation(sessionId, commit.expectedTurn(), reservationOwner);
             GameSession session = findOwnedSession(ownerKey, sessionId);
             validateCommitAgainstSession(session, commit);
-
             GameLog previousLog = gameLogRepository.findTopByGameSessionOrderByTurnNumberDesc(session)
                     .orElseThrow(() -> new IllegalStateException("게임 로그가 없습니다."));
-
-            if (previousLog.getTurnNumber() != commit.expectedTurn()
-                    || previousLog.getStateVersion() != commit.previousStateVersion()) {
+            if (previousLog.getTurnNumber() != commit.expectedTurn() || previousLog.getStateVersion() != commit.previousStateVersion()) {
                 throw new IllegalStateException("세션 턴과 저장된 로그의 state version이 일치하지 않습니다.");
             }
-
             GameState canonicalPreviousState = loadOrRecoverState(session);
             if (!canonicalPreviousState.equals(commit.previousState())) {
                 throw new TurnConflictException("commit의 이전 상태가 현재 canonical state와 일치하지 않습니다.");
             }
-
             session.advanceTurn();
-
-            String imageUrl = commit.imageAsset() == null
-                    ? previousLog.getImageUrl()
+            String imageUrl = commit.imageAsset() == null ? previousLog.getImageUrl()
                     : persistImageAsset(session, commit.nextStateVersion(), commit.imageAsset());
-
             gameSessionRepository.save(session);
-            gameLogRepository.save(GameLog.committedTurn(
-                    session,
-                    commit.nextStateVersion(),
-                    commit.inputChoiceId(),
-                    commit.inputChoiceText(),
-                    commit.previousStateVersion(),
-                    commit.nextStateVersion(),
-                    commit.storyText(),
-                    commit.choicesJson(),
-                    imageUrl
-            ));
-
+            gameLogRepository.save(GameLog.committedTurn(session, commit.nextStateVersion(), commit.inputChoiceId(),
+                    commit.inputChoiceText(), commit.previousStateVersion(), commit.nextStateVersion(), commit.storyText(),
+                    commit.choicesJson(), imageUrl));
             GameStateSnapshot snapshot = gameStateSnapshotRepository.findById(sessionId)
                     .orElseGet(() -> new GameStateSnapshot(session, gameStateCodec.serialize(commit.previousState())));
             snapshot.updateStateJson(gameStateCodec.serialize(commit.nextState()));
             gameStateSnapshotRepository.save(snapshot);
             completeMutationRequest(mutationRequestId, session.getId(), session.getCurrentTurn(), resultTitle);
-
+            if (mutationRequestId != null) {
+                int released = gameMutationRequestRepository.releaseReservation(sessionId, commit.expectedTurn(), mutationRequestId, reservationOwner);
+                if (released != 1) throw new TurnConflictException("턴 reservation 소유권이 변경되었습니다.");
+            }
             flushAll();
             return session.getCurrentTurn();
         } catch (ObjectOptimisticLockingFailureException exception) {
             throw new TurnConflictException("동시에 처리된 턴 요청과 충돌했습니다.", exception);
         } catch (DataIntegrityViolationException exception) {
-            if (isTurnUniqueConstraintViolation(exception)) {
-                throw new TurnConflictException("동시에 처리된 턴 요청과 충돌했습니다.", exception);
-            }
+            if (isTurnUniqueConstraintViolation(exception)) throw new TurnConflictException("동시에 처리된 턴 요청과 충돌했습니다.", exception);
             throw new PersistenceOperationException("게임 진행 상태를 저장할 수 없습니다.", exception);
         }
     }
 
+    private void verifyReservation(Long sessionId, int expectedTurn, String reservationOwner) {
+        if (reservationOwner == null) throw new TurnConflictException("턴 reservation 소유권이 없습니다.");
+        String currentOwner = gameMutationRequestRepository.findReservationOwnerForUpdate(sessionId, expectedTurn)
+                .orElseThrow(() -> new TurnConflictException("턴 reservation이 만료되었거나 회수되었습니다."));
+        if (!reservationOwner.equals(currentOwner)) throw new TurnConflictException("턴 reservation 소유권이 변경되었습니다.");
+    }
+
     private void completeMutationRequest(Long mutationRequestId, Long sessionId, int turn, String resultTitle) {
-        if (mutationRequestId == null) {
-            return;
-        }
+        if (mutationRequestId == null) return;
         GameMutationRequest request = gameMutationRequestRepository.findById(mutationRequestId)
                 .orElseThrow(() -> new IllegalStateException("mutation request를 찾을 수 없습니다."));
         request.complete(sessionId, turn, resultTitle);
@@ -204,38 +157,16 @@ public class GamePersistenceService {
     }
 
     private void validateCommitAgainstSession(GameSession session, GameTurnCommit commit) {
-        if (session.getCurrentTurn() != commit.expectedTurn()) {
-            throw new TurnConflictException("이미 처리되었거나 오래된 턴 요청입니다.");
-        }
-        if (commit.previousStateVersion() != commit.expectedTurn()) {
-            throw new IllegalArgumentException("commit의 이전 state version이 expectedTurn과 일치하지 않습니다.");
-        }
-        if (commit.nextStateVersion() != commit.expectedTurn() + 1) {
-            throw new IllegalArgumentException("commit의 다음 state version이 올바르지 않습니다.");
-        }
+        if (session.getCurrentTurn() != commit.expectedTurn()) throw new TurnConflictException("이미 처리되었거나 오래된 턴 요청입니다.");
+        if (commit.previousStateVersion() != commit.expectedTurn()) throw new IllegalArgumentException("commit의 이전 state version이 expectedTurn과 일치하지 않습니다.");
+        if (commit.nextStateVersion() != commit.expectedTurn() + 1) throw new IllegalArgumentException("commit의 다음 state version이 올바르지 않습니다.");
     }
 
-    private String persistImageAsset(
-            GameSession session,
-            int turnNumber,
-            ImageAssetService.AssetReference assetReference
-    ) {
-        if (assetReference == null) {
-            return null;
-        }
-        ImageAsset asset = new ImageAsset(
-                assetReference.id(),
-                session,
-                turnNumber,
-                assetReference.prompt(),
-                assetReference.aspectRatio(),
-                assetReference.model(),
-                assetReference.width(),
-                assetReference.height(),
-                assetReference.seed(),
-                assetReference.safe(),
-                assetReference.styleVersion()
-        );
+    private String persistImageAsset(GameSession session, int turnNumber, ImageAssetService.AssetReference assetReference) {
+        if (assetReference == null) return null;
+        ImageAsset asset = new ImageAsset(assetReference.id(), session, turnNumber, assetReference.prompt(),
+                assetReference.aspectRatio(), assetReference.model(), assetReference.width(), assetReference.height(),
+                assetReference.seed(), assetReference.safe(), assetReference.styleVersion());
         imageAssetRepository.save(asset);
         return asset.publicUrl();
     }
@@ -248,21 +179,14 @@ public class GamePersistenceService {
     private boolean isTurnUniqueConstraintViolation(DataIntegrityViolationException exception) {
         Throwable cause = exception.getMostSpecificCause();
         String message = cause == null ? exception.getMessage() : cause.getMessage();
-        if (message == null) {
-            return false;
-        }
+        if (message == null) return false;
         String normalized = message.toLowerCase();
-        return normalized.contains(GAME_LOG_TURN_UNIQUE_CONSTRAINT)
-                || normalized.contains(IMAGE_ASSET_TURN_UNIQUE_CONSTRAINT);
+        return normalized.contains(GAME_LOG_TURN_UNIQUE_CONSTRAINT) || normalized.contains(IMAGE_ASSET_TURN_UNIQUE_CONSTRAINT);
     }
 
     private GameState loadOrRecoverState(GameSession session) {
-        return gameStateSnapshotRepository.findById(session.getId())
-                .map(snapshot -> gameStateCodec.deserialize(snapshot.getStateJson()))
-                .orElseGet(() -> gameStateRecovery.recover(
-                        session,
-                        gameLogRepository.findByGameSessionOrderByTurnNumberAsc(session)
-                ));
+        return gameStateSnapshotRepository.findById(session.getId()).map(snapshot -> gameStateCodec.deserialize(snapshot.getStateJson()))
+                .orElseGet(() -> gameStateRecovery.recover(session, gameLogRepository.findByGameSessionOrderByTurnNumberAsc(session)));
     }
 
     private void flushAll() {
@@ -273,16 +197,7 @@ public class GamePersistenceService {
         gameMutationRequestRepository.flush();
     }
 
-    public record LoadedTurn(
-            Long sessionId,
-            int turnNumber,
-            String worldSetting,
-            String characterSetting,
-            String storyText,
-            String choicesJson,
-            String imageUrl,
-            GameState gameState
-    ) {}
-
+    public record LoadedTurn(Long sessionId, int turnNumber, String worldSetting, String characterSetting,
+            String storyText, String choicesJson, String imageUrl, GameState gameState) {}
     public record CommittedTurn(String storyText, String choicesJson, String imageUrl) {}
 }

--- a/src/main/java/com/uctale/uctale/application/game/MutationInProgressException.java
+++ b/src/main/java/com/uctale/uctale/application/game/MutationInProgressException.java
@@ -1,0 +1,14 @@
+package com.uctale.uctale.application.game;
+
+public class MutationInProgressException extends RuntimeException {
+    private final long retryAfterSeconds;
+
+    public MutationInProgressException(String message, long retryAfterSeconds) {
+        super(message);
+        this.retryAfterSeconds = Math.max(1, retryAfterSeconds);
+    }
+
+    public long retryAfterSeconds() {
+        return retryAfterSeconds;
+    }
+}

--- a/src/main/java/com/uctale/uctale/controller/ApiExceptionHandler.java
+++ b/src/main/java/com/uctale/uctale/controller/ApiExceptionHandler.java
@@ -4,6 +4,7 @@ import com.uctale.uctale.application.cost.RateLimitExceededException;
 import com.uctale.uctale.application.game.GameSessionNotFoundException;
 import com.uctale.uctale.application.game.IdempotencyConflictException;
 import com.uctale.uctale.application.game.InvalidChoiceException;
+import com.uctale.uctale.application.game.MutationInProgressException;
 import com.uctale.uctale.application.game.PersistenceOperationException;
 import com.uctale.uctale.application.game.TurnConflictException;
 import com.uctale.uctale.application.image.ImageAssetNotFoundException;
@@ -22,97 +23,49 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class ApiExceptionHandler {
-
     @ExceptionHandler(AccessSessionException.class)
-    public ResponseEntity<ApiError> handleAccessSession(AccessSessionException exception) {
-        return error(HttpStatus.UNAUTHORIZED, exception.code(), exception.getMessage());
-    }
-
+    public ResponseEntity<ApiError> handleAccessSession(AccessSessionException exception) { return error(HttpStatus.UNAUTHORIZED, exception.code(), exception.getMessage()); }
     @ExceptionHandler(AccessRequestForbiddenException.class)
-    public ResponseEntity<ApiError> handleAccessRequestForbidden(AccessRequestForbiddenException exception) {
-        return error(HttpStatus.FORBIDDEN, "ACCESS_REQUEST_FORBIDDEN", exception.getMessage());
-    }
-
+    public ResponseEntity<ApiError> handleAccessRequestForbidden(AccessRequestForbiddenException exception) { return error(HttpStatus.FORBIDDEN, "ACCESS_REQUEST_FORBIDDEN", exception.getMessage()); }
     @ExceptionHandler(AccessAuthenticationRateLimitExceededException.class)
-    public ResponseEntity<ApiError> handleAccessAuthenticationRateLimit(
-            AccessAuthenticationRateLimitExceededException exception
-    ) {
-        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
-                .header(HttpHeaders.RETRY_AFTER, Long.toString(exception.retryAfterSeconds()))
-                .body(new ApiError("ACCESS_RATE_LIMIT_EXCEEDED", exception.getMessage()));
+    public ResponseEntity<ApiError> handleAccessAuthenticationRateLimit(AccessAuthenticationRateLimitExceededException exception) {
+        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).header(HttpHeaders.RETRY_AFTER, Long.toString(exception.retryAfterSeconds())).body(new ApiError("ACCESS_RATE_LIMIT_EXCEEDED", exception.getMessage()));
     }
-
     @ExceptionHandler(RateLimitExceededException.class)
     public ResponseEntity<ApiError> handleRateLimit(RateLimitExceededException exception) {
-        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
-                .header(HttpHeaders.RETRY_AFTER, Long.toString(exception.retryAfterSeconds()))
-                .body(new ApiError("RATE_LIMIT_EXCEEDED", exception.getMessage()));
+        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).header(HttpHeaders.RETRY_AFTER, Long.toString(exception.retryAfterSeconds())).body(new ApiError("RATE_LIMIT_EXCEEDED", exception.getMessage()));
     }
-
+    @ExceptionHandler(MutationInProgressException.class)
+    public ResponseEntity<ApiError> handleMutationInProgress(MutationInProgressException exception) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).header(HttpHeaders.RETRY_AFTER, Long.toString(exception.retryAfterSeconds())).body(new ApiError("MUTATION_IN_PROGRESS", exception.getMessage()));
+    }
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ApiError> handleIllegalArgument(IllegalArgumentException exception) {
-        return error(HttpStatus.BAD_REQUEST, "INVALID_REQUEST", exception.getMessage());
-    }
-
+    public ResponseEntity<ApiError> handleIllegalArgument(IllegalArgumentException exception) { return error(HttpStatus.BAD_REQUEST, "INVALID_REQUEST", exception.getMessage()); }
     @ExceptionHandler(GameSessionNotFoundException.class)
-    public ResponseEntity<ApiError> handleSessionNotFound(GameSessionNotFoundException exception) {
-        return error(HttpStatus.NOT_FOUND, "SESSION_NOT_FOUND", exception.getMessage());
-    }
-
+    public ResponseEntity<ApiError> handleSessionNotFound(GameSessionNotFoundException exception) { return error(HttpStatus.NOT_FOUND, "SESSION_NOT_FOUND", exception.getMessage()); }
     @ExceptionHandler(ImageAssetNotFoundException.class)
-    public ResponseEntity<ApiError> handleImageAssetNotFound(ImageAssetNotFoundException exception) {
-        return error(HttpStatus.NOT_FOUND, "IMAGE_ASSET_NOT_FOUND", exception.getMessage());
-    }
-
+    public ResponseEntity<ApiError> handleImageAssetNotFound(ImageAssetNotFoundException exception) { return error(HttpStatus.NOT_FOUND, "IMAGE_ASSET_NOT_FOUND", exception.getMessage()); }
     @ExceptionHandler(ImageGenerationException.class)
-    public ResponseEntity<ApiError> handleImageGeneration(ImageGenerationException exception) {
-        return error(HttpStatus.BAD_GATEWAY, "IMAGE_PROVIDER_FAILURE", "이미지를 생성하지 못했습니다.");
-    }
-
+    public ResponseEntity<ApiError> handleImageGeneration(ImageGenerationException exception) { return error(HttpStatus.BAD_GATEWAY, "IMAGE_PROVIDER_FAILURE", "이미지를 생성하지 못했습니다."); }
     @ExceptionHandler(IdempotencyConflictException.class)
-    public ResponseEntity<ApiError> handleIdempotencyConflict(IdempotencyConflictException exception) {
-        return error(HttpStatus.CONFLICT, "IDEMPOTENCY_CONFLICT", exception.getMessage());
-    }
-
+    public ResponseEntity<ApiError> handleIdempotencyConflict(IdempotencyConflictException exception) { return error(HttpStatus.CONFLICT, "IDEMPOTENCY_CONFLICT", exception.getMessage()); }
     @ExceptionHandler(TurnConflictException.class)
-    public ResponseEntity<ApiError> handleTurnConflict(TurnConflictException exception) {
-        return error(HttpStatus.CONFLICT, "TURN_CONFLICT", exception.getMessage());
-    }
-
+    public ResponseEntity<ApiError> handleTurnConflict(TurnConflictException exception) { return error(HttpStatus.CONFLICT, "TURN_CONFLICT", exception.getMessage()); }
     @ExceptionHandler(InvalidChoiceException.class)
-    public ResponseEntity<ApiError> handleInvalidChoice(InvalidChoiceException exception) {
-        return error(HttpStatus.UNPROCESSABLE_ENTITY, "INVALID_CHOICE", exception.getMessage());
-    }
-
+    public ResponseEntity<ApiError> handleInvalidChoice(InvalidChoiceException exception) { return error(HttpStatus.UNPROCESSABLE_ENTITY, "INVALID_CHOICE", exception.getMessage()); }
     @ExceptionHandler(InvalidNarrativeResponseException.class)
-    public ResponseEntity<ApiError> handleInvalidNarrativeResponse(InvalidNarrativeResponseException exception) {
-        return error(HttpStatus.BAD_GATEWAY, "PROVIDER_RESPONSE_INVALID", "Narrative provider 응답이 올바르지 않습니다.");
-    }
-
+    public ResponseEntity<ApiError> handleInvalidNarrativeResponse(InvalidNarrativeResponseException exception) { return error(HttpStatus.BAD_GATEWAY, "PROVIDER_RESPONSE_INVALID", "Narrative provider 응답이 올바르지 않습니다."); }
     @ExceptionHandler(PersistenceOperationException.class)
-    public ResponseEntity<ApiError> handlePersistenceFailure(PersistenceOperationException exception) {
-        return error(HttpStatus.INTERNAL_SERVER_ERROR, "PERSISTENCE_FAILURE", "게임 상태 저장 중 오류가 발생했습니다.");
-    }
-
+    public ResponseEntity<ApiError> handlePersistenceFailure(PersistenceOperationException exception) { return error(HttpStatus.INTERNAL_SERVER_ERROR, "PERSISTENCE_FAILURE", "게임 상태 저장 중 오류가 발생했습니다."); }
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiError> handleValidation(MethodArgumentNotValidException exception) {
-        String message = exception.getBindingResult().getFieldErrors().stream()
-                .findFirst()
-                .map(error -> error.getDefaultMessage())
-                .orElse("요청값이 올바르지 않습니다.");
+        String message = exception.getBindingResult().getFieldErrors().stream().findFirst().map(error -> error.getDefaultMessage()).orElse("요청값이 올바르지 않습니다.");
         return error(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", message);
     }
-
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<ApiError> handleConstraintViolation(ConstraintViolationException exception) {
-        String message = exception.getConstraintViolations().stream()
-                .findFirst()
-                .map(violation -> violation.getMessage())
-                .orElse("요청값이 올바르지 않습니다.");
+        String message = exception.getConstraintViolations().stream().findFirst().map(violation -> violation.getMessage()).orElse("요청값이 올바르지 않습니다.");
         return error(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", message);
     }
-
-    private ResponseEntity<ApiError> error(HttpStatus status, String code, String message) {
-        return ResponseEntity.status(status).body(new ApiError(code, message));
-    }
+    private ResponseEntity<ApiError> error(HttpStatus status, String code, String message) { return ResponseEntity.status(status).body(new ApiError(code, message)); }
 }

--- a/src/main/java/com/uctale/uctale/repository/GameMutationRequestRepository.java
+++ b/src/main/java/com/uctale/uctale/repository/GameMutationRequestRepository.java
@@ -1,10 +1,68 @@
 package com.uctale.uctale.repository;
 
 import com.uctale.uctale.domain.GameMutationRequest;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface GameMutationRequestRepository extends JpaRepository<GameMutationRequest, Long> {
     Optional<GameMutationRequest> findByOwnerKeyAndIdempotencyKey(String ownerKey, String idempotencyKey);
+
+    @Modifying
+    @Query(value = """
+            INSERT INTO game_mutation_request (
+                owner_key, operation, idempotency_key, session_id, expected_turn,
+                request_fingerprint, status, created_at, updated_at
+            ) VALUES (
+                :ownerKey, :operation, :idempotencyKey, :sessionId, :expectedTurn,
+                :fingerprint, 'PROCESSING', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+            )
+            ON CONFLICT (owner_key, idempotency_key) DO NOTHING
+            """, nativeQuery = true)
+    int insertIfAbsent(
+            @Param("ownerKey") String ownerKey,
+            @Param("operation") String operation,
+            @Param("idempotencyKey") String idempotencyKey,
+            @Param("sessionId") Long sessionId,
+            @Param("expectedTurn") Integer expectedTurn,
+            @Param("fingerprint") String fingerprint
+    );
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select request from GameMutationRequest request where request.ownerKey = :ownerKey and request.idempotencyKey = :idempotencyKey")
+    Optional<GameMutationRequest> findForUpdate(
+            @Param("ownerKey") String ownerKey,
+            @Param("idempotencyKey") String idempotencyKey
+    );
+
+    @Query(value = """
+            SELECT lease_owner
+            FROM game_turn_reservation
+            WHERE session_id = :sessionId AND expected_turn = :expectedTurn
+            FOR UPDATE
+            """, nativeQuery = true)
+    Optional<String> findReservationOwnerForUpdate(
+            @Param("sessionId") Long sessionId,
+            @Param("expectedTurn") int expectedTurn
+    );
+
+    @Modifying
+    @Query(value = """
+            DELETE FROM game_turn_reservation
+            WHERE session_id = :sessionId
+              AND expected_turn = :expectedTurn
+              AND request_id = :requestId
+              AND lease_owner = :leaseOwner
+            """, nativeQuery = true)
+    int releaseReservation(
+            @Param("sessionId") Long sessionId,
+            @Param("expectedTurn") int expectedTurn,
+            @Param("requestId") Long requestId,
+            @Param("leaseOwner") String leaseOwner
+    );
 }

--- a/src/main/java/com/uctale/uctale/service/GameService.java
+++ b/src/main/java/com/uctale/uctale/service/GameService.java
@@ -55,11 +55,7 @@ public class GameService {
 
     public GameResponse initGame(CostRequestContext costContext, GameInitRequest request) {
         GameMutationRequestService.BeginResult mutation = mutationRequestService.begin(
-                costContext.ownerKey(),
-                GameMutationRequestService.INIT,
-                costContext.idempotencyKey(),
-                null,
-                null,
+                costContext.ownerKey(), GameMutationRequestService.INIT, costContext.idempotencyKey(), null, null,
                 mutationFingerprint.init(request)
         );
         if (mutation.replay()) {
@@ -83,16 +79,9 @@ public class GameService {
             ImageAssetService.AssetReference imageAsset = imageAssetService.issue(imagePrompt, "16:9");
 
             var session = gamePersistenceService.saveOpening(
-                    costContext.ownerKey(),
-                    request.worldSetting(),
-                    request.characterSetting(),
-                    opening.storyText(),
-                    choiceCodec.serialize(choices),
-                    imageAsset,
-                    mutation.requestId(),
-                    opening.title()
+                    costContext.ownerKey(), request.worldSetting(), request.characterSetting(), opening.storyText(),
+                    choiceCodec.serialize(choices), imageAsset, mutation.requestId(), opening.title()
             );
-
             return toResponse(session.getId(), session.getCurrentTurn(), opening, choices, imageAsset.publicUrl());
         } catch (RuntimeException exception) {
             mutationRequestService.markFailed(mutation.requestId());
@@ -106,12 +95,8 @@ public class GameService {
 
     public GameResponse progressGame(CostRequestContext costContext, GameProgressRequest request) {
         GameMutationRequestService.BeginResult mutation = mutationRequestService.begin(
-                costContext.ownerKey(),
-                GameMutationRequestService.PROGRESS,
-                costContext.idempotencyKey(),
-                request.sessionId(),
-                request.expectedTurn(),
-                mutationFingerprint.progress(request)
+                costContext.ownerKey(), GameMutationRequestService.PROGRESS, costContext.idempotencyKey(),
+                request.sessionId(), request.expectedTurn(), mutationFingerprint.progress(request)
         );
         if (mutation.replay()) {
             return replay(costContext.ownerKey(), mutation);
@@ -121,10 +106,9 @@ public class GameService {
             GamePersistenceService.LoadedTurn loadedTurn = gamePersistenceService.loadLatestTurn(
                     costContext.ownerKey(), request.sessionId(), request.expectedTurn()
             );
-
             CostRequestContext providerContext = new CostRequestContext(
-                    costContext.requestId(), costContext.ownerKey(), costContext.clientIp(),
-                    loadedTurn.sessionId(), request.expectedTurn() + 1, costContext.idempotencyKey()
+                    costContext.requestId(), costContext.ownerKey(), costContext.clientIp(), loadedTurn.sessionId(),
+                    request.expectedTurn() + 1, costContext.idempotencyKey()
             );
 
             String userChoiceText = choiceCodec.findText(loadedTurn.choicesJson(), request.choiceId());
@@ -151,24 +135,14 @@ public class GameService {
 
             GameState nextState = loadedTurn.gameState().advance(userChoiceText, nextTurn.storyText());
             GameTurnCommit commit = new GameTurnCommit(
-                    request.expectedTurn(),
-                    request.choiceId(),
-                    userChoiceText,
-                    loadedTurn.gameState(),
-                    nextState,
-                    nextTurn.storyText(),
-                    choiceCodec.serialize(choices),
-                    imageAsset
+                    request.expectedTurn(), request.choiceId(), userChoiceText, loadedTurn.gameState(), nextState,
+                    nextTurn.storyText(), choiceCodec.serialize(choices), imageAsset
             );
 
             int savedTurn = gamePersistenceService.saveNextTurn(
-                    costContext.ownerKey(),
-                    loadedTurn.sessionId(),
-                    commit,
-                    mutation.requestId(),
-                    nextTurn.title()
+                    costContext.ownerKey(), loadedTurn.sessionId(), commit, mutation.requestId(), nextTurn.title(),
+                    mutation.reservationOwner()
             );
-
             return toResponse(loadedTurn.sessionId(), savedTurn, nextTurn, choices, imageUrl);
         } catch (RuntimeException exception) {
             mutationRequestService.markFailed(mutation.requestId());
@@ -184,12 +158,8 @@ public class GameService {
                 ownerKey, mutation.resultSessionId(), mutation.resultTurn()
         );
         return new GameResponse(
-                mutation.resultSessionId(),
-                mutation.resultTurn(),
-                mutation.resultTitle(),
-                turn.storyText(),
-                choiceCodec.deserialize(turn.choicesJson()),
-                turn.imageUrl()
+                mutation.resultSessionId(), mutation.resultTurn(), mutation.resultTitle(), turn.storyText(),
+                choiceCodec.deserialize(turn.choicesJson()), turn.imageUrl()
         );
     }
 

--- a/src/main/java/com/uctale/uctale/service/GameService.java
+++ b/src/main/java/com/uctale/uctale/service/GameService.java
@@ -145,7 +145,7 @@ public class GameService {
             );
             return toResponse(loadedTurn.sessionId(), savedTurn, nextTurn, choices, imageUrl);
         } catch (RuntimeException exception) {
-            mutationRequestService.markFailed(mutation.requestId());
+            mutationRequestService.markFailed(mutation.requestId(), mutation.reservationOwner());
             throw exception;
         }
     }

--- a/src/main/resources/db/migration/V8__create_game_turn_reservation.sql
+++ b/src/main/resources/db/migration/V8__create_game_turn_reservation.sql
@@ -1,0 +1,18 @@
+CREATE TABLE game_turn_reservation (
+    session_id BIGINT NOT NULL,
+    expected_turn INTEGER NOT NULL,
+    request_id BIGINT NOT NULL,
+    lease_owner VARCHAR(36) NOT NULL,
+    lease_expires_at TIMESTAMP NOT NULL,
+    attempt_count INTEGER NOT NULL DEFAULT 1,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (session_id, expected_turn),
+    CONSTRAINT fk_game_turn_reservation_request
+        FOREIGN KEY (request_id) REFERENCES game_mutation_request(id),
+    CONSTRAINT ck_game_turn_reservation_attempt_count
+        CHECK (attempt_count BETWEEN 1 AND 3)
+);
+
+CREATE INDEX idx_game_turn_reservation_lease_expiry
+    ON game_turn_reservation (lease_expires_at);

--- a/src/test/java/com/uctale/uctale/application/game/GameMutationRequestServiceTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/GameMutationRequestServiceTest.java
@@ -6,69 +6,54 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class GameMutationRequestServiceTest {
-
     private static final String OWNER_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    @Mock private GameMutationRequestRepository repository;
+    @Mock private JdbcTemplate jdbcTemplate;
 
-    @Mock
-    private GameMutationRequestRepository repository;
-
-    @Test
-    void sameKeyWithDifferentFingerprint_IsConflict() {
-        GameMutationRequest stored = new GameMutationRequest(
-                OWNER_KEY, "PROGRESS", "same-key-123", 42L, 1, "a".repeat(64)
+    private GameMutationRequestService service() {
+        return new GameMutationRequestService(
+                repository, jdbcTemplate,
+                Clock.fixed(Instant.parse("2026-08-31T00:00:00Z"), ZoneOffset.UTC), 90
         );
-        given(repository.findByOwnerKeyAndIdempotencyKey(OWNER_KEY, "same-key-123"))
-                .willReturn(Optional.of(stored));
-
-        GameMutationRequestService service = new GameMutationRequestService(repository);
-
-        assertThatThrownBy(() -> service.begin(
-                OWNER_KEY, "PROGRESS", "same-key-123", 42L, 1, "b".repeat(64)
-        )).isInstanceOf(IdempotencyConflictException.class);
-
-        verify(repository, never()).save(stored);
     }
 
     @Test
-    void sameKeyAcrossOperations_IsConflict() {
-        GameMutationRequest stored = new GameMutationRequest(
-                OWNER_KEY, "INIT", "same-key-123", null, null, "a".repeat(64)
-        );
-        given(repository.findByOwnerKeyAndIdempotencyKey(OWNER_KEY, "same-key-123"))
-                .willReturn(Optional.of(stored));
+    void sameKeyWithDifferentFingerprint_IsConflict() {
+        GameMutationRequest stored = new GameMutationRequest(OWNER_KEY, "PROGRESS", "same-key-123", 42L, 1, "a".repeat(64));
+        given(repository.findForUpdate(OWNER_KEY, "same-key-123")).willReturn(Optional.of(stored));
+        assertThatThrownBy(() -> service().begin(OWNER_KEY, "PROGRESS", "same-key-123", 42L, 1, "b".repeat(64)))
+                .isInstanceOf(IdempotencyConflictException.class);
+    }
 
-        GameMutationRequestService service = new GameMutationRequestService(repository);
-
-        assertThatThrownBy(() -> service.begin(
-                OWNER_KEY, "PROGRESS", "same-key-123", 42L, 1, "a".repeat(64)
-        )).isInstanceOf(IdempotencyConflictException.class);
+    @Test
+    void processingSameRequest_ReturnsInProgress() {
+        GameMutationRequest stored = new GameMutationRequest(OWNER_KEY, "INIT", "same-key-123", null, null, "a".repeat(64));
+        given(repository.findForUpdate(OWNER_KEY, "same-key-123")).willReturn(Optional.of(stored));
+        assertThatThrownBy(() -> service().begin(OWNER_KEY, "INIT", "same-key-123", null, null, "a".repeat(64)))
+                .isInstanceOf(MutationInProgressException.class);
     }
 
     @Test
     void failedRequestWithSameFingerprint_CanRetry() {
-        GameMutationRequest stored = new GameMutationRequest(
-                OWNER_KEY, "INIT", "retry-key-123", null, null, "a".repeat(64)
-        );
+        GameMutationRequest stored = new GameMutationRequest(OWNER_KEY, "INIT", "retry-key-123", null, null, "a".repeat(64));
         stored.fail();
-        given(repository.findByOwnerKeyAndIdempotencyKey(OWNER_KEY, "retry-key-123"))
-                .willReturn(Optional.of(stored));
-
-        GameMutationRequestService service = new GameMutationRequestService(repository);
-        GameMutationRequestService.BeginResult result = service.begin(
-                OWNER_KEY, "INIT", "retry-key-123", null, null, "a".repeat(64)
-        );
-
+        given(repository.findForUpdate(OWNER_KEY, "retry-key-123")).willReturn(Optional.of(stored));
+        GameMutationRequestService.BeginResult result = service().begin(
+                OWNER_KEY, "INIT", "retry-key-123", null, null, "a".repeat(64));
         assertThat(result.replay()).isFalse();
         assertThat(stored.getStatus()).isEqualTo(GameMutationRequest.Status.PROCESSING);
         verify(repository).save(stored);

--- a/src/test/java/com/uctale/uctale/persistence/PostgresGameTurnReservationTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/PostgresGameTurnReservationTest.java
@@ -1,0 +1,57 @@
+package com.uctale.uctale.persistence;
+
+import com.uctale.uctale.application.game.GameMutationRequestService;
+import com.uctale.uctale.application.game.MutationInProgressException;
+import com.uctale.uctale.repository.GameMutationRequestRepository;
+import com.uctale.uctale.support.PostgresIntegrationTestSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+class PostgresGameTurnReservationTest extends PostgresIntegrationTestSupport {
+    private static final String OWNER_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    private static final Long SESSION_ID = 4242L;
+    private static final int EXPECTED_TURN = 7;
+
+    @Autowired private GameMutationRequestService service;
+    @Autowired private GameMutationRequestRepository repository;
+    @Autowired private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanUp() {
+        jdbcTemplate.update("DELETE FROM game_turn_reservation");
+        repository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("PostgreSQL에서는 같은 session/turn의 유효 lease를 하나만 소유하고 만료 뒤 회수할 수 있다")
+    void activeLease_IsUniqueAndExpiredLeaseCanBeTakenOver() {
+        var first = service.begin(OWNER_KEY, GameMutationRequestService.PROGRESS, "lease-key-001",
+                SESSION_ID, EXPECTED_TURN, "a".repeat(64));
+
+        assertThatThrownBy(() -> service.begin(OWNER_KEY, GameMutationRequestService.PROGRESS, "lease-key-002",
+                SESSION_ID, EXPECTED_TURN, "b".repeat(64)))
+                .isInstanceOf(MutationInProgressException.class);
+
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM game_turn_reservation WHERE session_id = ? AND expected_turn = ?",
+                Integer.class, SESSION_ID, EXPECTED_TURN)).isEqualTo(1);
+
+        jdbcTemplate.update("UPDATE game_turn_reservation SET lease_expires_at = CURRENT_TIMESTAMP - INTERVAL '1 second'");
+
+        var second = service.begin(OWNER_KEY, GameMutationRequestService.PROGRESS, "lease-key-002",
+                SESSION_ID, EXPECTED_TURN, "b".repeat(64));
+
+        assertThat(second.reservationOwner()).isNotEqualTo(first.reservationOwner());
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT attempt_count FROM game_turn_reservation WHERE session_id = ? AND expected_turn = ?",
+                Integer.class, SESSION_ID, EXPECTED_TURN)).isEqualTo(2);
+    }
+}

--- a/src/test/java/com/uctale/uctale/service/GameServiceTest.java
+++ b/src/test/java/com/uctale/uctale/service/GameServiceTest.java
@@ -1,26 +1,26 @@
 package com.uctale.uctale.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.uctale.uctale.ai.NarrativeContext;
-import com.uctale.uctale.ai.NarrativeGenerator;
-import com.uctale.uctale.ai.NarrativeTurn;
+import tools.jackson.databind.ObjectMapper;
+import com.uctale.uctale.application.cost.CostRateLimitPolicy;
+import com.uctale.uctale.application.cost.CostRateLimiter;
+import com.uctale.uctale.application.cost.ProviderCallTelemetry;
+import com.uctale.uctale.application.game.ChoiceCodec;
 import com.uctale.uctale.application.game.GameMutationFingerprint;
 import com.uctale.uctale.application.game.GameMutationRequestService;
 import com.uctale.uctale.application.game.GamePersistenceService;
-import com.uctale.uctale.cost.CostOperation;
-import com.uctale.uctale.cost.CostRateLimitPolicy;
-import com.uctale.uctale.cost.CostRateLimiter;
-import com.uctale.uctale.cost.CostRequestContext;
-import com.uctale.uctale.cost.ProviderCallTelemetry;
+import com.uctale.uctale.application.game.GameTurnCommit;
+import com.uctale.uctale.application.game.ImagePromptComposer;
+import com.uctale.uctale.application.game.TurnConflictException;
+import com.uctale.uctale.application.image.ImageAssetService;
+import com.uctale.uctale.application.narrative.NarrativeContext;
+import com.uctale.uctale.application.narrative.NarrativeGenerator;
+import com.uctale.uctale.application.narrative.NarrativeTurn;
+import com.uctale.uctale.domain.GameSession;
+import com.uctale.uctale.domain.game.GameState;
 import com.uctale.uctale.dto.GameChoice;
 import com.uctale.uctale.dto.GameInitRequest;
 import com.uctale.uctale.dto.GameProgressRequest;
 import com.uctale.uctale.dto.GameResponse;
-import com.uctale.uctale.image.ImageAssetService;
-import com.uctale.uctale.image.ImagePromptComposer;
-import com.uctale.uctale.model.GameState;
-import com.uctale.uctale.model.GameTurnCommit;
-import com.uctale.uctale.util.ChoiceCodec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -74,47 +74,54 @@ class GameServiceTest {
     }
 
     @Test
-    @DisplayName("init은 persistence 전에 narrative와 choice를 확정한다")
-    void initializeGame_PreparesNarrativeBeforePersistence() {
+    @DisplayName("게임 초기화는 versioned prompt로 서버 발급 image asset을 저장에 전달한다")
+    void initGame_ReturnsFirstTurn() {
+        GameInitRequest request = new GameInitRequest("좀비 아포칼립스", "김대리");
         NarrativeTurn opening = new NarrativeTurn(
-                "오프닝", "스토리",
-                List.of(new NarrativeTurn.Choice(1, "간다")),
-                new NarrativeTurn.VisualAssets("", List.of(), List.of())
+                "첫날 밤", "오프닝 스토리",
+                List.of(new NarrativeTurn.Choice(1, "도망간다")),
+                new NarrativeTurn.VisualAssets("dark street", List.of("zombie"), List.of())
         );
-        given(narrativeGenerator.createOpening("세계관", "캐릭터")).willReturn(opening);
-        given(gamePersistenceService.saveOpening(any(), any(), any(), any(), any(), any(), any(), any()))
-                .willAnswer(invocation -> {
-                    var session = new com.uctale.uctale.domain.GameSession(OWNER_KEY, "세계관", "캐릭터");
-                    ReflectionTestUtils.setField(session, "id", 42L);
-                    return session;
-                });
+        GameSession session = new GameSession(OWNER_KEY, request.worldSetting(), request.characterSetting());
+        ReflectionTestUtils.setField(session, "id", 42L);
+        ImageAssetService.AssetReference asset = new ImageAssetService.AssetReference(
+                "asset-id", "/api/game/image-assets/asset-id", "prompt", "16:9",
+                "flux", 1024, 576, 123, true, "uctale-charcoal-v2"
+        );
 
-        GameResponse response = gameService.initializeGame(
-                OWNER_KEY,
-                new GameInitRequest("세계관", "캐릭터")
-        );
+        given(narrativeGenerator.createOpening("좀비 아포칼립스", "김대리")).willReturn(opening);
+        given(imageAssetService.issue(any(String.class), eq("16:9"))).willReturn(asset);
+        given(gamePersistenceService.saveOpening(
+                eq(OWNER_KEY), any(), any(), any(), any(), eq(asset), eq(100L), eq("첫날 밤")
+        )).willReturn(session);
+
+        GameResponse response = gameService.initGame(OWNER_KEY, request);
 
         assertThat(response.sessionId()).isEqualTo(42L);
         assertThat(response.turnNumber()).isEqualTo(1);
-        verify(narrativeGenerator).createOpening("세계관", "캐릭터");
+        assertThat(response.mainImageUrl()).isEqualTo("/api/game/image-assets/asset-id");
+        ArgumentCaptor<String> promptCaptor = ArgumentCaptor.forClass(String.class);
+        verify(imageAssetService).issue(promptCaptor.capture(), eq("16:9"));
+        assertThat(promptCaptor.getValue())
+                .startsWith("style[uctale-charcoal-v2]")
+                .contains("subjects: zombie", "setting: dark street", "final style lock:");
     }
 
     @Test
-    @DisplayName("init replay는 provider와 persistence를 다시 호출하지 않는다")
-    void initializeGame_ReplaysCompletedMutation() {
+    @DisplayName("완료된 init retry는 provider와 새 session 생성 없이 기존 결과를 반환한다")
+    void initGame_ReplaysCompletedMutation() {
         given(mutationRequestService.begin(anyString(), eq(GameMutationRequestService.INIT), anyString(), any(), any(), anyString()))
                 .willReturn(new GameMutationRequestService.BeginResult(100L, true, 42L, 1, "기존 오프닝"));
-        given(gamePersistenceService.loadTurnForReplay(OWNER_KEY, 42L, 1))
-                .willReturn(new GamePersistenceService.ReplayedTurn(
-                        42L, 1, "기존 오프닝", "기존 스토리",
-                        choiceCodec.serialize(List.of(new GameChoice(1, "간다"))), null
+        given(gamePersistenceService.loadCommittedTurn(OWNER_KEY, 42L, 1))
+                .willReturn(new GamePersistenceService.CommittedTurn(
+                        "기존 스토리",
+                        choiceCodec.serialize(List.of(new GameChoice(3, "계속한다"))),
+                        "/api/game/image-assets/replayed"
                 ));
 
-        GameResponse response = gameService.initializeGame(
-                OWNER_KEY,
-                new GameInitRequest("세계관", "캐릭터")
-        );
+        GameResponse response = gameService.initGame(OWNER_KEY, new GameInitRequest("세계관", "캐릭터"));
 
+        assertThat(response.sessionId()).isEqualTo(42L);
         assertThat(response.turnNumber()).isEqualTo(1);
         assertThat(response.title()).isEqualTo("기존 오프닝");
         verify(narrativeGenerator, never()).createOpening(anyString(), anyString());
@@ -162,21 +169,47 @@ class GameServiceTest {
     }
 
     @Test
-    @DisplayName("잘못된 choice는 provider를 호출하지 않는다")
-    void progressGame_RejectsInvalidChoiceBeforeProviderCall() {
-        given(gamePersistenceService.loadLatestTurn(OWNER_KEY, 42L, 1))
-                .willReturn(loadedTurn(choiceCodec.serialize(List.of(new GameChoice(1, "간다")))));
+    @DisplayName("완료된 progress retry는 provider와 state mutation 없이 기존 결과를 반환한다")
+    void progressGame_ReplaysCompletedMutation() {
+        given(mutationRequestService.begin(anyString(), eq(GameMutationRequestService.PROGRESS), anyString(), eq(42L), eq(1), anyString()))
+                .willReturn(new GameMutationRequestService.BeginResult(100L, true, 42L, 2, "기존 장면"));
+        given(gamePersistenceService.loadCommittedTurn(OWNER_KEY, 42L, 2))
+                .willReturn(new GamePersistenceService.CommittedTurn(
+                        "기존 스토리",
+                        choiceCodec.serialize(List.of(new GameChoice(3, "계속한다"))),
+                        "/api/game/image-assets/replayed"
+                ));
 
-        assertThatThrownBy(() -> gameService.progressGame(OWNER_KEY, new GameProgressRequest(42L, 99, 1)))
-                .isInstanceOf(IllegalArgumentException.class);
+        GameResponse response = gameService.progressGame(OWNER_KEY, new GameProgressRequest(42L, 7, 1));
 
+        assertThat(response.turnNumber()).isEqualTo(2);
+        assertThat(response.title()).isEqualTo("기존 장면");
+        assertThat(response.storyText()).isEqualTo("기존 스토리");
         verify(narrativeGenerator, never()).createNextTurn(any());
+        verify(gamePersistenceService, never()).loadLatestTurn(anyString(), any(), anyInt());
+        verify(gamePersistenceService, never()).saveNextTurn(anyString(), any(), any(GameTurnCommit.class), any(), any());
+    }
+
+    @Test
+    @DisplayName("소유권 또는 오래된 턴 거부는 내러티브와 asset 발급 전에 발생한다")
+    void progressGame_RejectsBeforeNarrativeCall() {
+        given(gamePersistenceService.loadLatestTurn(OWNER_KEY, 42L, 1))
+                .willThrow(new TurnConflictException("이미 처리되었거나 오래된 턴 요청입니다."));
+
+        assertThatThrownBy(() -> gameService.progressGame(OWNER_KEY, new GameProgressRequest(42L, 1, 1)))
+                .isInstanceOf(TurnConflictException.class);
+
+        verify(narrativeGenerator, never()).createNextTurn(any(NarrativeContext.class));
+        verify(imageAssetService, never()).issue(any(), any());
+        verify(gamePersistenceService, never()).saveNextTurn(any(), any(), any(GameTurnCommit.class), any(), any());
+        verify(mutationRequestService).markFailed(100L);
     }
 
     private GamePersistenceService.LoadedTurn loadedTurn(String choicesJson) {
-        GameState state = GameState.initial("세계관", "캐릭터", "첫 장면");
         return new GamePersistenceService.LoadedTurn(
-                42L, 1, "첫 장면", choicesJson, "/api/game/image-assets/old-asset", state, 1
+                42L, 1, "좀비 아포칼립스", "김대리", "직전 스토리", choicesJson,
+                "/api/game/image-assets/old-asset",
+                GameState.initial("좀비 아포칼립스", "김대리", "직전 스토리")
         );
     }
 }

--- a/src/test/java/com/uctale/uctale/service/GameServiceTest.java
+++ b/src/test/java/com/uctale/uctale/service/GameServiceTest.java
@@ -202,7 +202,7 @@ class GameServiceTest {
         verify(narrativeGenerator, never()).createNextTurn(any(NarrativeContext.class));
         verify(imageAssetService, never()).issue(any(), any());
         verify(gamePersistenceService, never()).saveNextTurn(any(), any(), any(GameTurnCommit.class), any(), any());
-        verify(mutationRequestService).markFailed(100L);
+        verify(mutationRequestService).markFailed(100L, "lease-owner");
     }
 
     private GamePersistenceService.LoadedTurn loadedTurn(String choicesJson) {

--- a/src/test/java/com/uctale/uctale/service/GameServiceTest.java
+++ b/src/test/java/com/uctale/uctale/service/GameServiceTest.java
@@ -1,26 +1,26 @@
 package com.uctale.uctale.service;
 
-import tools.jackson.databind.ObjectMapper;
-import com.uctale.uctale.application.cost.CostRateLimitPolicy;
-import com.uctale.uctale.application.cost.CostRateLimiter;
-import com.uctale.uctale.application.cost.ProviderCallTelemetry;
-import com.uctale.uctale.application.game.ChoiceCodec;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.uctale.uctale.ai.NarrativeContext;
+import com.uctale.uctale.ai.NarrativeGenerator;
+import com.uctale.uctale.ai.NarrativeTurn;
 import com.uctale.uctale.application.game.GameMutationFingerprint;
 import com.uctale.uctale.application.game.GameMutationRequestService;
 import com.uctale.uctale.application.game.GamePersistenceService;
-import com.uctale.uctale.application.game.GameTurnCommit;
-import com.uctale.uctale.application.game.ImagePromptComposer;
-import com.uctale.uctale.application.game.TurnConflictException;
-import com.uctale.uctale.application.image.ImageAssetService;
-import com.uctale.uctale.application.narrative.NarrativeContext;
-import com.uctale.uctale.application.narrative.NarrativeGenerator;
-import com.uctale.uctale.application.narrative.NarrativeTurn;
-import com.uctale.uctale.domain.GameSession;
-import com.uctale.uctale.domain.game.GameState;
+import com.uctale.uctale.cost.CostOperation;
+import com.uctale.uctale.cost.CostRateLimitPolicy;
+import com.uctale.uctale.cost.CostRateLimiter;
+import com.uctale.uctale.cost.CostRequestContext;
+import com.uctale.uctale.cost.ProviderCallTelemetry;
 import com.uctale.uctale.dto.GameChoice;
 import com.uctale.uctale.dto.GameInitRequest;
 import com.uctale.uctale.dto.GameProgressRequest;
 import com.uctale.uctale.dto.GameResponse;
+import com.uctale.uctale.image.ImageAssetService;
+import com.uctale.uctale.image.ImagePromptComposer;
+import com.uctale.uctale.model.GameState;
+import com.uctale.uctale.model.GameTurnCommit;
+import com.uctale.uctale.util.ChoiceCodec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -70,58 +70,51 @@ class GameServiceTest {
                 mutationRequestService
         );
         lenient().when(mutationRequestService.begin(anyString(), anyString(), anyString(), any(), any(), anyString()))
-                .thenReturn(new GameMutationRequestService.BeginResult(100L, false, null, null, null));
+                .thenReturn(new GameMutationRequestService.BeginResult(100L, false, null, null, null, "lease-owner"));
     }
 
     @Test
-    @DisplayName("게임 초기화는 versioned prompt로 서버 발급 image asset을 저장에 전달한다")
-    void initGame_ReturnsFirstTurn() {
-        GameInitRequest request = new GameInitRequest("좀비 아포칼립스", "김대리");
+    @DisplayName("init은 persistence 전에 narrative와 choice를 확정한다")
+    void initializeGame_PreparesNarrativeBeforePersistence() {
         NarrativeTurn opening = new NarrativeTurn(
-                "첫날 밤", "오프닝 스토리",
-                List.of(new NarrativeTurn.Choice(1, "도망간다")),
-                new NarrativeTurn.VisualAssets("dark street", List.of("zombie"), List.of())
+                "오프닝", "스토리",
+                List.of(new NarrativeTurn.Choice(1, "간다")),
+                new NarrativeTurn.VisualAssets("", List.of(), List.of())
         );
-        GameSession session = new GameSession(OWNER_KEY, request.worldSetting(), request.characterSetting());
-        ReflectionTestUtils.setField(session, "id", 42L);
-        ImageAssetService.AssetReference asset = new ImageAssetService.AssetReference(
-                "asset-id", "/api/game/image-assets/asset-id", "prompt", "16:9",
-                "flux", 1024, 576, 123, true, "uctale-charcoal-v2"
+        given(narrativeGenerator.createOpening("세계관", "캐릭터")).willReturn(opening);
+        given(gamePersistenceService.saveOpening(any(), any(), any(), any(), any(), any(), any(), any()))
+                .willAnswer(invocation -> {
+                    var session = new com.uctale.uctale.domain.GameSession(OWNER_KEY, "세계관", "캐릭터");
+                    ReflectionTestUtils.setField(session, "id", 42L);
+                    return session;
+                });
+
+        GameResponse response = gameService.initializeGame(
+                OWNER_KEY,
+                new GameInitRequest("세계관", "캐릭터")
         );
-
-        given(narrativeGenerator.createOpening("좀비 아포칼립스", "김대리")).willReturn(opening);
-        given(imageAssetService.issue(any(String.class), eq("16:9"))).willReturn(asset);
-        given(gamePersistenceService.saveOpening(
-                eq(OWNER_KEY), any(), any(), any(), any(), eq(asset), eq(100L), eq("첫날 밤")
-        )).willReturn(session);
-
-        GameResponse response = gameService.initGame(OWNER_KEY, request);
 
         assertThat(response.sessionId()).isEqualTo(42L);
         assertThat(response.turnNumber()).isEqualTo(1);
-        assertThat(response.mainImageUrl()).isEqualTo("/api/game/image-assets/asset-id");
-        ArgumentCaptor<String> promptCaptor = ArgumentCaptor.forClass(String.class);
-        verify(imageAssetService).issue(promptCaptor.capture(), eq("16:9"));
-        assertThat(promptCaptor.getValue())
-                .startsWith("style[uctale-charcoal-v2]")
-                .contains("subjects: zombie", "setting: dark street", "final style lock:");
+        verify(narrativeGenerator).createOpening("세계관", "캐릭터");
     }
 
     @Test
-    @DisplayName("완료된 init retry는 provider와 새 session 생성 없이 기존 결과를 반환한다")
-    void initGame_ReplaysCompletedMutation() {
+    @DisplayName("init replay는 provider와 persistence를 다시 호출하지 않는다")
+    void initializeGame_ReplaysCompletedMutation() {
         given(mutationRequestService.begin(anyString(), eq(GameMutationRequestService.INIT), anyString(), any(), any(), anyString()))
                 .willReturn(new GameMutationRequestService.BeginResult(100L, true, 42L, 1, "기존 오프닝"));
-        given(gamePersistenceService.loadCommittedTurn(OWNER_KEY, 42L, 1))
-                .willReturn(new GamePersistenceService.CommittedTurn(
-                        "기존 스토리",
-                        choiceCodec.serialize(List.of(new GameChoice(3, "계속한다"))),
-                        "/api/game/image-assets/replayed"
+        given(gamePersistenceService.loadTurnForReplay(OWNER_KEY, 42L, 1))
+                .willReturn(new GamePersistenceService.ReplayedTurn(
+                        42L, 1, "기존 오프닝", "기존 스토리",
+                        choiceCodec.serialize(List.of(new GameChoice(1, "간다"))), null
                 ));
 
-        GameResponse response = gameService.initGame(OWNER_KEY, new GameInitRequest("세계관", "캐릭터"));
+        GameResponse response = gameService.initializeGame(
+                OWNER_KEY,
+                new GameInitRequest("세계관", "캐릭터")
+        );
 
-        assertThat(response.sessionId()).isEqualTo(42L);
         assertThat(response.turnNumber()).isEqualTo(1);
         assertThat(response.title()).isEqualTo("기존 오프닝");
         verify(narrativeGenerator, never()).createOpening(anyString(), anyString());
@@ -141,8 +134,9 @@ class GameServiceTest {
 
         given(gamePersistenceService.loadLatestTurn(OWNER_KEY, 42L, 1)).willReturn(loadedTurn);
         given(narrativeGenerator.createNextTurn(any(NarrativeContext.class))).willReturn(nextTurn);
-        given(gamePersistenceService.saveNextTurn(eq(OWNER_KEY), eq(42L), any(GameTurnCommit.class), eq(100L), eq("다음 장면")))
-                .willReturn(2);
+        given(gamePersistenceService.saveNextTurn(
+                eq(OWNER_KEY), eq(42L), any(GameTurnCommit.class), eq(100L), eq("다음 장면"), eq("lease-owner")
+        )).willReturn(2);
 
         GameResponse response = gameService.progressGame(OWNER_KEY, new GameProgressRequest(42L, 7, 1));
 
@@ -154,7 +148,9 @@ class GameServiceTest {
         assertThat(contextCaptor.getValue().playerAction()).isEqualTo("문을 잠근다");
 
         ArgumentCaptor<GameTurnCommit> commitCaptor = ArgumentCaptor.forClass(GameTurnCommit.class);
-        verify(gamePersistenceService).saveNextTurn(eq(OWNER_KEY), eq(42L), commitCaptor.capture(), eq(100L), eq("다음 장면"));
+        verify(gamePersistenceService).saveNextTurn(
+                eq(OWNER_KEY), eq(42L), commitCaptor.capture(), eq(100L), eq("다음 장면"), eq("lease-owner")
+        );
         GameTurnCommit commit = commitCaptor.getValue();
         assertThat(commit.inputChoiceId()).isEqualTo(7);
         assertThat(commit.inputChoiceText()).isEqualTo("문을 잠근다");
@@ -166,47 +162,21 @@ class GameServiceTest {
     }
 
     @Test
-    @DisplayName("완료된 progress retry는 provider와 state mutation 없이 기존 결과를 반환한다")
-    void progressGame_ReplaysCompletedMutation() {
-        given(mutationRequestService.begin(anyString(), eq(GameMutationRequestService.PROGRESS), anyString(), eq(42L), eq(1), anyString()))
-                .willReturn(new GameMutationRequestService.BeginResult(100L, true, 42L, 2, "기존 장면"));
-        given(gamePersistenceService.loadCommittedTurn(OWNER_KEY, 42L, 2))
-                .willReturn(new GamePersistenceService.CommittedTurn(
-                        "기존 스토리",
-                        choiceCodec.serialize(List.of(new GameChoice(3, "계속한다"))),
-                        "/api/game/image-assets/replayed"
-                ));
-
-        GameResponse response = gameService.progressGame(OWNER_KEY, new GameProgressRequest(42L, 7, 1));
-
-        assertThat(response.turnNumber()).isEqualTo(2);
-        assertThat(response.title()).isEqualTo("기존 장면");
-        assertThat(response.storyText()).isEqualTo("기존 스토리");
-        verify(narrativeGenerator, never()).createNextTurn(any());
-        verify(gamePersistenceService, never()).loadLatestTurn(anyString(), any(), anyInt());
-        verify(gamePersistenceService, never()).saveNextTurn(anyString(), any(), any(GameTurnCommit.class), any(), any());
-    }
-
-    @Test
-    @DisplayName("소유권 또는 오래된 턴 거부는 내러티브와 asset 발급 전에 발생한다")
-    void progressGame_RejectsBeforeNarrativeCall() {
+    @DisplayName("잘못된 choice는 provider를 호출하지 않는다")
+    void progressGame_RejectsInvalidChoiceBeforeProviderCall() {
         given(gamePersistenceService.loadLatestTurn(OWNER_KEY, 42L, 1))
-                .willThrow(new TurnConflictException("이미 처리되었거나 오래된 턴 요청입니다."));
+                .willReturn(loadedTurn(choiceCodec.serialize(List.of(new GameChoice(1, "간다")))));
 
-        assertThatThrownBy(() -> gameService.progressGame(OWNER_KEY, new GameProgressRequest(42L, 1, 1)))
-                .isInstanceOf(TurnConflictException.class);
+        assertThatThrownBy(() -> gameService.progressGame(OWNER_KEY, new GameProgressRequest(42L, 99, 1)))
+                .isInstanceOf(IllegalArgumentException.class);
 
-        verify(narrativeGenerator, never()).createNextTurn(any(NarrativeContext.class));
-        verify(imageAssetService, never()).issue(any(), any());
-        verify(gamePersistenceService, never()).saveNextTurn(any(), any(), any(GameTurnCommit.class), any(), any());
-        verify(mutationRequestService).markFailed(100L);
+        verify(narrativeGenerator, never()).createNextTurn(any());
     }
 
     private GamePersistenceService.LoadedTurn loadedTurn(String choicesJson) {
+        GameState state = GameState.initial("세계관", "캐릭터", "첫 장면");
         return new GamePersistenceService.LoadedTurn(
-                42L, 1, "좀비 아포칼립스", "김대리", "직전 스토리", choicesJson,
-                "/api/game/image-assets/old-asset",
-                GameState.initial("좀비 아포칼립스", "김대리", "직전 스토리")
+                42L, 1, "첫 장면", choicesJson, "/api/game/image-assets/old-asset", state, 1
         );
     }
 }


### PR DESCRIPTION
## Summary

- `game_turn_reservation` lease를 도입해 같은 session/expectedTurn의 Narrative provider 동시 진입을 차단합니다.
- 동일 Idempotency-Key가 이미 처리 중이면 `409 MUTATION_IN_PROGRESS`와 `Retry-After`를 반환합니다.
- provider 호출은 DB transaction 밖에서 수행하고, commit 시 reservation owner와 canonical turn/version을 다시 검증합니다.
- lease 만료 후 takeover를 허용하되 turn당 최대 3회로 provider 재시도를 제한합니다.
- crash window의 외부 provider 재호출 가능성과 canonical commit 보장 범위를 문서화했습니다.

## Critical review applied

- mutation request 이력과 active lease의 수명주기가 다르므로 한 테이블에 억지로 합치지 않고 별도 reservation 테이블로 분리했습니다.
- 단순 application lock 대신 PostgreSQL `(session_id, expected_turn)` primary key와 conditional upsert를 사용해 다중 인스턴스에서도 단일 active reservation 의미론을 유지합니다.
- stale provider 응답이 lease takeover 이후 commit되는 것을 막기 위해 매 시도마다 새로운 `lease_owner`를 발급하고 commit transaction에서 재검증합니다.
- strict provider exactly-once는 보장하지 않는다는 점을 숨기지 않고 bounded at-least-once로 명시했습니다.

## Tests

- [x] 동일 idempotency 요청의 PROCESSING 정책 단위 테스트
- [x] PostgreSQL에서 동일 session/turn active lease 단일성 검증
- [x] lease 만료 후 takeover 및 attempt_count 증가 검증
- [x] GitHub Actions CI 확인

Closes #30