### PR TITLE
test(persistence): M2 턴 무결성 PostgreSQL 회귀 matrix 완성

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, test/32-m2-postgres-regression-matrix]
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, test/32-m2-postgres-regression-matrix]
   pull_request:
     branches: [main]
 

--- a/docs/testing/postgresql-integration-tests.md
+++ b/docs/testing/postgresql-integration-tests.md
@@ -28,7 +28,7 @@ GitHub Actions도 같은 `./gradlew postgresIntegrationTest` 명령을 사용합
 
 - 로컬과 CI가 동일한 Java test code와 동일한 database image를 사용합니다.
 - 포트, username, password를 CI workflow와 로컬 설정에 중복 정의하지 않습니다.
-- 후속 #28~#31 persistence tests가 공통 support class만 상속해 같은 환경을 재사용할 수 있습니다.
+- 후속 persistence tests가 공통 support class만 상속해 같은 환경을 재사용할 수 있습니다.
 - 테스트가 production Neon DB에 연결될 가능성을 구조적으로 줄입니다.
 
 Testcontainers version은 BOM `2.0.5`, PostgreSQL image는 `postgres:17.6-alpine`으로 고정합니다. 버전 변경은 일반 dependency/image update처럼 PR에서 검증한 뒤 반영합니다.
@@ -43,24 +43,52 @@ JUnit tag `postgres`를 경계로 사용합니다.
 
 현재 baseline은 다음 production 의미론을 검증합니다.
 
-- 빈 PostgreSQL에서 Flyway V1~V5 migration chain 적용
+- 빈 PostgreSQL에서 Flyway V1~V8 production migration chain 순차 적용
 - Hibernate `ddl-auto=validate`가 migration 결과와 현재 entity mapping을 검증
 - `uk_game_log_session_turn` unique constraint
 - `GameSession`의 `@Version` optimistic locking
+- owner 범위 `Idempotency-Key` unique constraint와 fingerprint conflict
+- `(session_id, expected_turn)` turn reservation unique/lease takeover 의미론
+- versioned `GameState` snapshot의 legacy 호환 및 latest schema round-trip
 
-## 후속 이슈 규칙
+## M2 regression matrix
 
-#28~#31에서 PostgreSQL에 의존하는 constraint, migration, locking 또는 recovery 동작을 추가할 경우 새 harness를 만들지 말고 기존 `PostgresIntegrationTestSupport`를 재사용합니다.
+#32의 종료 게이트는 기존 개별 persistence 테스트를 제거하지 않고, cross-feature 경계를 `PostgresM2TurnIntegrityMatrixTest`와 legacy migration fixture로 추가 고정합니다.
 
-#32에서는 이 기반 위에서 M2의 cross-feature concurrency/migration/recovery regression matrix를 완성합니다.
+| 계약 | PostgreSQL 검증 |
+| --- | --- |
+| `/init` completed retry | 동일 key 재시도는 저장된 session/turn을 재사용하고 provider 및 새 session 생성을 반복하지 않음 |
+| `/progress` completed retry | 동일 key 재시도는 저장 결과를 재사용하고 canonical GameLog/snapshot을 다시 쓰지 않음 |
+| 동일 key + 다른 payload | fingerprint mismatch를 provider 진입 전에 conflict로 거부 |
+| 같은 session/turn 최초 동시 요청 | active reservation은 하나만 유지되고 유효 lease 동안 provider 진입도 하나로 제한 |
+| crash + lease expiry | deterministic clock으로 takeover를 재현하고 stale reservation owner의 commit을 차단 |
+| canonical commit | `GameSession.currentTurn`, latest `GameLog.stateVersion`, snapshot turn, mutation request result turn이 같은 값으로 수렴 |
+| legacy production 형태 | V5 fixture를 V8까지 migration한 뒤 ledger 데이터와 frozen v0 snapshot이 복구 가능함을 검증 |
+
+동시성 케이스는 짧은 wall-clock timeout이나 `Thread.sleep`에 의존하지 않습니다. 시작 barrier와 deterministic clock을 사용하고, fake provider 호출 횟수를 직접 세어 race 조건을 관찰합니다. 같은 session/turn 최초 요청 케이스는 반복 실행해 scheduling 순서가 바뀌어도 계약이 유지되는지 검증합니다.
+
+## provider exactly-once 경계
+
+turn reservation은 **유효한 lease 동안** 중복 provider 호출을 억제하고 canonical DB commit을 하나로 제한합니다. 하지만 provider 호출 성공 직후 프로세스가 죽고 lease가 만료되면 takeover 요청이 provider를 다시 호출할 수 있습니다.
+
+따라서 M2가 보장하는 것은 다음과 같습니다.
+
+- active lease 동안 duplicate provider suppression
+- stale reservation owner의 canonical commit 차단
+- canonical `GameSession` / `GameLog` / snapshot / completed request 결과는 단일 commit으로 수렴
+
+반대로 외부 provider에 대한 strict exactly-once 호출은 보장하지 않습니다. crash/takeover 테스트는 이 한계를 숨기지 않고 provider 호출이 두 번 발생할 수 있음을 명시적으로 assert합니다.
 
 ## 실패 진단
 
 CI의 `Run PostgreSQL integration tests` step은 일반 backend test와 분리되어 있습니다. 따라서 실패 시 먼저 다음을 구분합니다.
 
 1. container startup / Docker 문제
-2. Flyway migration 실패
+2. Flyway migration 및 실패 version/schema
 3. Hibernate schema validation 실패
-4. PostgreSQL constraint / optimistic locking assertion 실패
+4. PostgreSQL unique / optimistic locking assertion 실패
+5. idempotency request key/fingerprint 단계 실패
+6. reservation session/turn/attempt 단계 실패
+7. canonical `currentTurn` / ledger stateVersion / snapshot / request resultTurn 불일치
 
-Testcontainers와 Spring Boot가 container 및 datasource 초기화 로그를 남기며, 테스트 이름은 실패한 contract를 직접 나타내도록 유지합니다. DB password는 ephemeral fixture 값이며 production credential이나 application secret을 사용하지 않습니다.
+M2 matrix assertion은 가능한 경우 `phase`, `request`, `session`, `turn` 또는 migration `schema` 문맥을 함께 출력합니다. Testcontainers와 Spring Boot가 container 및 datasource 초기화 로그를 남기며, DB password는 ephemeral fixture 값이고 production credential이나 application secret을 사용하지 않습니다.

--- a/src/test/java/com/uctale/uctale/persistence/PostgresGameLogMigrationTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/PostgresGameLogMigrationTest.java
@@ -1,11 +1,17 @@
 package com.uctale.uctale.persistence;
 
