### PR TITLE
ci: production post-deploy smoke check 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
+      - name: Validate production smoke script syntax
+        run: bash -n scripts/production-smoke.sh
+
       - name: Set up Java 21
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -1,0 +1,62 @@
+name: Production Smoke
+
+on:
+  status:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-smoke
+  cancel-in-progress: true
+
+env:
+  UCTALE_SMOKE_FRONTEND_URL: https://uctale.vercel.app
+  UCTALE_SMOKE_BACKEND_URL: https://uctale.onrender.com/api/game
+  UCTALE_SMOKE_ORIGIN: https://uctale.vercel.app
+
+jobs:
+  production-smoke:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.context == 'Vercel' && github.event.state == 'success')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: 현재 main checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - name: Vercel status가 현재 main 배포인지 확인
+        id: deployment
+        shell: bash
+        env:
+          STATUS_SHA: ${{ github.event.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "수동 production smoke를 실행합니다."
+            exit 0
+          fi
+
+          main_sha="$(git rev-parse HEAD)"
+          if [[ "$STATUS_SHA" != "$main_sha" ]]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "Vercel status SHA가 현재 main HEAD와 달라 smoke를 건너뜁니다."
+            exit 0
+          fi
+
+          echo "run=true" >> "$GITHUB_OUTPUT"
+          echo "현재 main의 Vercel production 배포 완료를 확인했습니다."
+
+      - name: production smoke 실행
+        if: steps.deployment.outputs.run == 'true'
+        shell: bash
+        env:
+          UCTALE_SMOKE_ACCESS_PASSWORD: ${{ secrets.PRODUCTION_SMOKE_ACCESS_PASSWORD }}
+        run: bash scripts/production-smoke.sh

--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: 현재 main checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 1

--- a/docs/operations/production-smoke.md
+++ b/docs/operations/production-smoke.md
@@ -1,0 +1,81 @@
+# Production post-deploy smoke
+
+UCTale의 일반 CI는 테스트, lint, build를 검증하지만 실제 Vercel frontend와 Render backend 사이의 production CORS·credential 동작까지 보장하지는 않습니다.
+
+`Production Smoke` workflow는 Vercel이 현재 `main` commit에 production deployment 성공 status를 기록한 뒤 별도의 GitHub Actions run으로 실행됩니다. 일반 CI와 run 이름을 분리해 production 회귀를 빠르게 식별합니다.
+
+## 자동 검증 범위
+
+자동 smoke는 외부 AI provider를 호출하지 않습니다.
+
+1. `https://uctale.vercel.app/`이 HTTP 200을 반환하고 UCTale root markup을 제공하는지 확인합니다.
+2. Render backend의 `/api/game/access-session`에 production origin으로 CORS preflight를 보내 다음 계약을 확인합니다.
+   - `Access-Control-Allow-Origin: https://uctale.vercel.app`
+   - `Access-Control-Allow-Credentials: true`
+3. `/api/game/verify-password`로 공유 접근 세션을 발급받고 다음을 확인합니다.
+   - HTTP 204
+   - production CORS credential 계약
+   - `uctale_access`, `uctale_owner` HttpOnly session cookie가 발급 가능한 상태
+4. 발급된 cookie jar를 `/api/game/access-session`에 재전송해 실제 credential 검증 경로가 HTTP 204를 반환하는지 확인합니다.
+
+이 흐름은 frontend 가용성, backend 가용성, CORS allowlist, cross-origin credential 발급·재사용을 production 구성 그대로 검증합니다.
+
+## 비용 정책
+
+자동 post-deploy smoke에서는 `/init`, `/progress`, image generation을 호출하지 않습니다. 이 경로들은 Gemini 또는 Pollinations provider 비용이 발생할 수 있으므로 코드 push마다 자동 반복하지 않습니다.
+
+따라서 자동 smoke의 provider 호출 수는 항상 0회입니다. 실제 narrative 생성, 턴 진행, image asset 생성은 기능 변경 또는 M2 종료 검증 시 수동 smoke 대상으로 유지합니다.
+
+## GitHub Actions secret
+
+Repository Actions secret에 다음 값을 한 번 등록해야 합니다.
+
+- `PRODUCTION_SMOKE_ACCESS_PASSWORD`: 현재 production `GAME_ACCESS_PASSWORD`와 같은 공유 베타 비밀번호
+
+workflow와 스크립트는 secret 값을 출력하지 않습니다. 비밀번호 JSON과 cookie jar는 runner의 임시 디렉터리에만 만들고 종료 시 삭제합니다. response의 `Set-Cookie` header나 cookie 값도 로그에 출력하지 않습니다.
+
+## 실행 조건
+
+자동 실행:
+
+- GitHub `status` event의 context가 `Vercel`
+- status가 `success`
+- status 대상 SHA가 실행 시점의 현재 `main` HEAD와 동일
+
+오래된 deployment가 늦게 완료되어 status가 도착해도 현재 `main`과 SHA가 다르면 smoke를 건너뜁니다.
+
+수동 실행:
+
+- GitHub Actions의 `Production Smoke` workflow에서 `workflow_dispatch`로 실행할 수 있습니다.
+
+## 실패 로그
+
+스크립트는 단계와 HTTP status, 공개 origin 같은 진단 정보만 출력합니다. 비밀번호, access token, owner token, cookie header 전문은 출력하지 않습니다.
+
+실패는 `Production Smoke`라는 독립 workflow run으로 표시되므로 일반 `CI` 실패와 구분됩니다.
+
+## 수동 smoke로 남기는 범위
+
+다음 항목은 #70 자동화 범위 밖에 둡니다.
+
+- 실제 `/init` narrative 생성
+- 실제 `/progress` 턴 진행
+- 실제 image asset provider fetch
+- 브라우저 UI interaction과 visual regression
+- production 실패 시 자동 rollback
+
+이 항목은 provider 비용 또는 브라우저 수준 검증이 필요합니다. 관련 기능을 변경했거나 milestone 종료 게이트를 확인할 때 수동으로 검증합니다.
+
+## 로컬 실행
+
+production과 같은 공유 비밀번호를 환경변수로 전달하면 같은 스크립트를 직접 실행할 수 있습니다.
+
+```bash
+UCTALE_SMOKE_ACCESS_PASSWORD='...' bash scripts/production-smoke.sh
+```
+
+공개 endpoint를 다른 환경에서 검증해야 할 때만 다음 환경변수를 덮어씁니다.
+
+- `UCTALE_SMOKE_FRONTEND_URL`
+- `UCTALE_SMOKE_BACKEND_URL`
+- `UCTALE_SMOKE_ORIGIN`

--- a/scripts/production-smoke.sh
+++ b/scripts/production-smoke.sh
@@ -22,9 +22,11 @@ chmod 700 "$TMP_DIR"
 curl_common=(
   --silent
   --show-error
-  --location
   --connect-timeout 10
   --max-time 45
+)
+
+curl_retry=(
   --retry 3
   --retry-delay 5
   --retry-all-errors
@@ -38,7 +40,6 @@ fail() {
 header_value() {
   local name="$1"
   awk -v target="$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" '
-    BEGIN { IGNORECASE = 1 }
     {
       line = $0
       sub(/\r$/, "", line)
@@ -62,6 +63,27 @@ assert_cors_headers() {
   [[ "${allow_credentials,,}" == "true" ]] || fail "Access-Control-Allow-Credentials가 true가 아닙니다."
 }
 
+assert_cross_site_cookie() {
+  local cookie_name="$1"
+  local cookie_line
+  cookie_line="$(awk -v prefix="Set-Cookie: ${cookie_name}=" '
+    BEGIN { IGNORECASE = 1 }
+    index(tolower($0), tolower(prefix)) == 1 {
+      sub(/\r$/, "")
+      print
+      exit
+    }
+  ' "$RESPONSE_HEADERS")"
+
+  [[ -n "$cookie_line" ]] || fail "${cookie_name} Set-Cookie header가 없습니다."
+  local attributes="${cookie_line#*;}"
+  local normalized="${attributes,,}"
+  [[ "$normalized" == *"httponly"* ]] || fail "${cookie_name} 쿠키에 HttpOnly가 없습니다."
+  [[ "$normalized" == *"secure"* ]] || fail "${cookie_name} 쿠키에 Secure가 없습니다."
+  [[ "$normalized" == *"samesite=none"* ]] || fail "${cookie_name} 쿠키가 cross-site SameSite=None 계약을 만족하지 않습니다."
+  [[ "$normalized" == *"path=/api/game"* ]] || fail "${cookie_name} 쿠키 path가 /api/game이 아닙니다."
+}
+
 request() {
   : > "$RESPONSE_HEADERS"
   : > "$RESPONSE_BODY"
@@ -72,14 +94,24 @@ request() {
     "$@"
 }
 
+request_with_retry() {
+  : > "$RESPONSE_HEADERS"
+  : > "$RESPONSE_BODY"
+  curl "${curl_common[@]}" "${curl_retry[@]}" \
+    --dump-header "$RESPONSE_HEADERS" \
+    --output "$RESPONSE_BODY" \
+    --write-out '%{http_code}' \
+    "$@"
+}
+
 echo "[smoke] 1/4 production frontend 응답 확인"
-frontend_status="$(request "$FRONTEND_URL/")"
+frontend_status="$(request_with_retry "$FRONTEND_URL/")"
 [[ "$frontend_status" == "200" ]] || fail "frontend가 HTTP 200을 반환하지 않았습니다. (status=$frontend_status)"
 grep -Fq '<div id="root"></div>' "$RESPONSE_BODY" || fail "frontend root markup을 찾지 못했습니다."
 grep -Fq '<title>UCTale</title>' "$RESPONSE_BODY" || fail "frontend title을 찾지 못했습니다."
 
 echo "[smoke] 2/4 backend CORS preflight 확인"
-preflight_status="$(request \
+preflight_status="$(request_with_retry \
   --request OPTIONS \
   --header "Origin: $ORIGIN" \
   --header 'Access-Control-Request-Method: GET' \
@@ -102,12 +134,14 @@ verify_status="$(request \
   "$BACKEND_URL/verify-password")"
 [[ "$verify_status" == "204" ]] || fail "verify-password가 HTTP 204를 반환하지 않았습니다. (status=$verify_status)"
 assert_cors_headers
+assert_cross_site_cookie 'uctale_access'
+assert_cross_site_cookie 'uctale_owner'
 chmod 600 "$COOKIE_JAR"
-grep -q $'\tuctale_access\t' "$COOKIE_JAR" || fail "uctale_access 쿠키가 발급되지 않았습니다."
-grep -q $'\tuctale_owner\t' "$COOKIE_JAR" || fail "uctale_owner 쿠키가 발급되지 않았습니다."
+grep -q $'\tuctale_access\t' "$COOKIE_JAR" || fail "uctale_access 쿠키가 cookie jar에 저장되지 않았습니다."
+grep -q $'\tuctale_owner\t' "$COOKIE_JAR" || fail "uctale_owner 쿠키가 cookie jar에 저장되지 않았습니다."
 
 echo "[smoke] 4/4 발급된 credential 재사용 확인"
-session_status="$(request \
+session_status="$(request_with_retry \
   --request GET \
   --header "Origin: $ORIGIN" \
   --header 'X-UCTale-Client: web' \

--- a/scripts/production-smoke.sh
+++ b/scripts/production-smoke.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FRONTEND_URL="${UCTALE_SMOKE_FRONTEND_URL:-https://uctale.vercel.app}"
+BACKEND_URL="${UCTALE_SMOKE_BACKEND_URL:-https://uctale.onrender.com/api/game}"
+ACCESS_PASSWORD="${UCTALE_SMOKE_ACCESS_PASSWORD:-}"
+ORIGIN="${UCTALE_SMOKE_ORIGIN:-$FRONTEND_URL}"
+
+if [[ -z "$ACCESS_PASSWORD" ]]; then
+  echo "[smoke] UCTALE_SMOKE_ACCESS_PASSWORD가 설정되지 않았습니다." >&2
+  exit 2
+fi
+
+TMP_DIR="$(mktemp -d)"
+COOKIE_JAR="$TMP_DIR/cookies.txt"
+REQUEST_BODY="$TMP_DIR/verify-password.json"
+RESPONSE_HEADERS="$TMP_DIR/headers.txt"
+RESPONSE_BODY="$TMP_DIR/body.txt"
+trap 'rm -rf "$TMP_DIR"' EXIT
+chmod 700 "$TMP_DIR"
+
+curl_common=(
+  --silent
+  --show-error
+  --location
+  --connect-timeout 10
+  --max-time 45
+  --retry 3
+  --retry-delay 5
+  --retry-all-errors
+)
+
+fail() {
+  echo "[smoke] 실패: $*" >&2
+  exit 1
+}
+
+header_value() {
+  local name="$1"
+  awk -v target="$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" '
+    BEGIN { IGNORECASE = 1 }
+    {
+      line = $0
+      sub(/\r$/, "", line)
+      split(line, parts, ":")
+      key = tolower(parts[1])
+      if (key == target) {
+        sub(/^[^:]*:[[:space:]]*/, "", line)
+        value = line
+      }
+    }
+    END { if (value != "") print value }
+  ' "$RESPONSE_HEADERS"
+}
+
+assert_cors_headers() {
+  local allow_origin allow_credentials
+  allow_origin="$(header_value 'Access-Control-Allow-Origin')"
+  allow_credentials="$(header_value 'Access-Control-Allow-Credentials')"
+
+  [[ "$allow_origin" == "$ORIGIN" ]] || fail "Access-Control-Allow-Origin 불일치 (expected=$ORIGIN, actual=${allow_origin:-missing})"
+  [[ "${allow_credentials,,}" == "true" ]] || fail "Access-Control-Allow-Credentials가 true가 아닙니다."
+}
+
+request() {
+  : > "$RESPONSE_HEADERS"
+  : > "$RESPONSE_BODY"
+  curl "${curl_common[@]}" \
+    --dump-header "$RESPONSE_HEADERS" \
+    --output "$RESPONSE_BODY" \
+    --write-out '%{http_code}' \
+    "$@"
+}
+
+echo "[smoke] 1/4 production frontend 응답 확인"
+frontend_status="$(request "$FRONTEND_URL/")"
+[[ "$frontend_status" == "200" ]] || fail "frontend가 HTTP 200을 반환하지 않았습니다. (status=$frontend_status)"
+grep -Fq '<div id="root"></div>' "$RESPONSE_BODY" || fail "frontend root markup을 찾지 못했습니다."
+grep -Fq '<title>UCTale</title>' "$RESPONSE_BODY" || fail "frontend title을 찾지 못했습니다."
+
+echo "[smoke] 2/4 backend CORS preflight 확인"
+preflight_status="$(request \
+  --request OPTIONS \
+  --header "Origin: $ORIGIN" \
+  --header 'Access-Control-Request-Method: GET' \
+  --header 'Access-Control-Request-Headers: X-UCTale-Client' \
+  "$BACKEND_URL/access-session")"
+[[ "$preflight_status" =~ ^2[0-9][0-9]$ ]] || fail "CORS preflight가 성공하지 않았습니다. (status=$preflight_status)"
+assert_cors_headers
+
+printf '{"password":%s}\n' "$(printf '%s' "$ACCESS_PASSWORD" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')" > "$REQUEST_BODY"
+chmod 600 "$REQUEST_BODY"
+
+echo "[smoke] 3/4 공유 접근 세션 발급 확인"
+verify_status="$(request \
+  --request POST \
+  --header "Origin: $ORIGIN" \
+  --header 'X-UCTale-Client: web' \
+  --header 'Content-Type: application/json' \
+  --cookie-jar "$COOKIE_JAR" \
+  --data-binary "@$REQUEST_BODY" \
+  "$BACKEND_URL/verify-password")"
+[[ "$verify_status" == "204" ]] || fail "verify-password가 HTTP 204를 반환하지 않았습니다. (status=$verify_status)"
+assert_cors_headers
+chmod 600 "$COOKIE_JAR"
+grep -q $'\tuctale_access\t' "$COOKIE_JAR" || fail "uctale_access 쿠키가 발급되지 않았습니다."
+grep -q $'\tuctale_owner\t' "$COOKIE_JAR" || fail "uctale_owner 쿠키가 발급되지 않았습니다."
+
+echo "[smoke] 4/4 발급된 credential 재사용 확인"
+session_status="$(request \
+  --request GET \
+  --header "Origin: $ORIGIN" \
+  --header 'X-UCTale-Client: web' \
+  --cookie "$COOKIE_JAR" \
+  "$BACKEND_URL/access-session")"
+[[ "$session_status" == "204" ]] || fail "access-session이 발급된 credential을 거부했습니다. (status=$session_status)"
+assert_cors_headers
+
+echo "[smoke] production frontend/CORS/access-session smoke 통과"


### PR DESCRIPTION
## 왜 필요한가요?

일반 CI는 backend/frontend의 test·lint·build를 검증하지만 실제 Vercel frontend와 Render backend 사이의 production CORS·credential 계약은 확인하지 못합니다. #63처럼 CI를 통과한 뒤 production에서만 드러나는 회귀를 더 빠르게 탐지하기 위해 provider 비용이 없는 얇은 post-deploy smoke를 추가합니다.

- Closes #70

## 무엇이 바뀌나요?

- 게임 규칙·상태: 변경 없음.
- Backend / API / DB: API와 DB schema 변경 없음. 기존 `verify-password`와 `access-session` production 계약을 smoke 대상으로 사용합니다.
- AI narrative / prompt: 변경 없음. 자동 smoke는 narrative provider를 호출하지 않습니다.
- Image generation: 변경 없음. 자동 smoke는 image provider를 호출하지 않습니다.
- Frontend / UX: UI 변경 없음. production frontend root 응답을 실제 Vercel URL에서 확인합니다.
- Build / deploy / docs: `Production Smoke` workflow, `scripts/production-smoke.sh`, 운영 문서를 추가하고 일반 CI에서 smoke 스크립트의 Bash 문법을 검증합니다.

## 책임 경계

게임 기능이나 AI 변경은 없습니다.

- **서버가 결정하는 사실:** 기존 access password 검증, access/owner session cookie 발급·검증, production CORS allowlist 계약을 그대로 사용합니다.
- **LLM이 서술하는 내용:** 해당 없음.
- **LLM이 변경하면 안 되는 사실:** 해당 없음.

## 어떻게 검증했나요?

- [x] `./gradlew clean test`
- [x] `./gradlew build`
- [x] `cd frontend && npm ci && npm run lint && npm run build`
- [ ] 정상 흐름을 직접 확인했습니다.
- [x] 잘못된 입력/실패 흐름을 확인했습니다.
- [x] 중복 요청 또는 상태 전이가 관련되면 이를 검증했습니다.

PR CI run #161: https://github.com/krestar/uctale/actions/runs/33360623934

- `bash -n scripts/production-smoke.sh`: 성공
- backend unit tests: 성공
- PostgreSQL integration tests: 성공
- backend build: 성공
- frontend tests: 성공
- ESLint: 성공
- frontend build: 성공

실패 흐름은 secret 미설정, CORS mismatch, cookie 누락, 인증 세션 거부 시 즉시 실패하도록 검토했습니다. 중복 요청·게임 상태 전이는 이번 변경 범위와 무관함을 확인했습니다.

production smoke의 실제 인증 정상 흐름은 `PRODUCTION_SMOKE_ACCESS_PASSWORD` Actions secret이 필요한 post-merge 운영 검증입니다. workflow가 `main`에 존재해야 Vercel status event로 자동 실행되므로 실제 production 정상 흐름 확인 후 마지막 체크를 완료합니다.

## PR 전 자체 비판적 리뷰 및 보완

- 공통 `curl --location` 사용은 인증 POST가 redirect될 경우 민감한 password payload가 다른 endpoint로 전달될 위험이 있어 타당한 문제로 판단했습니다. redirect follow를 제거했습니다.
- 인증 POST까지 공통 retry하면 공유 인증 rate limit을 불필요하게 소모하고 access/owner session을 반복 발급할 수 있어 타당한 문제로 판단했습니다. retry는 frontend GET, CORS OPTIONS, authenticated GET처럼 안전한 조회에만 적용하고 `verify-password` POST는 한 번만 호출하도록 수정했습니다.
- curl cookie jar 재사용만으로는 브라우저의 SameSite 정책 회귀를 검출하지 못합니다. `Set-Cookie` 값을 출력하지 않은 채 `HttpOnly`, `Secure`, `SameSite=None`, `Path=/api/game` 속성을 직접 검증하도록 보강했습니다.
- 오래된 Vercel deployment status가 늦게 도착해 현재 production을 잘못 검사할 수 있어 status SHA와 실행 시점 `main` HEAD가 동일할 때만 자동 smoke를 실행합니다.
- 자동 smoke에서 `/init`, `/progress`, image generation을 호출하면 배포마다 provider 비용이 발생하므로 이 경로들은 수동 smoke로 남기고 자동 provider 호출을 0회로 고정했습니다.

## 게임 상태·AI 안전성

해당 작업은 게임 상태나 AI 실행 경로를 변경하지 않습니다.

- [x] 게임의 결정적 상태는 서버에서 검증·저장됩니다.
- [x] LLM 출력만으로 HP, 보상, 성공/실패 등 결정적 상태가 임의 변경되지 않습니다.
- [x] AI 요청에 필요한 최소 문맥만 전달합니다.
- [x] AI 응답 파싱 실패와 provider 오류가 게임 상태를 오염시키지 않습니다.
- [x] 기존 저장 데이터 또는 GameState 호환성 영향을 확인했습니다.

## 보안·비용

- [x] API Key, 토큰, 비밀번호가 코드·로그·URL·클라이언트 응답에 노출되지 않습니다.
- [x] 외부 AI/Image 호출 횟수와 실패 시 동작을 검토했습니다.
- [x] 사용자 입력 길이와 외부 API 비용 증가 가능성을 검토했습니다.
- [x] CORS 또는 공개 endpoint 변경이 있다면 의도된 변경입니다.

자동 smoke의 외부 AI/Image provider 호출 수는 0회입니다. 공유 password JSON과 cookie jar는 runner 임시 디렉터리에만 만들고 종료 시 삭제하며 `Set-Cookie` header 전문이나 cookie 값을 로그에 출력하지 않습니다.

## API·DB·운영 영향

- [x] API 계약 변경 시 Frontend 호출부와 문서를 함께 갱신했습니다.
- [x] DB schema 변경 시 migration 전략을 포함했습니다.
- [x] 환경변수는 이름과 용도만 문서화했고 실제 Secret은 포함하지 않았습니다.
- [x] 배포 후 확인할 smoke test가 있습니다.

API/DB 계약 변경과 migration은 없습니다. 운영 시 Repository Actions secret `PRODUCTION_SMOKE_ACCESS_PASSWORD`에 production `GAME_ACCESS_PASSWORD`와 동일한 값을 한 번 등록해야 합니다.

Vercel이 `main` SHA에 `context=Vercel`, `state=success` commit status를 기록하면 자동 workflow가 시작되고, 해당 SHA가 현재 `main` HEAD일 때 production smoke를 실행합니다. 수동 `workflow_dispatch`도 지원합니다.

Secret이 등록되지 않았다면 smoke script는 비밀번호 값을 출력하지 않고 설정 누락으로 즉시 실패합니다.

## 화면 / 응답 예시

UI/API 응답 형식 변경은 없습니다. smoke 로그에는 단계명과 HTTP status 같은 비민감 진단 정보만 기록됩니다.