### PR TITLE
refactor(game): AvailableAction과 PlayerAction 경계 도입

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, refactor/33-player-action-boundary]
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, refactor/33-player-action-boundary]
   pull_request:
     branches: [main]
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -155,7 +155,7 @@ function App() {
     setProgressError(null)
 
     try {
-      const nextData = await progressGame(sessionId, choiceId, turnNumber, idempotencyKey)
+      const nextData = await progressGame(sessionId, choice, turnNumber, idempotencyKey)
       setGameData(nextData)
       setIsTypingComplete(false)
       setProgressError(null)

--- a/frontend/src/api/gameApi.js
+++ b/frontend/src/api/gameApi.js
@@ -19,11 +19,15 @@ export const initGame = async (worldSetting, characterSetting, idempotencyKey) =
     return response.data;
 };
 
-export const progressGame = async (sessionId, choiceId, expectedTurn, idempotencyKey) => {
+export const progressGame = async (sessionId, choice, expectedTurn, idempotencyKey) => {
     const response = await apiClient.post(`${BASE_URL}/progress`, {
         sessionId,
-        choiceId,
-        expectedTurn
+        choiceId: choice.id,
+        expectedTurn,
+        actionToken: choice.actionToken ?? null,
+        actionType: choice.actionType ?? null,
+        sourceTurn: choice.sourceTurn ?? null,
+        arguments: choice.arguments ?? null
     }, {
         headers: { 'Idempotency-Key': idempotencyKey }
     });

--- a/src/main/java/com/uctale/uctale/application/game/ChoiceCodec.java
+++ b/src/main/java/com/uctale/uctale/application/game/ChoiceCodec.java
@@ -1,12 +1,18 @@
 package com.uctale.uctale.application.game;
 
+import com.uctale.uctale.application.narrative.NarrativeTurn;
+import com.uctale.uctale.domain.action.ActionType;
+import com.uctale.uctale.domain.action.PlayerAction;
+import com.uctale.uctale.dto.GameChoice;
+import com.uctale.uctale.dto.GameProgressRequest;
+import org.springframework.stereotype.Component;
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.ObjectMapper;
-import com.uctale.uctale.dto.GameChoice;
-import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 @Component
 public class ChoiceCodec {
@@ -15,6 +21,19 @@ public class ChoiceCodec {
 
     public ChoiceCodec(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
+    }
+
+    public List<GameChoice> issue(List<NarrativeTurn.Choice> choices, int sourceTurn) {
+        return choices.stream()
+                .map(choice -> new GameChoice(
+                        choice.id(),
+                        choice.text(),
+                        UUID.randomUUID().toString(),
+                        ActionType.NARRATIVE_CHOICE.name(),
+                        sourceTurn,
+                        Map.of("choiceId", Integer.toString(choice.id()))
+                ))
+                .toList();
     }
 
     public String serialize(List<GameChoice> choices) {
@@ -33,11 +52,63 @@ public class ChoiceCodec {
         }
     }
 
+    public PlayerAction resolve(String json, GameProgressRequest request) {
+        GameChoice available = deserialize(json).stream()
+                .filter(choice -> choice.id() == request.choiceId())
+                .findFirst()
+                .orElseThrow(() -> invalidAction());
+
+        if (available.actionToken() == null || available.actionToken().isBlank()) {
+            if (request.actionToken() != null || request.actionType() != null || request.sourceTurn() != null || request.arguments() != null) {
+                throw invalidAction();
+            }
+            return new PlayerAction(
+                    available.id(),
+                    null,
+                    ActionType.NARRATIVE_CHOICE,
+                    request.expectedTurn(),
+                    Map.of("choiceId", Integer.toString(available.id())),
+                    available.text()
+            );
+        }
+
+        ActionType requestedType;
+        try {
+            requestedType = ActionType.valueOf(request.actionType());
+        } catch (RuntimeException exception) {
+            throw invalidAction();
+        }
+
+        Map<String, String> requestedArguments = request.arguments() == null ? Map.of() : Map.copyOf(request.arguments());
+        Map<String, String> availableArguments = available.arguments() == null ? Map.of() : Map.copyOf(available.arguments());
+        if (!available.actionToken().equals(request.actionToken())
+                || !available.actionType().equals(requestedType.name())
+                || available.sourceTurn() == null
+                || available.sourceTurn() != request.expectedTurn()
+                || !available.sourceTurn().equals(request.sourceTurn())
+                || !availableArguments.equals(requestedArguments)) {
+            throw invalidAction();
+        }
+
+        return new PlayerAction(
+                available.id(),
+                available.actionToken(),
+                requestedType,
+                available.sourceTurn(),
+                availableArguments,
+                available.text()
+        );
+    }
+
     public String findText(String json, int choiceId) {
         return deserialize(json).stream()
                 .filter(choice -> choice.id() == choiceId)
                 .findFirst()
                 .map(GameChoice::text)
-                .orElseThrow(() -> new InvalidChoiceException("현재 턴에서 선택할 수 없는 선택지입니다."));
+                .orElseThrow(() -> invalidAction());
+    }
+
+    private InvalidChoiceException invalidAction() {
+        return new InvalidChoiceException("현재 턴에서 서버가 허용한 행동이 아닙니다.");
     }
 }

--- a/src/main/java/com/uctale/uctale/application/game/ChoiceCodec.java
+++ b/src/main/java/com/uctale/uctale/application/game/ChoiceCodec.java
@@ -2,6 +2,7 @@ package com.uctale.uctale.application.game;
 
 import com.uctale.uctale.application.narrative.NarrativeTurn;
 import com.uctale.uctale.domain.action.ActionType;
+import com.uctale.uctale.domain.action.AvailableAction;
 import com.uctale.uctale.domain.action.PlayerAction;
 import com.uctale.uctale.dto.GameChoice;
 import com.uctale.uctale.dto.GameProgressRequest;
@@ -25,14 +26,15 @@ public class ChoiceCodec {
 
     public List<GameChoice> issue(List<NarrativeTurn.Choice> choices, int sourceTurn) {
         return choices.stream()
-                .map(choice -> new GameChoice(
+                .map(choice -> new AvailableAction(
                         choice.id(),
-                        choice.text(),
                         UUID.randomUUID().toString(),
-                        ActionType.NARRATIVE_CHOICE.name(),
+                        ActionType.NARRATIVE_CHOICE,
                         sourceTurn,
-                        Map.of("choiceId", Integer.toString(choice.id()))
+                        Map.of("choiceId", Integer.toString(choice.id())),
+                        choice.text()
                 ))
+                .map(this::toDto)
                 .toList();
     }
 
@@ -53,25 +55,16 @@ public class ChoiceCodec {
     }
 
     public PlayerAction resolve(String json, GameProgressRequest request) {
-        GameChoice available = deserialize(json).stream()
+        GameChoice storedChoice = deserialize(json).stream()
                 .filter(choice -> choice.id() == request.choiceId())
                 .findFirst()
-                .orElseThrow(() -> invalidAction());
+                .orElseThrow(this::invalidAction);
 
-        if (available.actionToken() == null || available.actionToken().isBlank()) {
-            if (request.actionToken() != null || request.actionType() != null || request.sourceTurn() != null || request.arguments() != null) {
-                throw invalidAction();
-            }
-            return new PlayerAction(
-                    available.id(),
-                    null,
-                    ActionType.NARRATIVE_CHOICE,
-                    request.expectedTurn(),
-                    Map.of("choiceId", Integer.toString(available.id())),
-                    available.text()
-            );
+        if (storedChoice.actionToken() == null || storedChoice.actionToken().isBlank()) {
+            return resolveLegacy(storedChoice, request);
         }
 
+        AvailableAction available = toDomain(storedChoice);
         ActionType requestedType;
         try {
             requestedType = ActionType.valueOf(request.actionType());
@@ -80,23 +73,22 @@ public class ChoiceCodec {
         }
 
         Map<String, String> requestedArguments = request.arguments() == null ? Map.of() : Map.copyOf(request.arguments());
-        Map<String, String> availableArguments = available.arguments() == null ? Map.of() : Map.copyOf(available.arguments());
-        if (!available.actionToken().equals(request.actionToken())
-                || !available.actionType().equals(requestedType.name())
-                || available.sourceTurn() == null
+        if (!available.token().equals(request.actionToken())
+                || available.type() != requestedType
                 || available.sourceTurn() != request.expectedTurn()
-                || !available.sourceTurn().equals(request.sourceTurn())
-                || !availableArguments.equals(requestedArguments)) {
+                || request.sourceTurn() == null
+                || available.sourceTurn() != request.sourceTurn()
+                || !available.arguments().equals(requestedArguments)) {
             throw invalidAction();
         }
 
         return new PlayerAction(
-                available.id(),
-                available.actionToken(),
-                requestedType,
+                available.legacyChoiceId(),
+                available.token(),
+                available.type(),
                 available.sourceTurn(),
-                availableArguments,
-                available.text()
+                available.arguments(),
+                available.displayText()
         );
     }
 
@@ -105,7 +97,47 @@ public class ChoiceCodec {
                 .filter(choice -> choice.id() == choiceId)
                 .findFirst()
                 .map(GameChoice::text)
-                .orElseThrow(() -> invalidAction());
+                .orElseThrow(this::invalidAction);
+    }
+
+    private PlayerAction resolveLegacy(GameChoice storedChoice, GameProgressRequest request) {
+        if (request.actionToken() != null || request.actionType() != null || request.sourceTurn() != null || request.arguments() != null) {
+            throw invalidAction();
+        }
+        return new PlayerAction(
+                storedChoice.id(),
+                null,
+                ActionType.NARRATIVE_CHOICE,
+                request.expectedTurn(),
+                Map.of("choiceId", Integer.toString(storedChoice.id())),
+                storedChoice.text()
+        );
+    }
+
+    private AvailableAction toDomain(GameChoice choice) {
+        try {
+            return new AvailableAction(
+                    choice.id(),
+                    choice.actionToken(),
+                    ActionType.valueOf(choice.actionType()),
+                    choice.sourceTurn() == null ? 0 : choice.sourceTurn(),
+                    choice.arguments(),
+                    choice.text()
+            );
+        } catch (RuntimeException exception) {
+            throw invalidAction();
+        }
+    }
+
+    private GameChoice toDto(AvailableAction action) {
+        return new GameChoice(
+                action.legacyChoiceId(),
+                action.displayText(),
+                action.token(),
+                action.type().name(),
+                action.sourceTurn(),
+                action.arguments()
+        );
     }
 
     private InvalidChoiceException invalidAction() {

--- a/src/main/java/com/uctale/uctale/application/game/ChoiceCodec.java
+++ b/src/main/java/com/uctale/uctale/application/game/ChoiceCodec.java
@@ -60,11 +60,24 @@ public class ChoiceCodec {
                 .findFirst()
                 .orElseThrow(this::invalidAction);
 
+        boolean legacyWireRequest = request.actionToken() == null
+                && request.actionType() == null
+                && request.sourceTurn() == null
+                && request.arguments() == null;
+
         if (storedChoice.actionToken() == null || storedChoice.actionToken().isBlank()) {
-            return resolveLegacy(storedChoice, request);
+            if (!legacyWireRequest) throw invalidAction();
+            return legacyPlayerAction(storedChoice, request.expectedTurn());
         }
 
         AvailableAction available = toDomain(storedChoice);
+        if (available.sourceTurn() != request.expectedTurn()) {
+            throw invalidAction();
+        }
+        if (legacyWireRequest) {
+            return playerActionFrom(available);
+        }
+
         ActionType requestedType;
         try {
             requestedType = ActionType.valueOf(request.actionType());
@@ -72,24 +85,21 @@ public class ChoiceCodec {
             throw invalidAction();
         }
 
-        Map<String, String> requestedArguments = request.arguments() == null ? Map.of() : Map.copyOf(request.arguments());
+        Map<String, String> requestedArguments;
+        try {
+            requestedArguments = request.arguments() == null ? Map.of() : Map.copyOf(request.arguments());
+        } catch (RuntimeException exception) {
+            throw invalidAction();
+        }
         if (!available.token().equals(request.actionToken())
                 || available.type() != requestedType
-                || available.sourceTurn() != request.expectedTurn()
                 || request.sourceTurn() == null
                 || available.sourceTurn() != request.sourceTurn()
                 || !available.arguments().equals(requestedArguments)) {
             throw invalidAction();
         }
 
-        return new PlayerAction(
-                available.legacyChoiceId(),
-                available.token(),
-                available.type(),
-                available.sourceTurn(),
-                available.arguments(),
-                available.displayText()
-        );
+        return playerActionFrom(available);
     }
 
     public String findText(String json, int choiceId) {
@@ -100,17 +110,25 @@ public class ChoiceCodec {
                 .orElseThrow(this::invalidAction);
     }
 
-    private PlayerAction resolveLegacy(GameChoice storedChoice, GameProgressRequest request) {
-        if (request.actionToken() != null || request.actionType() != null || request.sourceTurn() != null || request.arguments() != null) {
-            throw invalidAction();
-        }
+    private PlayerAction legacyPlayerAction(GameChoice storedChoice, int expectedTurn) {
         return new PlayerAction(
                 storedChoice.id(),
                 null,
                 ActionType.NARRATIVE_CHOICE,
-                request.expectedTurn(),
+                expectedTurn,
                 Map.of("choiceId", Integer.toString(storedChoice.id())),
                 storedChoice.text()
+        );
+    }
+
+    private PlayerAction playerActionFrom(AvailableAction available) {
+        return new PlayerAction(
+                available.legacyChoiceId(),
+                available.token(),
+                available.type(),
+                available.sourceTurn(),
+                available.arguments(),
+                available.displayText()
         );
     }
 

--- a/src/main/java/com/uctale/uctale/application/game/GameMutationFingerprint.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameMutationFingerprint.java
@@ -18,6 +18,19 @@ public class GameMutationFingerprint {
     }
 
     public String progress(GameProgressRequest request) {
+        boolean legacyWireRequest = request.actionToken() == null
+                && request.actionType() == null
+                && request.sourceTurn() == null
+                && request.arguments() == null;
+        if (legacyWireRequest) {
+            return sha256(join(
+                    "progress",
+                    Long.toString(request.sessionId()),
+                    Integer.toString(request.choiceId()),
+                    Integer.toString(request.expectedTurn())
+            ));
+        }
+
         return sha256(join(
                 "progress",
                 Long.toString(request.sessionId()),

--- a/src/main/java/com/uctale/uctale/application/game/GameMutationFingerprint.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameMutationFingerprint.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Component;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Map;
+import java.util.TreeMap;
 
 @Component
 public class GameMutationFingerprint {
@@ -20,8 +22,27 @@ public class GameMutationFingerprint {
                 "progress",
                 Long.toString(request.sessionId()),
                 Integer.toString(request.choiceId()),
-                Integer.toString(request.expectedTurn())
+                Integer.toString(request.expectedTurn()),
+                nullable(request.actionToken()),
+                nullable(request.actionType()),
+                request.sourceTurn() == null ? "" : Integer.toString(request.sourceTurn()),
+                canonicalArguments(request.arguments())
         ));
+    }
+
+    private String canonicalArguments(Map<String, String> arguments) {
+        if (arguments == null || arguments.isEmpty()) return "";
+        StringBuilder builder = new StringBuilder();
+        new TreeMap<>(arguments).forEach((key, value) -> builder
+                .append(key.length()).append(':').append(key)
+                .append('=')
+                .append(value == null ? -1 : value.length()).append(':').append(value == null ? "" : value)
+                .append('|'));
+        return builder.toString();
+    }
+
+    private String nullable(String value) {
+        return value == null ? "" : value;
     }
 
     private String normalize(String value) {

--- a/src/main/java/com/uctale/uctale/domain/action/ActionType.java
+++ b/src/main/java/com/uctale/uctale/domain/action/ActionType.java
@@ -1,0 +1,5 @@
+package com.uctale.uctale.domain.action;
+
+public enum ActionType {
+    NARRATIVE_CHOICE
+}

--- a/src/main/java/com/uctale/uctale/domain/action/AvailableAction.java
+++ b/src/main/java/com/uctale/uctale/domain/action/AvailableAction.java
@@ -1,0 +1,25 @@
+package com.uctale.uctale.domain.action;
+
+import java.util.Map;
+import java.util.Objects;
+
+public record AvailableAction(
+        int legacyChoiceId,
+        String token,
+        ActionType type,
+        int sourceTurn,
+        Map<String, String> arguments,
+        String displayText
+) {
+    public AvailableAction {
+        if (legacyChoiceId <= 0) throw new IllegalArgumentException("choice ID는 양수여야 합니다.");
+        Objects.requireNonNull(type, "action type은 필수입니다.");
+        if (sourceTurn <= 0) throw new IllegalArgumentException("source turn은 양수여야 합니다.");
+        arguments = arguments == null ? Map.of() : Map.copyOf(arguments);
+        if (displayText == null || displayText.isBlank()) throw new IllegalArgumentException("action 표시 문구는 필수입니다.");
+    }
+
+    public boolean isLegacy() {
+        return token == null || token.isBlank();
+    }
+}

--- a/src/main/java/com/uctale/uctale/domain/action/PlayerAction.java
+++ b/src/main/java/com/uctale/uctale/domain/action/PlayerAction.java
@@ -1,0 +1,21 @@
+package com.uctale.uctale.domain.action;
+
+import java.util.Map;
+import java.util.Objects;
+
+public record PlayerAction(
+        int legacyChoiceId,
+        String token,
+        ActionType type,
+        int sourceTurn,
+        Map<String, String> arguments,
+        String displayText
+) {
+    public PlayerAction {
+        if (legacyChoiceId <= 0) throw new IllegalArgumentException("choice ID는 양수여야 합니다.");
+        Objects.requireNonNull(type, "action type은 필수입니다.");
+        if (sourceTurn <= 0) throw new IllegalArgumentException("source turn은 양수여야 합니다.");
+        arguments = arguments == null ? Map.of() : Map.copyOf(arguments);
+        if (displayText == null || displayText.isBlank()) throw new IllegalArgumentException("action 표시 문구는 필수입니다.");
+    }
+}

--- a/src/main/java/com/uctale/uctale/dto/GameChoice.java
+++ b/src/main/java/com/uctale/uctale/dto/GameChoice.java
@@ -1,3 +1,16 @@
 package com.uctale.uctale.dto;
 
-public record GameChoice(int id, String text) {}
+import java.util.Map;
+
+public record GameChoice(
+        int id,
+        String text,
+        String actionToken,
+        String actionType,
+        Integer sourceTurn,
+        Map<String, String> arguments
+) {
+    public GameChoice(int id, String text) {
+        this(id, text, null, null, null, null);
+    }
+}

--- a/src/main/java/com/uctale/uctale/dto/GameProgressRequest.java
+++ b/src/main/java/com/uctale/uctale/dto/GameProgressRequest.java
@@ -3,6 +3,8 @@ package com.uctale.uctale.dto;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
+import java.util.Map;
+
 public record GameProgressRequest(
         @NotNull(message = "세션 ID는 필수입니다.")
         @Positive(message = "세션 ID는 양수여야 합니다.")
@@ -12,5 +14,14 @@ public record GameProgressRequest(
         int choiceId,
 
         @Positive(message = "기대 턴은 양수여야 합니다.")
-        int expectedTurn
-) {}
+        int expectedTurn,
+
+        String actionToken,
+        String actionType,
+        Integer sourceTurn,
+        Map<String, String> arguments
+) {
+    public GameProgressRequest(Long sessionId, int choiceId, int expectedTurn) {
+        this(sessionId, choiceId, expectedTurn, null, null, null, null);
+    }
+}

--- a/src/main/java/com/uctale/uctale/service/GameService.java
+++ b/src/main/java/com/uctale/uctale/service/GameService.java
@@ -15,6 +15,7 @@ import com.uctale.uctale.application.narrative.InvalidNarrativeResponseException
 import com.uctale.uctale.application.narrative.NarrativeContext;
 import com.uctale.uctale.application.narrative.NarrativeGenerator;
 import com.uctale.uctale.application.narrative.NarrativeTurn;
+import com.uctale.uctale.domain.action.PlayerAction;
 import com.uctale.uctale.domain.game.GameState;
 import com.uctale.uctale.dto.GameChoice;
 import com.uctale.uctale.dto.GameInitRequest;
@@ -69,7 +70,7 @@ public class GameService {
                     () -> narrativeGenerator.createOpening(request.worldSetting(), request.characterSetting())
             );
             validateNarrativeTurn(opening);
-            List<GameChoice> choices = toGameChoices(opening.choices());
+            List<GameChoice> choices = choiceCodec.issue(opening.choices(), 1);
 
             String imagePrompt = imagePromptComposer.compose(opening.visualAssets());
             if (imagePrompt == null || imagePrompt.isBlank()) {
@@ -111,7 +112,8 @@ public class GameService {
                     request.expectedTurn() + 1, costContext.idempotencyKey()
             );
 
-            String userChoiceText = choiceCodec.findText(loadedTurn.choicesJson(), request.choiceId());
+            PlayerAction playerAction = choiceCodec.resolve(loadedTurn.choicesJson(), request);
+            String userChoiceText = playerAction.displayText();
             NarrativeContext narrativeContext = NarrativeContext.from(loadedTurn.gameState(), userChoiceText);
             costRateLimiter.check(CostOperation.NARRATIVE, providerContext);
             NarrativeTurn nextTurn = providerCallTelemetry.observe(
@@ -119,7 +121,7 @@ public class GameService {
                     () -> narrativeGenerator.createNextTurn(narrativeContext)
             );
             validateNarrativeTurn(nextTurn);
-            List<GameChoice> choices = toGameChoices(nextTurn.choices());
+            List<GameChoice> choices = choiceCodec.issue(nextTurn.choices(), request.expectedTurn() + 1);
 
             ImageAssetService.AssetReference imageAsset = null;
             String imageUrl = loadedTurn.imageUrl();
@@ -135,7 +137,7 @@ public class GameService {
 
             GameState nextState = loadedTurn.gameState().advance(userChoiceText, nextTurn.storyText());
             GameTurnCommit commit = new GameTurnCommit(
-                    request.expectedTurn(), request.choiceId(), userChoiceText, loadedTurn.gameState(), nextState,
+                    request.expectedTurn(), playerAction.legacyChoiceId(), userChoiceText, loadedTurn.gameState(), nextState,
                     nextTurn.storyText(), choiceCodec.serialize(choices), imageAsset
             );
 
@@ -193,9 +195,5 @@ public class GameService {
 
     private GameResponse toResponse(Long sessionId, int turnNumber, NarrativeTurn turn, List<GameChoice> choices, String imageUrl) {
         return new GameResponse(sessionId, turnNumber, turn.title(), turn.storyText(), choices, imageUrl);
-    }
-
-    private List<GameChoice> toGameChoices(List<NarrativeTurn.Choice> choices) {
-        return choices.stream().map(choice -> new GameChoice(choice.id(), choice.text())).toList();
     }
 }

--- a/src/test/java/com/uctale/uctale/application/game/ChoiceCodecTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/ChoiceCodecTest.java
@@ -1,0 +1,96 @@
+package com.uctale.uctale.application.game;
+
+import com.uctale.uctale.application.narrative.NarrativeTurn;
+import com.uctale.uctale.domain.action.ActionType;
+import com.uctale.uctale.domain.action.PlayerAction;
+import com.uctale.uctale.dto.GameChoice;
+import com.uctale.uctale.dto.GameProgressRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ChoiceCodecTest {
+
+    private ChoiceCodec codec;
+
+    @BeforeEach
+    void setUp() {
+        codec = new ChoiceCodec(new ObjectMapper());
+    }
+
+    @Test
+    @DisplayName("서버가 발급한 action은 token type sourceTurn arguments가 모두 일치할 때만 PlayerAction으로 변환된다")
+    void issuedActionResolvesOnlyWithExactContract() {
+        GameChoice issued = codec.issue(List.of(new NarrativeTurn.Choice(7, "문을 잠근다")), 3).getFirst();
+        String stored = codec.serialize(List.of(issued));
+        GameProgressRequest request = new GameProgressRequest(
+                42L,
+                issued.id(),
+                3,
+                issued.actionToken(),
+                issued.actionType(),
+                issued.sourceTurn(),
+                issued.arguments()
+        );
+
+        PlayerAction action = codec.resolve(stored, request);
+
+        assertThat(action.type()).isEqualTo(ActionType.NARRATIVE_CHOICE);
+        assertThat(action.sourceTurn()).isEqualTo(3);
+        assertThat(action.displayText()).isEqualTo("문을 잠근다");
+        assertThat(action.arguments()).containsEntry("choiceId", "7");
+    }
+
+    @Test
+    @DisplayName("action token type arguments 변조는 현재 턴 행동으로 인정하지 않는다")
+    void tamperedActionIsRejected() {
+        GameChoice issued = codec.issue(List.of(new NarrativeTurn.Choice(7, "문을 잠근다")), 3).getFirst();
+        String stored = codec.serialize(List.of(issued));
+
+        assertThatThrownBy(() -> codec.resolve(stored, new GameProgressRequest(
+                42L, 7, 3, "tampered", issued.actionType(), issued.sourceTurn(), issued.arguments()
+        ))).isInstanceOf(InvalidChoiceException.class);
+
+        assertThatThrownBy(() -> codec.resolve(stored, new GameProgressRequest(
+                42L, 7, 3, issued.actionToken(), "USE_ITEM", issued.sourceTurn(), issued.arguments()
+        ))).isInstanceOf(InvalidChoiceException.class);
+
+        assertThatThrownBy(() -> codec.resolve(stored, new GameProgressRequest(
+                42L, 7, 3, issued.actionToken(), issued.actionType(), issued.sourceTurn(), Map.of("choiceId", "8")
+        ))).isInstanceOf(InvalidChoiceException.class);
+    }
+
+    @Test
+    @DisplayName("이전 턴에서 발급된 action은 현재 턴에 재사용할 수 없다")
+    void expiredActionIsRejected() {
+        GameChoice issued = codec.issue(List.of(new NarrativeTurn.Choice(7, "문을 잠근다")), 2).getFirst();
+        String stored = codec.serialize(List.of(issued));
+
+        assertThatThrownBy(() -> codec.resolve(stored, new GameProgressRequest(
+                42L, 7, 3, issued.actionToken(), issued.actionType(), issued.sourceTurn(), issued.arguments()
+        ))).isInstanceOf(InvalidChoiceException.class);
+    }
+
+    @Test
+    @DisplayName("action metadata가 없는 기존 저장 선택지는 legacy compatibility adapter로만 수락한다")
+    void legacyChoiceUsesCompatibilityAdapter() {
+        String stored = codec.serialize(List.of(new GameChoice(7, "문을 잠근다")));
+
+        PlayerAction action = codec.resolve(stored, new GameProgressRequest(42L, 7, 3));
+
+        assertThat(action.type()).isEqualTo(ActionType.NARRATIVE_CHOICE);
+        assertThat(action.sourceTurn()).isEqualTo(3);
+        assertThat(action.displayText()).isEqualTo("문을 잠근다");
+
+        assertThatThrownBy(() -> codec.resolve(stored, new GameProgressRequest(
+                42L, 7, 3, "invented", ActionType.NARRATIVE_CHOICE.name(), 3, Map.of("choiceId", "7")
+        ))).isInstanceOf(InvalidChoiceException.class);
+    }
+}


### PR DESCRIPTION
## 왜 필요한가요?

현재 선택지는 Narrative provider가 만든 ID·문구를 서버가 그대로 다음 진행 입력으로 사용합니다. 이후 Attack, UseItem 같은 규칙 행동을 추가할 때 arbitrary text나 변조된 payload가 규칙 실행으로 이어지지 않도록, LLM의 선택지 제안과 서버가 실제로 허용한 행동 사이에 명시적인 경계가 필요합니다.

이번 변경은 기존 선택형 플레이를 유지하면서 `AvailableAction`과 `PlayerAction`을 도입해 현재 턴의 서버 발급 행동만 다음 진행 입력으로 해석할 수 있는 기반을 만듭니다.

- Closes #33

## 무엇이 바뀌나요?

- 게임 규칙·상태: `ActionType`, `AvailableAction`, `PlayerAction`을 추가했습니다. Narrative 선택지는 `NARRATIVE_CHOICE` 후보로 받은 뒤 서버가 token, source turn, arguments를 붙여 `AvailableAction`으로 다시 발급합니다.
- Backend / API / DB: `GameChoice` 응답과 `GameProgressRequest`에 `actionToken`, `actionType`, `sourceTurn`, `arguments`를 추가했습니다. 신규 요청은 저장된 현재 턴 action과 전체 metadata가 일치해야 하며, 기존 `choiceId + expectedTurn` 요청은 현재 서버에 저장된 action ID만 조회하는 compatibility adapter로 유지합니다. DB schema 변경은 없으며 기존 `choices_json`에 action metadata가 추가 저장됩니다.
- AI narrative / prompt: prompt 자체는 변경하지 않습니다. LLM이 만든 choice는 실행 가능한 행동이 아니라 후보이며, 서버가 `AvailableAction`으로 발급한 뒤에만 다음 턴 입력으로 해석됩니다.
- Image generation: 변경 없음.
- Frontend / UX: UI 표현은 유지하고, 선택 시 서버가 응답한 action metadata 전체를 progress 요청에 다시 전달합니다.
- Build / deploy / docs: 환경변수나 배포 설정 변경은 없습니다. PR 전 검증을 위해 임시로 사용한 branch CI trigger는 최종 diff에서 제거했습니다.

## 책임 경계

- **서버가 결정하는 사실:** action type, action token, source turn, typed arguments, 현재 턴에서 허용된 action 집합, 요청을 `PlayerAction`으로 수락할지 여부
- **LLM이 서술하는 내용:** 선택지의 표시 문구와 narrative 후보 제안
- **LLM이 변경하면 안 되는 사실:** action token/type/sourceTurn/arguments, 현재 턴에서 실행 가능한 행동 여부, 서버가 확정한 `PlayerAction`

## 어떻게 검증했나요?

- [x] `./gradlew clean test`
- [x] `./gradlew build`
- [x] `cd frontend && npm ci && npm run lint && npm run build`
- [x] 정상 흐름을 직접 확인했습니다.
- [x] 잘못된 입력/실패 흐름을 확인했습니다.
- [x] 중복 요청 또는 상태 전이가 관련되면 이를 검증했습니다.
- [x] `./gradlew postgresIntegrationTest`
- [x] `cd frontend && npm test`

`ChoiceCodecTest`에서 정상 서버 발급 action, token/type/arguments 변조, 오래된 source turn, legacy 저장 선택지 호환을 검증했습니다. 기존 M2 PostgreSQL idempotency/concurrency/recovery matrix도 그대로 통과해 action metadata 도입이 canonical turn 처리와 충돌하지 않는 것을 확인했습니다.

최종 보완 후 PR 전 CI 전체 성공: https://github.com/krestar/uctale/actions/runs/33358164044

## PR 전 자체 비판적 리뷰 및 보완

PR 생성 전에 main 대비 전체 diff와 action 경계를 별도로 재검토했습니다.

1. **`AvailableAction`이 장식용 타입이 될 가능성 보완**
   - 최초 구현은 타입을 추가했지만 발급 과정에서 DTO를 직접 생성해 도메인 경계를 실질적으로 통과하지 않았습니다.
   - `NarrativeTurn.Choice -> AvailableAction -> GameChoice DTO` 순서로 재구성하고, 요청도 저장된 DTO를 `AvailableAction`으로 복원한 뒤 `PlayerAction`으로 변환하도록 수정했습니다.
2. **기존 선택형 요청과의 호환성 보완**
   - 신규 metadata를 무조건 필수로 만들면 기존 backend/integration 호출부와 배포 전 저장 데이터의 진행 경로가 즉시 깨집니다.
   - metadata가 전혀 없는 기존 wire shape는 현재 턴에 서버가 저장한 action ID와 source turn을 기준으로만 허용하는 compatibility adapter를 두었습니다. 임의 ID나 현재 턴에 없는 ID는 여전히 provider 호출 전에 거절됩니다.
3. **기존 idempotency fingerprint 호환성 보완**
   - action metadata의 빈 값을 기존 fingerprint 계산에 추가하면 배포 전에 생성된 progress mutation request retry가 같은 요청인데도 conflict가 될 수 있었습니다.
   - metadata가 없는 legacy 요청에는 기존 fingerprint 공식을 그대로 유지하고, 신규 action 요청에만 token/type/sourceTurn/arguments를 fingerprint에 포함하도록 수정했습니다.
4. **검증 시점 재확인**
   - `ChoiceCodec.resolve()`를 Narrative provider 호출 전에 수행하도록 유지해 token/type/sourceTurn/arguments 변조가 provider 비용이나 state advance로 이어지지 않도록 확인했습니다.
5. **최종 변경 기준으로 CI 재검증**
   - 위 보완 이후 backend unit test, PostgreSQL integration test, backend build, frontend test/lint/build를 다시 실행해 모두 성공했습니다.
   - 임시 CI trigger는 복원했으며 최종 main 대비 diff에는 workflow 변경이 없습니다.

현재 코드 기준으로 merge를 막아야 할 추가 결함은 발견하지 못했습니다.

## 게임 상태·AI 안전성

- [x] 게임의 결정적 상태는 서버에서 검증·저장됩니다.
- [x] LLM 출력만으로 HP, 보상, 성공/실패 등 결정적 상태가 임의 변경되지 않습니다.
- [x] AI 요청에 필요한 최소 문맥만 전달합니다.
- [x] AI 응답 파싱 실패와 provider 오류가 게임 상태를 오염시키지 않습니다.
- [x] 기존 저장 데이터 또는 GameState 호환성 영향을 확인했습니다.

LLM의 choice ID와 문구는 후보일 뿐이며, 서버가 별도의 action metadata를 발급합니다. 신규 action metadata가 있는 요청은 저장된 현재 턴 action과 일치해야 하고, legacy 데이터는 metadata가 없는 경우에만 compatibility adapter를 사용합니다.

## 보안·비용

- [x] API Key, 토큰, 비밀번호가 코드·로그·URL·클라이언트 응답에 노출되지 않습니다.
- [x] 외부 AI/Image 호출 횟수와 실패 시 동작을 검토했습니다.
- [x] 사용자 입력 길이와 외부 API 비용 증가 가능성을 검토했습니다.
- [x] CORS 또는 공개 endpoint 변경이 있다면 의도된 변경입니다.

변조되거나 만료된 action은 Narrative provider 호출 전에 `INVALID_CHOICE`로 거절됩니다. 자유 텍스트 action 입력은 추가하지 않았고 현재 arguments도 서버가 발급한 최소 map과 정확히 일치해야 합니다.

## API·DB·운영 영향

- [x] API 계약 변경 시 Frontend 호출부와 문서를 함께 갱신했습니다.
- [x] DB schema 변경 시 migration 전략을 포함했습니다.
- [x] 환경변수는 이름과 용도만 문서화했고 실제 Secret은 포함하지 않았습니다.
- [x] 배포 후 확인할 smoke test가 있습니다.

API 변경은 additive입니다. `GameChoice`와 `/progress` 요청에 action metadata가 추가되며 frontend가 이를 그대로 전달합니다. DB schema 변경은 없어 migration은 필요하지 않습니다. 기존 `choices_json`은 새 필드가 없는 형태도 역직렬화되며 compatibility adapter로 처리됩니다.

배포 후에는 게임 시작 응답의 choice에 action metadata가 포함되는지, 정상 선택이 다음 턴으로 진행되는지, token/type/sourceTurn/arguments를 변조한 요청이 422 `INVALID_CHOICE`로 거절되는지 확인합니다.

## 화면 / 응답 예시

UI 변화는 없습니다. 신규 choice 응답은 다음과 같은 additive metadata를 포함합니다.

```json
{
  "id": 1,
  "text": "문을 연다",
  "actionToken": "<server-issued-token>",
  "actionType": "NARRATIVE_CHOICE",
  "sourceTurn": 1,
  "arguments": {
    "choiceId": "1"
  }
}
```