+import com.uctale.uctale.application.game.GameStateCodec;
+import com.uctale.uctale.application.game.GameStateUpgrader;
+import com.uctale.uctale.domain.game.GameState;
 import com.uctale.uctale.support.PostgresIntegrationTestSupport;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.MigrationVersion;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+import tools.jackson.databind.ObjectMapper;
 
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
@@ -15,22 +21,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class PostgresGameLogMigrationTest extends PostgresIntegrationTestSupport {
 
+    private static final String LEGACY_SNAPSHOT_FIXTURE = "fixtures/game-state/snapshot-v0-production.json";
+
     @Test
     @DisplayName("V5 legacy GameLog 선택 텍스트를 다음 committed turn 자기 행으로 이관한다")
     void v6_MigratesLegacyUserChoiceIntoCommittedTurnRow() throws Exception {
         String schema = "game_log_v6_legacy";
-        Flyway legacyFlyway = Flyway.configure()
-                .dataSource(POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword())
-                .schemas(schema)
-                .defaultSchema(schema)
-                .target(MigrationVersion.fromVersion("5"))
-                .load();
+        Flyway legacyFlyway = flywayAt(schema, "5");
         legacyFlyway.migrate();
 
-        try (Connection connection = DriverManager.getConnection(
-                POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
-             Statement statement = connection.createStatement()) {
-            statement.execute("set search_path to " + schema);
+        try (Connection connection = connection(schema); Statement statement = connection.createStatement()) {
             statement.executeUpdate("""
                     insert into game_session (
                         owner_key, world_setting, character_setting, is_game_over, current_turn, version
@@ -54,18 +54,9 @@ class PostgresGameLogMigrationTest extends PostgresIntegrationTestSupport {
                     """);
         }
 
-        Flyway latestFlyway = Flyway.configure()
-                .dataSource(POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword())
-                .schemas(schema)
-                .defaultSchema(schema)
-                .load();
-        latestFlyway.migrate();
+        latestFlyway(schema).migrate();
 
-        try (Connection connection = DriverManager.getConnection(
-                POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
-             Statement statement = connection.createStatement()) {
-            statement.execute("set search_path to " + schema);
-
+        try (Connection connection = connection(schema); Statement statement = connection.createStatement()) {
             try (ResultSet opening = statement.executeQuery("""
                     select input_choice_id, input_choice_text, previous_state_version, state_version
                     from game_log where turn_number = 1
@@ -94,6 +85,120 @@ class PostgresGameLogMigrationTest extends PostgresIntegrationTestSupport {
                 assertThat(legacyColumn.next()).isTrue();
                 assertThat(legacyColumn.getString("user_choice")).isEqualTo("문을 연다");
             }
+        }
+    }
+
+    @Test
+    @DisplayName("V5 production 형태 fixture는 V8까지 migration 후 ledger와 legacy snapshot을 데이터 손실 없이 복구한다")
+    void legacyV5Fixture_MigratesThroughLatestAndRemainsRecoverable() throws Exception {
+        String schema = "m2_legacy_v5_to_latest";
+        flywayAt(schema, "5").migrate();
+        String legacySnapshot = legacySnapshotJson();
+
+        try (Connection connection = connection(schema); Statement statement = connection.createStatement()) {
+            statement.executeUpdate("""
+                    insert into game_session (
+                        owner_key, world_setting, character_setting, is_game_over, current_turn, version
+                    ) values (
+                        'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', '세계관', '캐릭터', false, 1, 0
+                    )
+                    """);
+            statement.executeUpdate("""
+                    insert into game_log (
+                        session_id, turn_number, story_text, choices_json, user_choice
+                    ) values (
+                        1, 1, '첫 이야기', '[{"id":7,"text":"문을 연다"}]', null
+                    )
+                    """);
+            try (var prepared = connection.prepareStatement(
+                    "insert into game_state_snapshot (session_id, state_json) values (1, ?)"
+            )) {
+                prepared.setString(1, legacySnapshot);
+                prepared.executeUpdate();
+            }
+        }
+
+        Flyway latest = latestFlyway(schema);
+        latest.migrate();
+
+        assertThat(latest.info().pending()).as("schema=%s pending migrations", schema).isEmpty();
+        assertThat(latest.info().applied())
+                .as("schema=%s applied migration chain", schema)
+                .extracting(info -> info.getVersion().getVersion())
+                .contains("1", "2", "3", "4", "5", "6", "7", "8");
+
+        try (Connection connection = connection(schema); Statement statement = connection.createStatement()) {
+            try (ResultSet ledger = statement.executeQuery("""
+                    select story_text, previous_state_version, state_version
+                    from game_log where session_id = 1 and turn_number = 1
+                    """)) {
+                assertThat(ledger.next()).as("schema=%s session=1 turn=1 ledger row", schema).isTrue();
+                assertThat(ledger.getString("story_text")).isEqualTo("첫 이야기");
+                assertThat(ledger.getInt("previous_state_version")).isZero();
+                assertThat(ledger.getInt("state_version")).isEqualTo(1);
+            }
+
+            String storedSnapshot;
+            try (ResultSet snapshot = statement.executeQuery(
+                    "select state_json from game_state_snapshot where session_id = 1"
+            )) {
+                assertThat(snapshot.next()).as("schema=%s session=1 legacy snapshot", schema).isTrue();
+                storedSnapshot = snapshot.getString(1);
+            }
+            assertThat(storedSnapshot).isEqualTo(legacySnapshot);
+
+            GameState recovered = new GameStateCodec(new ObjectMapper(), new GameStateUpgrader())
+                    .deserialize(storedSnapshot);
+            assertThat(recovered.turnNumber()).as("schema=%s recovered snapshot turn", schema).isEqualTo(1);
+            assertThat(recovered.worldState().premise()).isEqualTo("세계관");
+            assertThat(recovered.playerCharacter().description()).isEqualTo("캐릭터");
+
+            assertThat(tableExists(statement, "game_mutation_request"))
+                    .as("schema=%s V7 table", schema).isTrue();
+            assertThat(tableExists(statement, "game_turn_reservation"))
+                    .as("schema=%s V8 table", schema).isTrue();
+        }
+    }
+
+    private Flyway flywayAt(String schema, String version) {
+        return Flyway.configure()
+                .dataSource(POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword())
+                .schemas(schema)
+                .defaultSchema(schema)
+                .target(MigrationVersion.fromVersion(version))
+                .load();
+    }
+
+    private Flyway latestFlyway(String schema) {
+        return Flyway.configure()
+                .dataSource(POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword())
+                .schemas(schema)
+                .defaultSchema(schema)
+                .load();
+    }
+
+    private Connection connection(String schema) throws Exception {
+        Connection connection = DriverManager.getConnection(
+                POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword()
+        );
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("set search_path to " + schema);
+        }
+        return connection;
+    }
+
+    private boolean tableExists(Statement statement, String tableName) throws Exception {
+        try (ResultSet result = statement.executeQuery(
+                "select to_regclass('" + tableName + "') is not null"
+        )) {
+            return result.next() && result.getBoolean(1);
+        }
+    }
+
+    private String legacySnapshotJson() throws Exception {
+        ClassPathResource resource = new ClassPathResource(LEGACY_SNAPSHOT_FIXTURE);
+        try (var inputStream = resource.getInputStream()) {
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
         }
     }
 }

--- a/src/test/java/com/uctale/uctale/persistence/PostgresGameLogMigrationTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/PostgresGameLogMigrationTest.java
@@ -124,6 +124,7 @@ class PostgresGameLogMigrationTest extends PostgresIntegrationTestSupport {
         assertThat(latest.info().pending()).as("schema=%s pending migrations", schema).isEmpty();
         assertThat(latest.info().applied())
                 .as("schema=%s applied migration chain", schema)
+                .filteredOn(info -> info.getVersion() != null)
                 .extracting(info -> info.getVersion().getVersion())
                 .contains("1", "2", "3", "4", "5", "6", "7", "8");
 

--- a/src/test/java/com/uctale/uctale/persistence/PostgresM2TurnIntegrityMatrixTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/PostgresM2TurnIntegrityMatrixTest.java
@@ -1,0 +1,330 @@
+package com.uctale.uctale.persistence;
+
+import com.uctale.uctale.application.game.GameMutationRequestService;
+import com.uctale.uctale.application.game.GamePersistenceService;
+import com.uctale.uctale.application.game.GameTurnCommit;
+import com.uctale.uctale.application.game.IdempotencyConflictException;
+import com.uctale.uctale.application.game.MutationInProgressException;
+import com.uctale.uctale.application.game.TurnConflictException;
+import com.uctale.uctale.domain.GameSession;
+import com.uctale.uctale.domain.game.GameState;
+import com.uctale.uctale.repository.GameMutationRequestRepository;
+import com.uctale.uctale.support.PostgresIntegrationTestSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
+
+    private static final String OWNER_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    private static final String OPENING_CHOICES = "[{\"id\":1,\"text\":\"문을 연다\"}]";
+    private static final String NEXT_CHOICES = "[{\"id\":2,\"text\":\"계속 간다\"}]";
+    private static final int LEASE_SECONDS = 30;
+
+    @Autowired private GamePersistenceService persistenceService;
+    @Autowired private GameMutationRequestRepository mutationRequestRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
+    @Autowired private PlatformTransactionManager transactionManager;
+
+    private MutableClock clock;
+    private GameMutationRequestService mutationService;
+    private TransactionTemplate transactionTemplate;
+    private FakeNarrativeProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute("""
+                truncate table game_turn_reservation, game_mutation_request, image_asset,
+                    game_state_snapshot, game_log, game_session restart identity
+                """);
+        clock = new MutableClock(Instant.parse("2026-08-31T04:00:00Z"));
+        mutationService = new GameMutationRequestService(
+                mutationRequestRepository, jdbcTemplate, clock, LEASE_SECONDS
+        );
+        transactionTemplate = new TransactionTemplate(transactionManager);
+        provider = new FakeNarrativeProvider();
+    }
+
+    @Test
+    @DisplayName("완료 retry는 provider와 canonical state를 재실행하지 않고 저장 결과를 재사용한다")
+    void completedRetry_ReusesCanonicalResultExactlyOnce() {
+        GameSession session = createOpening();
+        String key = "matrix-retry-key-001";
+        String fingerprint = "a".repeat(64);
+
+        BeginAttempt first = beginAttempt(session.getId(), key, fingerprint);
+        assertThat(first.error()).as(context("begin", key, session.getId(), 1)).isNull();
+
+        String story = provider.nextStory();
+        commitTurn(session.getId(), first.result(), story);
+
+        BeginAttempt retry = beginAttempt(session.getId(), key, fingerprint);
+        assertThat(retry.error()).as(context("retry", key, session.getId(), 1)).isNull();
+        assertThat(retry.result().replay()).isTrue();
+        assertThat(retry.result().resultSessionId()).isEqualTo(session.getId());
+        assertThat(retry.result().resultTurn()).isEqualTo(2);
+
+        BeginAttempt conflictingPayload = beginAttempt(session.getId(), key, "b".repeat(64));
+        assertThat(conflictingPayload.error())
+                .as(context("fingerprint-conflict", key, session.getId(), 1))
+                .isInstanceOf(IdempotencyConflictException.class);
+
+        assertThat(provider.calls()).as("provider calls for completed retry").isEqualTo(1);
+        assertCanonicalTurn(session.getId(), key, 2, 2);
+    }
+
+    @Test
+    @DisplayName("같은 session/turn 최초 동시 요청은 active reservation과 provider 진입을 하나로 제한한다")
+    void concurrentFirstRequests_AllowSingleActiveProviderExecution() throws Exception {
+        GameSession session = createOpening();
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+
+        try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
+            Future<ProviderAttempt> first = executor.submit(concurrentAttempt(
+                    ready, start, session.getId(), "matrix-concurrent-key-a", "c".repeat(64)
+            ));
+            Future<ProviderAttempt> second = executor.submit(concurrentAttempt(
+                    ready, start, session.getId(), "matrix-concurrent-key-b", "c".repeat(64)
+            ));
+
+            ready.await();
+            start.countDown();
+
+            List<ProviderAttempt> attempts = List.of(first.get(), second.get());
+            List<ProviderAttempt> winners = attempts.stream().filter(ProviderAttempt::providerCalled).toList();
+            List<ProviderAttempt> rejected = attempts.stream().filter(attempt -> !attempt.providerCalled()).toList();
+
+            assertThat(winners).as("provider winner session=%d turn=1", session.getId()).hasSize(1);
+            assertThat(rejected).as("reservation loser session=%d turn=1", session.getId()).hasSize(1);
+            assertThat(rejected.getFirst().begin().error()).isInstanceOf(MutationInProgressException.class);
+            assertThat(provider.calls()).as("provider calls while lease is active").isEqualTo(1);
+            assertThat(reservationCount(session.getId(), 1)).as("active reservation rows").isEqualTo(1);
+
+            ProviderAttempt winner = winners.getFirst();
+            commitTurn(session.getId(), winner.begin().result(), winner.story());
+
+            assertCanonicalTurn(session.getId(), winner.key(), 2, 2);
+            assertThat(reservationCount(session.getId(), 1)).isZero();
+        }
+    }
+
+    @Test
+    @DisplayName("crash 후 lease takeover는 provider 재호출을 허용하지만 stale owner의 canonical commit은 차단한다")
+    void expiredLeaseTakeover_AllowsProviderRetryButSingleCanonicalCommit() {
+        GameSession session = createOpening();
+
+        BeginAttempt crashed = beginAttempt(session.getId(), "matrix-crash-key-a", "d".repeat(64));
+        assertThat(crashed.error()).as(context("crashed-begin", "matrix-crash-key-a", session.getId(), 1)).isNull();
+        String staleStory = provider.nextStory();
+
+        clock.advance(Duration.ofSeconds(LEASE_SECONDS + 1));
+
+        BeginAttempt takeover = beginAttempt(session.getId(), "matrix-crash-key-b", "d".repeat(64));
+        assertThat(takeover.error()).as(context("takeover-begin", "matrix-crash-key-b", session.getId(), 1)).isNull();
+        String canonicalStory = provider.nextStory();
+
+        assertThat(provider.calls())
+                .as("external provider strict exactly-once is intentionally not guaranteed after lease expiry")
+                .isEqualTo(2);
+        assertThat(jdbcTemplate.queryForObject(
+                "select attempt_count from game_turn_reservation where session_id = ? and expected_turn = ?",
+                Integer.class, session.getId(), 1
+        )).as("reservation attempt_count session=%d turn=1", session.getId()).isEqualTo(2);
+
+        assertThatThrownBy(() -> commitTurn(session.getId(), crashed.result(), staleStory))
+                .as(context("stale-owner-commit", "matrix-crash-key-a", session.getId(), 1))
+                .isInstanceOf(TurnConflictException.class)
+                .hasMessageContaining("reservation");
+
+        commitTurn(session.getId(), takeover.result(), canonicalStory);
+
+        assertCanonicalTurn(session.getId(), "matrix-crash-key-b", 2, 2);
+        assertThat(provider.calls()).isEqualTo(2);
+        assertThat(reservationCount(session.getId(), 1)).isZero();
+    }
+
+    private Callable<ProviderAttempt> concurrentAttempt(
+            CountDownLatch ready,
+            CountDownLatch start,
+            Long sessionId,
+            String key,
+            String fingerprint
+    ) {
+        return () -> {
+            ready.countDown();
+            start.await();
+            BeginAttempt begin = beginAttempt(sessionId, key, fingerprint);
+            if (begin.error() != null) {
+                return new ProviderAttempt(key, begin, null, false);
+            }
+            return new ProviderAttempt(key, begin, provider.nextStory(), true);
+        };
+    }
+
+    private BeginAttempt beginAttempt(Long sessionId, String key, String fingerprint) {
+        return transactionTemplate.execute(status -> {
+            try {
+                return BeginAttempt.success(mutationService.begin(
+                        OWNER_KEY,
+                        GameMutationRequestService.PROGRESS,
+                        key,
+                        sessionId,
+                        1,
+                        fingerprint
+                ));
+            } catch (RuntimeException exception) {
+                return BeginAttempt.failure(exception);
+            }
+        });
+    }
+
+    private GameSession createOpening() {
+        return persistenceService.saveOpening(
+                OWNER_KEY,
+                "matrix-world",
+                "matrix-character",
+                "opening-story",
+                OPENING_CHOICES,
+                null
+        );
+    }
+
+    private void commitTurn(Long sessionId, GameMutationRequestService.BeginResult mutation, String story) {
+        GamePersistenceService.LoadedTurn loaded = persistenceService.loadLatestTurn(OWNER_KEY, sessionId, 1);
+        GameState nextState = loaded.gameState().advance("문을 연다", story);
+        GameTurnCommit commit = new GameTurnCommit(
+                1,
+                1,
+                "문을 연다",
+                loaded.gameState(),
+                nextState,
+                story,
+                NEXT_CHOICES,
+                null
+        );
+        persistenceService.saveNextTurn(
+                OWNER_KEY,
+                sessionId,
+                commit,
+                mutation.requestId(),
+                "matrix-turn-2",
+                mutation.reservationOwner()
+        );
+    }
+
+    private void assertCanonicalTurn(Long sessionId, String completedKey, int expectedTurn, int expectedLogCount) {
+        Integer sessionTurn = jdbcTemplate.queryForObject(
+                "select current_turn from game_session where id = ?", Integer.class, sessionId
+        );
+        Integer logCount = jdbcTemplate.queryForObject(
+                "select count(*) from game_log where session_id = ?", Integer.class, sessionId
+        );
+        Integer latestStateVersion = jdbcTemplate.queryForObject(
+                "select max(state_version) from game_log where session_id = ?", Integer.class, sessionId
+        );
+        String requestStatus = jdbcTemplate.queryForObject(
+                "select status from game_mutation_request where owner_key = ? and idempotency_key = ?",
+                String.class, OWNER_KEY, completedKey
+        );
+        Integer requestResultTurn = jdbcTemplate.queryForObject(
+                "select result_turn from game_mutation_request where owner_key = ? and idempotency_key = ?",
+                Integer.class, OWNER_KEY, completedKey
+        );
+
+        assertThat(sessionTurn).as("session=%d current_turn", sessionId).isEqualTo(expectedTurn);
+        assertThat(logCount).as("session=%d committed GameLog rows", sessionId).isEqualTo(expectedLogCount);
+        assertThat(latestStateVersion).as("session=%d latest GameLog state_version", sessionId).isEqualTo(expectedTurn);
+        assertThat(requestStatus).as("request=%s status", completedKey).isEqualTo("COMPLETED");
+        assertThat(requestResultTurn).as("request=%s result_turn", completedKey).isEqualTo(expectedTurn);
+
+        GamePersistenceService.LoadedTurn loaded = persistenceService.loadLatestTurn(OWNER_KEY, sessionId, expectedTurn);
+        assertThat(loaded.gameState().turnNumber()).as("session=%d snapshot/currentTurn", sessionId).isEqualTo(expectedTurn);
+    }
+
+    private int reservationCount(Long sessionId, int expectedTurn) {
+        Integer count = jdbcTemplate.queryForObject(
+                "select count(*) from game_turn_reservation where session_id = ? and expected_turn = ?",
+                Integer.class, sessionId, expectedTurn
+        );
+        return count == null ? 0 : count;
+    }
+
+    private String context(String phase, String key, Long sessionId, int turn) {
+        return "phase=%s request=%s session=%d turn=%d".formatted(phase, key, sessionId, turn);
+    }
+
+    private record BeginAttempt(GameMutationRequestService.BeginResult result, RuntimeException error) {
+        static BeginAttempt success(GameMutationRequestService.BeginResult result) {
+            return new BeginAttempt(result, null);
+        }
+
+        static BeginAttempt failure(RuntimeException error) {
+            return new BeginAttempt(null, error);
+        }
+    }
+
+    private record ProviderAttempt(String key, BeginAttempt begin, String story, boolean providerCalled) {}
+
+    private static final class FakeNarrativeProvider {
+        private final AtomicInteger calls = new AtomicInteger();
+
+        String nextStory() {
+            return "provider-story-" + calls.incrementAndGet();
+        }
+
+        int calls() {
+            return calls.get();
+        }
+    }
+
+    private static final class MutableClock extends Clock {
+        private final AtomicReference<Instant> instant;
+
+        MutableClock(Instant initialInstant) {
+            this.instant = new AtomicReference<>(initialInstant);
+        }
+
+        void advance(Duration duration) {
+            instant.updateAndGet(current -> current.plus(duration));
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return instant.get();
+        }
+    }
+}

--- a/src/test/java/com/uctale/uctale/persistence/PostgresM2TurnIntegrityMatrixTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/PostgresM2TurnIntegrityMatrixTest.java
@@ -1,14 +1,25 @@
 package com.uctale.uctale.persistence;
 
+import com.uctale.uctale.application.cost.CostRateLimiter;
+import com.uctale.uctale.application.cost.CostRequestContext;
+import com.uctale.uctale.application.cost.ProviderCallTelemetry;
+import com.uctale.uctale.application.game.ChoiceCodec;
+import com.uctale.uctale.application.game.GameMutationFingerprint;
 import com.uctale.uctale.application.game.GameMutationRequestService;
 import com.uctale.uctale.application.game.GamePersistenceService;
 import com.uctale.uctale.application.game.GameTurnCommit;
 import com.uctale.uctale.application.game.IdempotencyConflictException;
+import com.uctale.uctale.application.game.ImagePromptComposer;
 import com.uctale.uctale.application.game.MutationInProgressException;
-import com.uctale.uctale.application.game.TurnConflictException;
-import com.uctale.uctale.domain.GameSession;
-import com.uctale.uctale.domain.game.GameState;
+import com.uctale.uctale.application.image.ImageAssetService;
+import com.uctale.uctale.application.narrative.NarrativeContext;
+import com.uctale.uctale.application.narrative.NarrativeGenerator;
+import com.uctale.uctale.application.narrative.NarrativeTurn;
+import com.uctale.uctale.dto.GameInitRequest;
+import com.uctale.uctale.dto.GameProgressRequest;
+import com.uctale.uctale.dto.GameResponse;
 import com.uctale.uctale.repository.GameMutationRequestRepository;
+import com.uctale.uctale.service.GameService;
 import com.uctale.uctale.support.PostgresIntegrationTestSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -36,24 +47,34 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
 
 @SpringBootTest
 class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
 
     private static final String OWNER_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-    private static final String OPENING_CHOICES = "[{\"id\":1,\"text\":\"문을 연다\"}]";
-    private static final String NEXT_CHOICES = "[{\"id\":2,\"text\":\"계속 간다\"}]";
     private static final int LEASE_SECONDS = 30;
 
     @Autowired private GamePersistenceService persistenceService;
     @Autowired private GameMutationRequestRepository mutationRequestRepository;
     @Autowired private JdbcTemplate jdbcTemplate;
     @Autowired private PlatformTransactionManager transactionManager;
+    @Autowired private ImageAssetService imageAssetService;
+    @Autowired private ChoiceCodec choiceCodec;
+    @Autowired private ImagePromptComposer imagePromptComposer;
+    @Autowired private CostRateLimiter costRateLimiter;
+    @Autowired private ProviderCallTelemetry providerCallTelemetry;
+    @Autowired private GameMutationFingerprint mutationFingerprint;
 
     private MutableClock clock;
-    private GameMutationRequestService mutationService;
-    private TransactionTemplate transactionTemplate;
-    private FakeNarrativeProvider provider;
+    private TransactionalMutationService mutationService;
+    private FakeNarrativeGenerator narrativeGenerator;
+    private GameService gameService;
 
     @BeforeEach
     void setUp() {
@@ -62,238 +83,209 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
                     game_state_snapshot, game_log, game_session restart identity
                 """);
         clock = new MutableClock(Instant.parse("2026-08-31T04:00:00Z"));
-        mutationService = new GameMutationRequestService(
-                mutationRequestRepository, jdbcTemplate, clock, LEASE_SECONDS
+        mutationService = new TransactionalMutationService(
+                mutationRequestRepository,
+                jdbcTemplate,
+                clock,
+                LEASE_SECONDS,
+                transactionManager
         );
-        transactionTemplate = new TransactionTemplate(transactionManager);
-        provider = new FakeNarrativeProvider();
+        narrativeGenerator = new FakeNarrativeGenerator();
+        gameService = newGameService(persistenceService);
     }
 
     @Test
-    @DisplayName("완료된 init retry는 provider와 새 session을 만들지 않고 canonical opening을 재사용한다")
+    @DisplayName("완료된 init retry는 실제 provider 경로를 재호출하지 않고 canonical opening을 재사용한다")
     void completedInitRetry_ReusesCanonicalOpeningExactlyOnce() {
         String key = "matrix-init-key-001";
-        String fingerprint = "i".repeat(64);
+        GameInitRequest request = new GameInitRequest("matrix-world", "matrix-character");
 
-        BeginAttempt first = beginInitAttempt(key, fingerprint);
-        assertThat(first.error()).as("phase=init-begin request=%s", key).isNull();
+        GameResponse first = gameService.initGame(initContext(key), request);
+        GameResponse retry = gameService.initGame(initContext(key), request);
 
-        String openingStory = provider.nextStory();
-        GameSession session = persistenceService.saveOpening(
-                OWNER_KEY,
-                "matrix-world",
-                "matrix-character",
-                openingStory,
-                OPENING_CHOICES,
-                null,
-                first.result().requestId(),
-                "matrix-opening"
-        );
-
-        BeginAttempt retry = beginInitAttempt(key, fingerprint);
-        assertThat(retry.error()).as("phase=init-retry request=%s", key).isNull();
-        assertThat(retry.result().replay()).isTrue();
-        assertThat(retry.result().resultSessionId()).isEqualTo(session.getId());
-        assertThat(retry.result().resultTurn()).isEqualTo(1);
-
-        BeginAttempt conflictingPayload = beginInitAttempt(key, "j".repeat(64));
-        assertThat(conflictingPayload.error())
-                .as("phase=init-fingerprint-conflict request=%s", key)
-                .isInstanceOf(IdempotencyConflictException.class);
-
-        assertThat(provider.calls()).as("provider calls for completed init retry").isEqualTo(1);
+        assertThat(retry.sessionId()).isEqualTo(first.sessionId());
+        assertThat(retry.turnNumber()).isEqualTo(1);
+        assertThat(retry.storyText()).isEqualTo(first.storyText());
+        assertThat(narrativeGenerator.openingCalls()).as("NarrativeGenerator opening calls").isEqualTo(1);
         assertThat(jdbcTemplate.queryForObject("select count(*) from game_session", Integer.class))
                 .as("canonical session count after init retry")
                 .isEqualTo(1);
-        assertCanonicalTurn(session.getId(), key, 1, 1);
+
+        assertThatThrownBy(() -> gameService.initGame(
+                initContext(key),
+                new GameInitRequest("different-world", "matrix-character")
+        )).as("phase=init-fingerprint-conflict request=%s", key)
+                .isInstanceOf(IdempotencyConflictException.class);
+        assertThat(narrativeGenerator.openingCalls()).as("provider calls after init fingerprint conflict").isEqualTo(1);
+
+        assertCanonicalTurn(first.sessionId(), key, 1, 1);
     }
 
     @Test
-    @DisplayName("완료된 progress retry는 provider와 canonical state를 재실행하지 않고 저장 결과를 재사용한다")
+    @DisplayName("완료된 progress retry는 실제 provider 경로를 재호출하지 않고 canonical turn을 재사용한다")
     void completedProgressRetry_ReusesCanonicalResultExactlyOnce() {
-        GameSession session = createOpening();
-        String key = "matrix-retry-key-001";
-        String fingerprint = "a".repeat(64);
+        GameResponse opening = createOpening("matrix-opening-progress");
+        String key = "matrix-progress-key-001";
+        GameProgressRequest request = new GameProgressRequest(opening.sessionId(), 1, 1);
 
-        BeginAttempt first = beginProgressAttempt(session.getId(), key, fingerprint);
-        assertThat(first.error()).as(context("begin", key, session.getId(), 1)).isNull();
+        GameResponse first = gameService.progressGame(progressContext(key, opening.sessionId()), request);
+        GameResponse retry = gameService.progressGame(progressContext(key, opening.sessionId()), request);
 
-        String story = provider.nextStory();
-        commitTurn(session.getId(), first.result(), story);
+        assertThat(retry.sessionId()).isEqualTo(first.sessionId());
+        assertThat(retry.turnNumber()).isEqualTo(2);
+        assertThat(retry.storyText()).isEqualTo(first.storyText());
+        assertThat(narrativeGenerator.progressCalls()).as("NarrativeGenerator progress calls").isEqualTo(1);
 
-        BeginAttempt retry = beginProgressAttempt(session.getId(), key, fingerprint);
-        assertThat(retry.error()).as(context("retry", key, session.getId(), 1)).isNull();
-        assertThat(retry.result().replay()).isTrue();
-        assertThat(retry.result().resultSessionId()).isEqualTo(session.getId());
-        assertThat(retry.result().resultTurn()).isEqualTo(2);
-
-        BeginAttempt conflictingPayload = beginProgressAttempt(session.getId(), key, "b".repeat(64));
-        assertThat(conflictingPayload.error())
-                .as(context("fingerprint-conflict", key, session.getId(), 1))
+        assertThatThrownBy(() -> gameService.progressGame(
+                progressContext(key, opening.sessionId()),
+                new GameProgressRequest(opening.sessionId(), 2, 1)
+        )).as(context("progress-fingerprint-conflict", key, opening.sessionId(), 1))
                 .isInstanceOf(IdempotencyConflictException.class);
+        assertThat(narrativeGenerator.progressCalls()).as("provider calls after progress fingerprint conflict").isEqualTo(1);
 
-        assertThat(provider.calls()).as("provider calls for completed progress retry").isEqualTo(1);
-        assertCanonicalTurn(session.getId(), key, 2, 2);
+        assertCanonicalTurn(opening.sessionId(), key, 2, 2);
     }
 
     @RepeatedTest(3)
-    @DisplayName("같은 session/turn 최초 동시 요청은 active reservation과 provider 진입을 하나로 제한한다")
+    @DisplayName("같은 session/turn 최초 동시 요청은 active lease 동안 실제 provider 진입을 하나로 제한한다")
     void concurrentFirstRequests_AllowSingleActiveProviderExecution() throws Exception {
-        GameSession session = createOpening();
+        GameResponse opening = createOpening("matrix-opening-concurrency");
+        GameProgressRequest request = new GameProgressRequest(opening.sessionId(), 1, 1);
+        narrativeGenerator.blockNextProgress();
+
         CountDownLatch ready = new CountDownLatch(2);
         CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch rejected = new CountDownLatch(1);
         ExecutorService executor = Executors.newFixedThreadPool(2);
 
         try {
-            Future<ProviderAttempt> first = executor.submit(concurrentAttempt(
-                    ready, start, session.getId(), "matrix-concurrent-key-a", "c".repeat(64)
+            Future<ProgressAttempt> first = executor.submit(concurrentProgressAttempt(
+                    ready, start, rejected, "matrix-concurrent-key-a", request
             ));
-            Future<ProviderAttempt> second = executor.submit(concurrentAttempt(
-                    ready, start, session.getId(), "matrix-concurrent-key-b", "c".repeat(64)
+            Future<ProgressAttempt> second = executor.submit(concurrentProgressAttempt(
+                    ready, start, rejected, "matrix-concurrent-key-b", request
             ));
 
             ready.await();
             start.countDown();
+            narrativeGenerator.awaitProgressEntry();
+            rejected.await();
 
-            List<ProviderAttempt> attempts = List.of(first.get(), second.get());
-            List<ProviderAttempt> winners = attempts.stream().filter(ProviderAttempt::providerCalled).toList();
-            List<ProviderAttempt> rejected = attempts.stream().filter(attempt -> !attempt.providerCalled()).toList();
+            assertThat(narrativeGenerator.progressCalls()).as("provider calls while lease is active").isEqualTo(1);
+            assertThat(reservationCount(opening.sessionId(), 1)).as("active reservation rows").isEqualTo(1);
 
-            assertThat(winners).as("provider winner session=%d turn=1", session.getId()).hasSize(1);
-            assertThat(rejected).as("reservation loser session=%d turn=1", session.getId()).hasSize(1);
-            assertThat(rejected.getFirst().begin().error()).isInstanceOf(MutationInProgressException.class);
-            assertThat(provider.calls()).as("provider calls while lease is active").isEqualTo(1);
-            assertThat(reservationCount(session.getId(), 1)).as("active reservation rows").isEqualTo(1);
+            narrativeGenerator.releaseProgress();
+            List<ProgressAttempt> attempts = List.of(first.get(), second.get());
+            List<ProgressAttempt> winners = attempts.stream().filter(ProgressAttempt::succeeded).toList();
+            List<ProgressAttempt> losers = attempts.stream().filter(attempt -> !attempt.succeeded()).toList();
 
-            ProviderAttempt winner = winners.getFirst();
-            commitTurn(session.getId(), winner.begin().result(), winner.story());
+            assertThat(winners).as("canonical winner session=%d turn=1", opening.sessionId()).hasSize(1);
+            assertThat(losers).as("reservation loser session=%d turn=1", opening.sessionId()).hasSize(1);
+            assertThat(losers.getFirst().error()).isInstanceOf(MutationInProgressException.class);
+            assertThat(narrativeGenerator.progressCalls()).isEqualTo(1);
 
-            assertCanonicalTurn(session.getId(), winner.key(), 2, 2);
-            assertThat(reservationCount(session.getId(), 1)).isZero();
+            String winnerKey = winners.getFirst().key();
+            assertCanonicalTurn(opening.sessionId(), winnerKey, 2, 2);
+            assertThat(reservationCount(opening.sessionId(), 1)).isZero();
         } finally {
+            narrativeGenerator.releaseProgress();
             executor.shutdownNow();
         }
     }
 
     @Test
-    @DisplayName("crash 후 lease takeover는 provider 재호출을 허용하지만 stale owner의 canonical commit은 차단한다")
+    @DisplayName("provider 성공 직후 crash와 lease expiry는 재호출을 허용해도 canonical commit은 하나로 수렴한다")
     void expiredLeaseTakeover_AllowsProviderRetryButSingleCanonicalCommit() {
-        GameSession session = createOpening();
+        GameResponse opening = createOpening("matrix-opening-crash");
+        GameProgressRequest request = new GameProgressRequest(opening.sessionId(), 1, 1);
+        String crashedKey = "matrix-crash-key-a";
 
-        BeginAttempt crashed = beginProgressAttempt(session.getId(), "matrix-crash-key-a", "d".repeat(64));
-        assertThat(crashed.error()).as(context("crashed-begin", "matrix-crash-key-a", session.getId(), 1)).isNull();
-        String staleStory = provider.nextStory();
+        GamePersistenceService crashingPersistence = spy(persistenceService);
+        doThrow(new SimulatedCrash()).when(crashingPersistence).saveNextTurn(
+                eq(OWNER_KEY),
+                anyLong(),
+                any(GameTurnCommit.class),
+                anyLong(),
+                anyString(),
+                anyString()
+        );
+        GameService crashingService = newGameService(crashingPersistence);
+
+        assertThatThrownBy(() -> crashingService.progressGame(
+                progressContext(crashedKey, opening.sessionId()), request
+        )).as(context("provider-success-before-crash", crashedKey, opening.sessionId(), 1))
+                .isInstanceOf(SimulatedCrash.class);
+
+        assertThat(narrativeGenerator.progressCalls()).as("provider calls before simulated crash").isEqualTo(1);
+        assertThat(requestStatus(crashedKey)).as("crashed request remains in-flight").isEqualTo("PROCESSING");
+        assertThat(reservationCount(opening.sessionId(), 1)).as("crashed active reservation").isEqualTo(1);
 
         clock.advance(Duration.ofSeconds(LEASE_SECONDS + 1));
 
-        BeginAttempt takeover = beginProgressAttempt(session.getId(), "matrix-crash-key-b", "d".repeat(64));
-        assertThat(takeover.error()).as(context("takeover-begin", "matrix-crash-key-b", session.getId(), 1)).isNull();
-        String canonicalStory = provider.nextStory();
+        String takeoverKey = "matrix-crash-key-b";
+        GameResponse recovered = gameService.progressGame(
+                progressContext(takeoverKey, opening.sessionId()), request
+        );
 
-        assertThat(provider.calls())
+        assertThat(recovered.turnNumber()).isEqualTo(2);
+        assertThat(narrativeGenerator.progressCalls())
                 .as("external provider strict exactly-once is intentionally not guaranteed after lease expiry")
                 .isEqualTo(2);
-        assertThat(jdbcTemplate.queryForObject(
-                "select attempt_count from game_turn_reservation where session_id = ? and expected_turn = ?",
-                Integer.class, session.getId(), 1
-        )).as("reservation attempt_count session=%d turn=1", session.getId()).isEqualTo(2);
-
-        assertThatThrownBy(() -> commitTurn(session.getId(), crashed.result(), staleStory))
-                .as(context("stale-owner-commit", "matrix-crash-key-a", session.getId(), 1))
-                .isInstanceOf(TurnConflictException.class)
-                .hasMessageContaining("reservation");
-
-        commitTurn(session.getId(), takeover.result(), canonicalStory);
-
-        assertCanonicalTurn(session.getId(), "matrix-crash-key-b", 2, 2);
-        assertThat(provider.calls()).isEqualTo(2);
-        assertThat(reservationCount(session.getId(), 1)).isZero();
+        assertCanonicalTurn(opening.sessionId(), takeoverKey, 2, 2);
+        assertThat(reservationCount(opening.sessionId(), 1)).isZero();
     }
 
-    private Callable<ProviderAttempt> concurrentAttempt(
+    private Callable<ProgressAttempt> concurrentProgressAttempt(
             CountDownLatch ready,
             CountDownLatch start,
-            Long sessionId,
+            CountDownLatch rejected,
             String key,
-            String fingerprint
+            GameProgressRequest request
     ) {
         return () -> {
             ready.countDown();
             start.await();
-            BeginAttempt begin = beginProgressAttempt(sessionId, key, fingerprint);
-            if (begin.error() != null) {
-                return new ProviderAttempt(key, begin, null, false);
+            try {
+                GameResponse response = gameService.progressGame(
+                        progressContext(key, request.sessionId()), request
+                );
+                return ProgressAttempt.success(key, response);
+            } catch (RuntimeException exception) {
+                if (exception instanceof MutationInProgressException) {
+                    rejected.countDown();
+                }
+                return ProgressAttempt.failure(key, exception);
             }
-            return new ProviderAttempt(key, begin, provider.nextStory(), true);
         };
     }
 
-    private BeginAttempt beginInitAttempt(String key, String fingerprint) {
-        return executeBegin(() -> mutationService.begin(
-                OWNER_KEY,
-                GameMutationRequestService.INIT,
-                key,
-                null,
-                null,
-                fingerprint
-        ));
-    }
-
-    private BeginAttempt beginProgressAttempt(Long sessionId, String key, String fingerprint) {
-        return executeBegin(() -> mutationService.begin(
-                OWNER_KEY,
-                GameMutationRequestService.PROGRESS,
-                key,
-                sessionId,
-                1,
-                fingerprint
-        ));
-    }
-
-    private BeginAttempt executeBegin(Callable<GameMutationRequestService.BeginResult> begin) {
-        return transactionTemplate.execute(status -> {
-            try {
-                return BeginAttempt.success(begin.call());
-            } catch (RuntimeException exception) {
-                return BeginAttempt.failure(exception);
-            } catch (Exception exception) {
-                throw new IllegalStateException("mutation begin 실행에 실패했습니다.", exception);
-            }
-        });
-    }
-
-    private GameSession createOpening() {
-        return persistenceService.saveOpening(
-                OWNER_KEY,
-                "matrix-world",
-                "matrix-character",
-                "opening-story",
-                OPENING_CHOICES,
-                null
+    private GameResponse createOpening(String key) {
+        return gameService.initGame(
+                initContext(key),
+                new GameInitRequest("matrix-world", "matrix-character")
         );
     }
 
-    private void commitTurn(Long sessionId, GameMutationRequestService.BeginResult mutation, String story) {
-        GamePersistenceService.LoadedTurn loaded = persistenceService.loadLatestTurn(OWNER_KEY, sessionId, 1);
-        GameState nextState = loaded.gameState().advance("문을 연다", story);
-        GameTurnCommit commit = new GameTurnCommit(
-                1,
-                1,
-                "문을 연다",
-                loaded.gameState(),
-                nextState,
-                story,
-                NEXT_CHOICES,
-                null
+    private GameService newGameService(GamePersistenceService persistence) {
+        return new GameService(
+                narrativeGenerator,
+                imageAssetService,
+                persistence,
+                choiceCodec,
+                imagePromptComposer,
+                costRateLimiter,
+                providerCallTelemetry,
+                mutationFingerprint,
+                mutationService
         );
-        persistenceService.saveNextTurn(
-                OWNER_KEY,
-                sessionId,
-                commit,
-                mutation.requestId(),
-                "matrix-turn-2",
-                mutation.reservationOwner()
-        );
+    }
+
+    private CostRequestContext initContext(String key) {
+        return CostRequestContext.create(OWNER_KEY, "127.0.0.1", null, 1, key);
+    }
+
+    private CostRequestContext progressContext(String key, Long sessionId) {
+        return CostRequestContext.create(OWNER_KEY, "127.0.0.1", sessionId, 2, key);
     }
 
     private void assertCanonicalTurn(Long sessionId, String completedKey, int expectedTurn, int expectedLogCount) {
@@ -306,10 +298,9 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
         Integer latestStateVersion = jdbcTemplate.queryForObject(
                 "select max(state_version) from game_log where session_id = ?", Integer.class, sessionId
         );
-        String requestStatus = jdbcTemplate.queryForObject(
-                "select status from game_mutation_request where owner_key = ? and idempotency_key = ?",
-                String.class, OWNER_KEY, completedKey
-        );
+        Integer snapshotTurn = persistenceService.loadLatestTurn(OWNER_KEY, sessionId, expectedTurn)
+                .gameState()
+                .turnNumber();
         Integer requestResultTurn = jdbcTemplate.queryForObject(
                 "select result_turn from game_mutation_request where owner_key = ? and idempotency_key = ?",
                 Integer.class, OWNER_KEY, completedKey
@@ -318,11 +309,16 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
         assertThat(sessionTurn).as("session=%d current_turn", sessionId).isEqualTo(expectedTurn);
         assertThat(logCount).as("session=%d committed GameLog rows", sessionId).isEqualTo(expectedLogCount);
         assertThat(latestStateVersion).as("session=%d latest GameLog state_version", sessionId).isEqualTo(expectedTurn);
-        assertThat(requestStatus).as("request=%s status", completedKey).isEqualTo("COMPLETED");
+        assertThat(snapshotTurn).as("session=%d snapshot/currentTurn", sessionId).isEqualTo(expectedTurn);
+        assertThat(requestStatus(completedKey)).as("request=%s status", completedKey).isEqualTo("COMPLETED");
         assertThat(requestResultTurn).as("request=%s result_turn", completedKey).isEqualTo(expectedTurn);
+    }
 
-        GamePersistenceService.LoadedTurn loaded = persistenceService.loadLatestTurn(OWNER_KEY, sessionId, expectedTurn);
-        assertThat(loaded.gameState().turnNumber()).as("session=%d snapshot/currentTurn", sessionId).isEqualTo(expectedTurn);
+    private String requestStatus(String key) {
+        return jdbcTemplate.queryForObject(
+                "select status from game_mutation_request where owner_key = ? and idempotency_key = ?",
+                String.class, OWNER_KEY, key
+        );
     }
 
     private int reservationCount(Long sessionId, int expectedTurn) {
@@ -337,27 +333,146 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
         return "phase=%s request=%s session=%d turn=%d".formatted(phase, key, sessionId, turn);
     }
 
-    private record BeginAttempt(GameMutationRequestService.BeginResult result, RuntimeException error) {
-        static BeginAttempt success(GameMutationRequestService.BeginResult result) {
-            return new BeginAttempt(result, null);
+    private record ProgressAttempt(String key, GameResponse response, RuntimeException error) {
+        static ProgressAttempt success(String key, GameResponse response) {
+            return new ProgressAttempt(key, response, null);
         }
 
-        static BeginAttempt failure(RuntimeException error) {
-            return new BeginAttempt(null, error);
+        static ProgressAttempt failure(String key, RuntimeException error) {
+            return new ProgressAttempt(key, null, error);
+        }
+
+        boolean succeeded() {
+            return response != null;
         }
     }
 
-    private record ProviderAttempt(String key, BeginAttempt begin, String story, boolean providerCalled) {}
+    private static final class FakeNarrativeGenerator implements NarrativeGenerator {
+        private final AtomicInteger openingCalls = new AtomicInteger();
+        private final AtomicInteger progressCalls = new AtomicInteger();
+        private final AtomicReference<CountDownLatch> progressEntered = new AtomicReference<>();
+        private final AtomicReference<CountDownLatch> progressRelease = new AtomicReference<>();
 
-    private static final class FakeNarrativeProvider {
-        private final AtomicInteger calls = new AtomicInteger();
-
-        String nextStory() {
-            return "provider-story-" + calls.incrementAndGet();
+        @Override
+        public NarrativeTurn createOpening(String worldSetting, String characterSetting) {
+            int call = openingCalls.incrementAndGet();
+            return turn("opening-title", "opening-story-" + call);
         }
 
-        int calls() {
-            return calls.get();
+        @Override
+        public NarrativeTurn createNextTurn(NarrativeContext context) {
+            int call = progressCalls.incrementAndGet();
+            CountDownLatch entered = progressEntered.get();
+            CountDownLatch release = progressRelease.get();
+            if (entered != null && release != null) {
+                entered.countDown();
+                try {
+                    release.await();
+                } catch (InterruptedException exception) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException("fake provider가 중단되었습니다.", exception);
+                }
+            }
+            return turn("progress-title", "progress-story-" + call);
+        }
+
+        void blockNextProgress() {
+            progressEntered.set(new CountDownLatch(1));
+            progressRelease.set(new CountDownLatch(1));
+        }
+
+        void awaitProgressEntry() throws InterruptedException {
+            CountDownLatch entered = progressEntered.get();
+            if (entered != null) {
+                entered.await();
+            }
+        }
+
+        void releaseProgress() {
+            CountDownLatch release = progressRelease.getAndSet(null);
+            if (release != null) {
+                release.countDown();
+            }
+            progressEntered.set(null);
+        }
+
+        int openingCalls() {
+            return openingCalls.get();
+        }
+
+        int progressCalls() {
+            return progressCalls.get();
+        }
+
+        private NarrativeTurn turn(String title, String story) {
+            return new NarrativeTurn(
+                    title,
+                    story,
+                    List.of(new NarrativeTurn.Choice(1, "문을 연다")),
+                    new NarrativeTurn.VisualAssets(null, List.of(), List.of())
+            );
+        }
+    }
+
+    private static final class TransactionalMutationService extends GameMutationRequestService {
+        private final TransactionTemplate transactionTemplate;
+
+        TransactionalMutationService(
+                GameMutationRequestRepository repository,
+                JdbcTemplate jdbcTemplate,
+                Clock clock,
+                long leaseSeconds,
+                PlatformTransactionManager transactionManager
+        ) {
+            super(repository, jdbcTemplate, clock, leaseSeconds);
+            this.transactionTemplate = new TransactionTemplate(transactionManager);
+        }
+
+        @Override
+        public BeginResult begin(
+                String ownerKey,
+                String operation,
+                String idempotencyKey,
+                Long sessionId,
+                Integer expectedTurn,
+                String fingerprint
+        ) {
+            BeginOutcome outcome = transactionTemplate.execute(status -> {
+                try {
+                    return BeginOutcome.success(super.begin(
+                            ownerKey, operation, idempotencyKey, sessionId, expectedTurn, fingerprint
+                    ));
+                } catch (MutationInProgressException exception) {
+                    return BeginOutcome.blocked(exception);
+                }
+            });
+            if (outcome == null) {
+                throw new IllegalStateException("mutation begin transaction 결과가 없습니다.");
+            }
+            if (outcome.blocked() != null) {
+                throw outcome.blocked();
+            }
+            return outcome.result();
+        }
+
+        @Override
+        public void markFailed(Long requestId) {
+            transactionTemplate.executeWithoutResult(status -> super.markFailed(requestId, null));
+        }
+
+        @Override
+        public void markFailed(Long requestId, String reservationOwner) {
+            transactionTemplate.executeWithoutResult(status -> super.markFailed(requestId, reservationOwner));
+        }
+
+        private record BeginOutcome(BeginResult result, MutationInProgressException blocked) {
+            static BeginOutcome success(BeginResult result) {
+                return new BeginOutcome(result, null);
+            }
+
+            static BeginOutcome blocked(MutationInProgressException exception) {
+                return new BeginOutcome(null, exception);
+            }
         }
     }
 
@@ -385,6 +500,12 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
         @Override
         public Instant instant() {
             return instant.get();
+        }
+    }
+
+    private static final class SimulatedCrash extends Error {
+        SimulatedCrash() {
+            super("simulated process crash after provider success");
         }
     }
 }

--- a/src/test/java/com/uctale/uctale/persistence/PostgresM2TurnIntegrityMatrixTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/PostgresM2TurnIntegrityMatrixTest.java
@@ -48,12 +48,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.spy;
 
 @SpringBootTest
 class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
@@ -201,16 +195,7 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
         GameProgressRequest request = new GameProgressRequest(opening.sessionId(), 1, 1);
         String crashedKey = "matrix-crash-key-a";
 
-        GamePersistenceService crashingPersistence = spy(persistenceService);
-        doThrow(new SimulatedCrash()).when(crashingPersistence).saveNextTurn(
-                eq(OWNER_KEY),
-                anyLong(),
-                any(GameTurnCommit.class),
-                anyLong(),
-                anyString(),
-                anyString()
-        );
-        GameService crashingService = newGameService(crashingPersistence);
+        GameService crashingService = newGameService(new CrashBeforeCommitPersistence(persistenceService));
 
         assertThatThrownBy(() -> crashingService.progressGame(
                 progressContext(crashedKey, opening.sessionId()), request
@@ -541,6 +526,32 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
             static BeginOutcome blocked(MutationInProgressException exception) {
                 return new BeginOutcome(null, exception);
             }
+        }
+    }
+
+    private static final class CrashBeforeCommitPersistence extends GamePersistenceService {
+        private final GamePersistenceService delegate;
+
+        CrashBeforeCommitPersistence(GamePersistenceService delegate) {
+            super(null, null, null, null, null, null, null);
+            this.delegate = delegate;
+        }
+
+        @Override
+        public LoadedTurn loadLatestTurn(String ownerKey, Long sessionId, int expectedTurn) {
+            return delegate.loadLatestTurn(ownerKey, sessionId, expectedTurn);
+        }
+
+        @Override
+        public int saveNextTurn(
+                String ownerKey,
+                Long sessionId,
+                GameTurnCommit commit,
+                Long mutationRequestId,
+                String resultTitle,
+                String reservationOwner
+        ) {
+            throw new SimulatedCrash();
         }
     }
 

--- a/src/test/java/com/uctale/uctale/persistence/PostgresM2TurnIntegrityMatrixTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/PostgresM2TurnIntegrityMatrixTest.java
@@ -12,6 +12,7 @@ import com.uctale.uctale.repository.GameMutationRequestRepository;
 import com.uctale.uctale.support.PostgresIntegrationTestSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -69,41 +70,81 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
     }
 
     @Test
-    @DisplayName("완료 retry는 provider와 canonical state를 재실행하지 않고 저장 결과를 재사용한다")
-    void completedRetry_ReusesCanonicalResultExactlyOnce() {
+    @DisplayName("완료된 init retry는 provider와 새 session을 만들지 않고 canonical opening을 재사용한다")
+    void completedInitRetry_ReusesCanonicalOpeningExactlyOnce() {
+        String key = "matrix-init-key-001";
+        String fingerprint = "i".repeat(64);
+
+        BeginAttempt first = beginInitAttempt(key, fingerprint);
+        assertThat(first.error()).as("phase=init-begin request=%s", key).isNull();
+
+        String openingStory = provider.nextStory();
+        GameSession session = persistenceService.saveOpening(
+                OWNER_KEY,
+                "matrix-world",
+                "matrix-character",
+                openingStory,
+                OPENING_CHOICES,
+                null,
+                first.result().requestId(),
+                "matrix-opening"
+        );
+
+        BeginAttempt retry = beginInitAttempt(key, fingerprint);
+        assertThat(retry.error()).as("phase=init-retry request=%s", key).isNull();
+        assertThat(retry.result().replay()).isTrue();
+        assertThat(retry.result().resultSessionId()).isEqualTo(session.getId());
+        assertThat(retry.result().resultTurn()).isEqualTo(1);
+
+        BeginAttempt conflictingPayload = beginInitAttempt(key, "j".repeat(64));
+        assertThat(conflictingPayload.error())
+                .as("phase=init-fingerprint-conflict request=%s", key)
+                .isInstanceOf(IdempotencyConflictException.class);
+
+        assertThat(provider.calls()).as("provider calls for completed init retry").isEqualTo(1);
+        assertThat(jdbcTemplate.queryForObject("select count(*) from game_session", Integer.class))
+                .as("canonical session count after init retry")
+                .isEqualTo(1);
+        assertCanonicalTurn(session.getId(), key, 1, 1);
+    }
+
+    @Test
+    @DisplayName("완료된 progress retry는 provider와 canonical state를 재실행하지 않고 저장 결과를 재사용한다")
+    void completedProgressRetry_ReusesCanonicalResultExactlyOnce() {
         GameSession session = createOpening();
         String key = "matrix-retry-key-001";
         String fingerprint = "a".repeat(64);
 
-        BeginAttempt first = beginAttempt(session.getId(), key, fingerprint);
+        BeginAttempt first = beginProgressAttempt(session.getId(), key, fingerprint);
         assertThat(first.error()).as(context("begin", key, session.getId(), 1)).isNull();
 
         String story = provider.nextStory();
         commitTurn(session.getId(), first.result(), story);
 
-        BeginAttempt retry = beginAttempt(session.getId(), key, fingerprint);
+        BeginAttempt retry = beginProgressAttempt(session.getId(), key, fingerprint);
         assertThat(retry.error()).as(context("retry", key, session.getId(), 1)).isNull();
         assertThat(retry.result().replay()).isTrue();
         assertThat(retry.result().resultSessionId()).isEqualTo(session.getId());
         assertThat(retry.result().resultTurn()).isEqualTo(2);
 
-        BeginAttempt conflictingPayload = beginAttempt(session.getId(), key, "b".repeat(64));
+        BeginAttempt conflictingPayload = beginProgressAttempt(session.getId(), key, "b".repeat(64));
         assertThat(conflictingPayload.error())
                 .as(context("fingerprint-conflict", key, session.getId(), 1))
                 .isInstanceOf(IdempotencyConflictException.class);
 
-        assertThat(provider.calls()).as("provider calls for completed retry").isEqualTo(1);
+        assertThat(provider.calls()).as("provider calls for completed progress retry").isEqualTo(1);
         assertCanonicalTurn(session.getId(), key, 2, 2);
     }
 
-    @Test
+    @RepeatedTest(3)
     @DisplayName("같은 session/turn 최초 동시 요청은 active reservation과 provider 진입을 하나로 제한한다")
     void concurrentFirstRequests_AllowSingleActiveProviderExecution() throws Exception {
         GameSession session = createOpening();
         CountDownLatch ready = new CountDownLatch(2);
         CountDownLatch start = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
 
-        try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
+        try {
             Future<ProviderAttempt> first = executor.submit(concurrentAttempt(
                     ready, start, session.getId(), "matrix-concurrent-key-a", "c".repeat(64)
             ));
@@ -129,6 +170,8 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
 
             assertCanonicalTurn(session.getId(), winner.key(), 2, 2);
             assertThat(reservationCount(session.getId(), 1)).isZero();
+        } finally {
+            executor.shutdownNow();
         }
     }
 
@@ -137,13 +180,13 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
     void expiredLeaseTakeover_AllowsProviderRetryButSingleCanonicalCommit() {
         GameSession session = createOpening();
 
-        BeginAttempt crashed = beginAttempt(session.getId(), "matrix-crash-key-a", "d".repeat(64));
+        BeginAttempt crashed = beginProgressAttempt(session.getId(), "matrix-crash-key-a", "d".repeat(64));
         assertThat(crashed.error()).as(context("crashed-begin", "matrix-crash-key-a", session.getId(), 1)).isNull();
         String staleStory = provider.nextStory();
 
         clock.advance(Duration.ofSeconds(LEASE_SECONDS + 1));
 
-        BeginAttempt takeover = beginAttempt(session.getId(), "matrix-crash-key-b", "d".repeat(64));
+        BeginAttempt takeover = beginProgressAttempt(session.getId(), "matrix-crash-key-b", "d".repeat(64));
         assertThat(takeover.error()).as(context("takeover-begin", "matrix-crash-key-b", session.getId(), 1)).isNull();
         String canonicalStory = provider.nextStory();
 
@@ -177,7 +220,7 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
         return () -> {
             ready.countDown();
             start.await();
-            BeginAttempt begin = beginAttempt(sessionId, key, fingerprint);
+            BeginAttempt begin = beginProgressAttempt(sessionId, key, fingerprint);
             if (begin.error() != null) {
                 return new ProviderAttempt(key, begin, null, false);
             }
@@ -185,19 +228,36 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
         };
     }
 
-    private BeginAttempt beginAttempt(Long sessionId, String key, String fingerprint) {
+    private BeginAttempt beginInitAttempt(String key, String fingerprint) {
+        return executeBegin(() -> mutationService.begin(
+                OWNER_KEY,
+                GameMutationRequestService.INIT,
+                key,
+                null,
+                null,
+                fingerprint
+        ));
+    }
+
+    private BeginAttempt beginProgressAttempt(Long sessionId, String key, String fingerprint) {
+        return executeBegin(() -> mutationService.begin(
+                OWNER_KEY,
+                GameMutationRequestService.PROGRESS,
+                key,
+                sessionId,
+                1,
+                fingerprint
+        ));
+    }
+
+    private BeginAttempt executeBegin(Callable<GameMutationRequestService.BeginResult> begin) {
         return transactionTemplate.execute(status -> {
             try {
-                return BeginAttempt.success(mutationService.begin(
-                        OWNER_KEY,
-                        GameMutationRequestService.PROGRESS,
-                        key,
-                        sessionId,
-                        1,
-                        fingerprint
-                ));
+                return BeginAttempt.success(begin.call());
             } catch (RuntimeException exception) {
                 return BeginAttempt.failure(exception);
+            } catch (Exception exception) {
+                throw new IllegalStateException("mutation begin 실행에 실패했습니다.", exception);
             }
         });
     }

--- a/src/test/java/com/uctale/uctale/persistence/PostgresM2TurnIntegrityMatrixTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/PostgresM2TurnIntegrityMatrixTest.java
@@ -11,6 +11,7 @@ import com.uctale.uctale.application.game.GameTurnCommit;
 import com.uctale.uctale.application.game.IdempotencyConflictException;
 import com.uctale.uctale.application.game.ImagePromptComposer;
 import com.uctale.uctale.application.game.MutationInProgressException;
+import com.uctale.uctale.application.game.TurnConflictException;
 import com.uctale.uctale.application.image.ImageAssetService;
 import com.uctale.uctale.application.narrative.NarrativeContext;
 import com.uctale.uctale.application.narrative.NarrativeGenerator;
@@ -194,8 +195,8 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
     }
 
     @Test
-    @DisplayName("provider 성공 직후 crash와 lease expiry는 재호출을 허용해도 canonical commit은 하나로 수렴한다")
-    void expiredLeaseTakeover_AllowsProviderRetryButSingleCanonicalCommit() {
+    @DisplayName("provider 성공 직후 crash와 lease expiry는 재호출을 허용해도 stale owner를 막고 canonical commit 하나로 수렴한다")
+    void expiredLeaseTakeover_AllowsProviderRetryButSingleCanonicalCommit() throws Exception {
         GameResponse opening = createOpening("matrix-opening-crash");
         GameProgressRequest request = new GameProgressRequest(opening.sessionId(), 1, 1);
         String crashedKey = "matrix-crash-key-a";
@@ -216,23 +217,53 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
         )).as(context("provider-success-before-crash", crashedKey, opening.sessionId(), 1))
                 .isInstanceOf(SimulatedCrash.class);
 
+        Long crashedRequestId = requestId(crashedKey);
+        String staleOwner = reservationOwner(opening.sessionId(), 1);
         assertThat(narrativeGenerator.progressCalls()).as("provider calls before simulated crash").isEqualTo(1);
         assertThat(requestStatus(crashedKey)).as("crashed request remains in-flight").isEqualTo("PROCESSING");
         assertThat(reservationCount(opening.sessionId(), 1)).as("crashed active reservation").isEqualTo(1);
 
         clock.advance(Duration.ofSeconds(LEASE_SECONDS + 1));
+        narrativeGenerator.blockNextProgress();
 
         String takeoverKey = "matrix-crash-key-b";
-        GameResponse recovered = gameService.progressGame(
-                progressContext(takeoverKey, opening.sessionId()), request
-        );
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<GameResponse> takeover = executor.submit(() -> gameService.progressGame(
+                    progressContext(takeoverKey, opening.sessionId()), request
+            ));
+            narrativeGenerator.awaitProgressEntry();
 
-        assertThat(recovered.turnNumber()).isEqualTo(2);
-        assertThat(narrativeGenerator.progressCalls())
-                .as("external provider strict exactly-once is intentionally not guaranteed after lease expiry")
-                .isEqualTo(2);
-        assertCanonicalTurn(opening.sessionId(), takeoverKey, 2, 2);
-        assertThat(reservationCount(opening.sessionId(), 1)).isZero();
+            assertThat(narrativeGenerator.progressCalls())
+                    .as("provider retry after deterministic lease expiry")
+                    .isEqualTo(2);
+            assertThat(reservationOwner(opening.sessionId(), 1))
+                    .as("reservation owner after takeover")
+                    .isNotEqualTo(staleOwner);
+            assertThat(jdbcTemplate.queryForObject(
+                    "select attempt_count from game_turn_reservation where session_id = ? and expected_turn = ?",
+                    Integer.class, opening.sessionId(), 1
+            )).as("reservation attempt_count session=%d turn=1", opening.sessionId()).isEqualTo(2);
+
+            assertThatThrownBy(() -> commitWithReservation(
+                    opening.sessionId(), crashedRequestId, staleOwner, "stale-owner-story"
+            )).as(context("stale-owner-commit", crashedKey, opening.sessionId(), 1))
+                    .isInstanceOf(TurnConflictException.class)
+                    .hasMessageContaining("reservation");
+
+            narrativeGenerator.releaseProgress();
+            GameResponse recovered = takeover.get();
+
+            assertThat(recovered.turnNumber()).isEqualTo(2);
+            assertThat(narrativeGenerator.progressCalls())
+                    .as("external provider strict exactly-once is intentionally not guaranteed after lease expiry")
+                    .isEqualTo(2);
+            assertCanonicalTurn(opening.sessionId(), takeoverKey, 2, 2);
+            assertThat(reservationCount(opening.sessionId(), 1)).isZero();
+        } finally {
+            narrativeGenerator.releaseProgress();
+            executor.shutdownNow();
+        }
     }
 
     private Callable<ProgressAttempt> concurrentProgressAttempt(
@@ -288,6 +319,29 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
         return CostRequestContext.create(OWNER_KEY, "127.0.0.1", sessionId, 2, key);
     }
 
+    private void commitWithReservation(Long sessionId, Long requestId, String reservationOwner, String story) {
+        GamePersistenceService.LoadedTurn loaded = persistenceService.loadLatestTurn(OWNER_KEY, sessionId, 1);
+        var nextState = loaded.gameState().advance("문을 연다", story);
+        GameTurnCommit commit = new GameTurnCommit(
+                1,
+                1,
+                "문을 연다",
+                loaded.gameState(),
+                nextState,
+                story,
+                loaded.choicesJson(),
+                null
+        );
+        persistenceService.saveNextTurn(
+                OWNER_KEY,
+                sessionId,
+                commit,
+                requestId,
+                "stale-owner-title",
+                reservationOwner
+        );
+    }
+
     private void assertCanonicalTurn(Long sessionId, String completedKey, int expectedTurn, int expectedLogCount) {
         Integer sessionTurn = jdbcTemplate.queryForObject(
                 "select current_turn from game_session where id = ?", Integer.class, sessionId
@@ -314,10 +368,24 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
         assertThat(requestResultTurn).as("request=%s result_turn", completedKey).isEqualTo(expectedTurn);
     }
 
+    private Long requestId(String key) {
+        return jdbcTemplate.queryForObject(
+                "select id from game_mutation_request where owner_key = ? and idempotency_key = ?",
+                Long.class, OWNER_KEY, key
+        );
+    }
+
     private String requestStatus(String key) {
         return jdbcTemplate.queryForObject(
                 "select status from game_mutation_request where owner_key = ? and idempotency_key = ?",
                 String.class, OWNER_KEY, key
+        );
+    }
+
+    private String reservationOwner(Long sessionId, int expectedTurn) {
+        return jdbcTemplate.queryForObject(
+                "select lease_owner from game_turn_reservation where session_id = ? and expected_turn = ?",
+                String.class, sessionId, expectedTurn
         );
     }
 

--- a/src/test/java/com/uctale/uctale/persistence/PostgresPersistenceBaselineTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/PostgresPersistenceBaselineTest.java
@@ -28,22 +28,27 @@ class PostgresPersistenceBaselineTest extends PostgresIntegrationTestSupport {
 
     @BeforeEach
     void cleanDatabase() {
-        jdbcTemplate.execute("truncate table game_mutation_request, image_asset, game_state_snapshot, game_log, game_session restart identity cascade");
+        jdbcTemplate.execute("""
+                truncate table game_turn_reservation, game_mutation_request, image_asset,
+                    game_state_snapshot, game_log, game_session restart identity
+                """);
     }
 
     @Test
     @DisplayName("빈 PostgreSQL에 production Flyway migration이 모두 적용된다")
     void productionMigrationChain_IsAppliedToPostgres() {
-        assertThat(flyway.info().pending()).isEmpty();
+        assertThat(flyway.info().pending()).as("pending production migration").isEmpty();
         assertThat(flyway.info().applied())
+                .as("applied production migration chain")
                 .extracting(info -> info.getVersion().getVersion())
-                .contains("1", "2", "3", "4", "5", "6", "7");
+                .contains("1", "2", "3", "4", "5", "6", "7", "8");
 
         assertThat(tableExists("game_session")).isTrue();
         assertThat(tableExists("game_log")).isTrue();
         assertThat(tableExists("game_state_snapshot")).isTrue();
         assertThat(tableExists("image_asset")).isTrue();
         assertThat(tableExists("game_mutation_request")).isTrue();
+        assertThat(tableExists("game_turn_reservation")).isTrue();
     }
 
     @Test
@@ -53,6 +58,7 @@ class PostgresPersistenceBaselineTest extends PostgresIntegrationTestSupport {
         insertGameLog(sessionId, 1);
 
         assertThatThrownBy(() -> insertGameLog(sessionId, 1))
+                .as("constraint=uk_game_log_session_turn session=%d turn=1", sessionId)
                 .isInstanceOf(DataIntegrityViolationException.class);
     }
 
@@ -75,6 +81,7 @@ class PostgresPersistenceBaselineTest extends PostgresIntegrationTestSupport {
             stale.advanceTurn();
 
             assertThatThrownBy(() -> secondEntityManager.getTransaction().commit())
+                    .as("optimistic-lock session=%d staleVersion=0", sessionId)
                     .isInstanceOf(RollbackException.class);
         } finally {
             rollbackIfActive(firstEntityManager);


### PR DESCRIPTION
## 왜 필요한가요?

M2에서 #28~#31을 통해 GameLog append-only ledger, mutation idempotency, turn reservation/lease, snapshot version upgrader가 각각 도입됐습니다. 개별 기능 테스트만으로는 migration·동시성·crash recovery가 서로 결합됐을 때 canonical state가 한 번만 확정되는지 보장하기 어려우므로, 실제 PostgreSQL 의미론에서 이 경계를 하나의 회귀 matrix로 묶어 M2 종료 게이트를 완성합니다.

- Closes #32

## 무엇이 바뀌나요?

- 게임 규칙·상태: GameState 규칙 자체는 변경하지 않습니다. 완료 turn 기준으로 `GameSession.currentTurn`, `GameLog.stateVersion`, snapshot turn, mutation request result turn이 일치하는지 검증합니다.
- Backend / API / DB: production 코드 변경 없이 PostgreSQL integration test를 보강합니다. Flyway V1~V8 전체 chain, idempotency retry/conflict, 동일 session/turn reservation 단일성, crash 후 lease takeover와 stale owner fencing을 검증합니다.
- AI narrative / prompt: production prompt는 변경하지 않습니다. fake `NarrativeGenerator`가 실제 `GameService -> ProviderCallTelemetry -> NarrativeGenerator` 호출 경로를 통과하도록 구성해 provider 호출 횟수를 검증합니다.
- Image generation: 변경 없음.
- Frontend / UX: 변경 없음.
- Build / deploy / docs: PostgreSQL integration test 문서를 V1~V8 및 M2 regression matrix 기준으로 최신화합니다. CI workflow 자체의 최종 변경은 없습니다.

## 책임 경계

- **서버가 결정하는 사실:** idempotency request 상태, reservation owner/lease, canonical turn commit, GameLog/snapshot/currentTurn 정합성
- **LLM이 서술하는 내용:** 테스트 fake provider가 반환하는 narrative title/story/choices
- **LLM이 변경하면 안 되는 사실:** session/turn, idempotency 완료 여부, reservation 소유권, canonical state version 및 commit 횟수

## 어떻게 검증했나요?

- [x] `./gradlew clean test`
- [x] `./gradlew build`
- [x] `cd frontend && npm ci && npm run lint && npm run build`
- [x] 정상 흐름을 직접 확인했습니다.
- [x] 잘못된 입력/실패 흐름을 확인했습니다.
- [x] 중복 요청 또는 상태 전이가 관련되면 이를 검증했습니다.
- [x] `./gradlew postgresIntegrationTest` — PostgreSQL integration 15 tests 통과
- [x] frontend `npm test` 통과

PR 생성 전 branch CI를 별도로 실행해 backend unit/H2, PostgreSQL integration, backend build, frontend test/lint/build가 모두 통과하는 것을 확인했습니다.

Pre-PR CI: https://github.com/krestar/uctale/actions/runs/33356853928

## PR 전 자체 비판적 리뷰 및 보완

PR 생성 전에 main 대비 전체 diff와 테스트 설계를 별도로 재검토했습니다.

1. **fake provider가 production 접근 경로를 우회하던 문제 보완**
   - 초기 구현은 provider 호출 횟수는 셌지만 `GameService`의 실제 provider 접근 경로를 지나지 않았습니다.
   - 정상 retry/동시성/crash 시나리오가 `GameService -> ProviderCallTelemetry -> NarrativeGenerator` 경로를 통과하도록 재구성했습니다.
2. **`/init` PostgreSQL idempotency 검증 누락 보완**
   - 초기 matrix가 `/progress` 중심이어서 `/init` completed result reuse를 실제 PostgreSQL에서 직접 검증하지 못했습니다.
   - `/init` retry와 same-key/different-payload conflict 케이스를 추가했습니다.
3. **legacy migration과 snapshot recovery 연결 보완**
   - 기존 테스트가 V6 ledger migration과 legacy snapshot compatibility를 별도로 검증해 V5 production fixture에서 latest migration + recovery라는 종료 게이트가 직접 연결되지 않았습니다.
   - V5 fixture를 V8까지 migration한 뒤 frozen v0 snapshot을 `GameStateCodec`으로 복구하는 시나리오를 추가했습니다.
4. **stale reservation owner fencing 직접 검증 추가**
   - 기존 reservation 테스트는 lease takeover까지 확인했지만 이전 owner의 canonical commit 차단은 직접 확인하지 않았습니다.
   - takeover provider가 대기 중일 때 stale owner로 `saveNextTurn`을 시도해 commit 전에 거부되는지 검증했습니다.
5. **첫 PR 전 CI에서 발견된 테스트 결함 수정**
   - custom Flyway schema history의 unversioned metadata row에서 NPE가 발생해 version-null row를 제외하도록 수정했습니다.
   - Spring proxy를 Mockito spy로 감싼 crash simulation이 충돌해 명시적인 crash delegate 방식으로 변경했습니다.

보완 후 전체 CI를 다시 실행했고 모두 통과했습니다. 최종 diff에는 production 코드 변경과 임시 CI trigger 변경이 남아 있지 않습니다.

## 게임 상태·AI 안전성

- [x] 게임의 결정적 상태는 서버에서 검증·저장됩니다.
- [x] LLM 출력만으로 HP, 보상, 성공/실패 등 결정적 상태가 임의 변경되지 않습니다.
- [x] AI 요청에 필요한 최소 문맥만 전달합니다.
- [x] AI 응답 파싱 실패와 provider 오류가 게임 상태를 오염시키지 않습니다.
- [x] 기존 저장 데이터 또는 GameState 호환성 영향을 확인했습니다.

이번 PR은 production AI 동작을 변경하지 않습니다. fake provider는 provider 호출 경계와 횟수만 검증하며 canonical state 결정에는 관여하지 않습니다.

## 보안·비용

- [x] API Key, 토큰, 비밀번호가 코드·로그·URL·클라이언트 응답에 노출되지 않습니다.
- [x] 외부 AI/Image 호출 횟수와 실패 시 동작을 검토했습니다.
- [x] 사용자 입력 길이와 외부 API 비용 증가 가능성을 검토했습니다.
- [x] CORS 또는 공개 endpoint 변경이 있다면 의도된 변경입니다.

실제 외부 provider를 호출하지 않고 fake `NarrativeGenerator`를 사용합니다. #30의 계약과 동일하게 정상 active lease 동안 중복 provider 호출은 억제하지만, provider 성공 후 process crash와 lease expiry가 발생한 경우 takeover 요청에서 provider 재호출이 일어날 수 있음을 테스트 기대값에 명시합니다.

## API·DB·운영 영향

- [x] API 계약 변경 시 Frontend 호출부와 문서를 함께 갱신했습니다.
- [x] DB schema 변경 시 migration 전략을 포함했습니다.
- [x] 환경변수는 이름과 용도만 문서화했고 실제 Secret은 포함하지 않았습니다.
- [x] 배포 후 확인할 smoke test가 있습니다.

API/DB schema/환경변수의 production 변경은 없습니다. 기존 Flyway V1~V8 migration을 실제 PostgreSQL fixture에 적용해 최신 chain과 legacy recovery를 검증합니다.

## 화면 / 응답 예시

UI/API 응답 변경 없음.