### PR TITLE
fix(persistence): turn reservation 재시도 카운트를 provider 시도와 정렬

### DIFF
--- a/docs/architecture/game-turn-reservation.md
+++ b/docs/architecture/game-turn-reservation.md
@@ -20,13 +20,14 @@
 - owner: `request_id` + 매 lease 획득마다 새로 생성되는 `lease_owner`
 - 기본 lease: 90초 (`app.game.turn-reservation.lease-seconds`)
 - 최대 provider 시도: 같은 turn reservation row 기준 3회
-- `attempt_count`: lease 획득 횟수가 아니라 실제 Narrative provider 실행 경계에 진입한 횟수
+- `provider_attempt_count`: 실제 Narrative provider 실행 경계에 진입한 횟수
+- `attempt_count`: V8에서 생성된 legacy lease-attempt 필드로, 신규 provider 상한 판정에는 사용하지 않는다.
 
 서로 다른 idempotency key가 같은 turn을 요청해도 lease가 유효하면 후발 요청은 provider를 호출하지 않고 `409 MUTATION_IN_PROGRESS`를 받는다.
 
-Reservation 획득 자체는 provider attempt를 소비하지 않는다. session/turn 검증, choice/action 검증, rate limit, 전역 provider budget guard처럼 provider 호출 전에 끝나는 실패는 lease만 실패/만료 처리하며 `attempt_count`를 증가시키지 않는다.
+Reservation 획득 자체는 provider attempt를 소비하지 않는다. session/turn 검증, choice/action 검증, rate limit, 전역 provider budget guard처럼 provider 호출 전에 끝나는 실패는 lease만 실패/만료 처리하며 `provider_attempt_count`를 증가시키지 않는다.
 
-모든 pre-provider 검증과 budget guard를 통과한 뒤 Narrative provider를 실제 호출하기 직전에 현재 `request_id`/`lease_owner`가 여전히 유효한지 확인하면서 `attempt_count`를 원자적으로 증가시킨다. 이미 3회에 도달했거나 lease가 만료/회수된 owner는 provider 호출 구간에 진입할 수 없다.
+모든 pre-provider 검증과 budget guard를 통과한 뒤 Narrative provider를 실제 호출하기 직전에 현재 `request_id`/`lease_owner`가 여전히 유효한지 확인하면서 `provider_attempt_count`를 원자적으로 증가시킨다. 이미 3회에 도달했거나 lease가 만료/회수된 owner는 provider 호출 구간에 진입할 수 없다.
 
 ## Transaction boundaries
 
@@ -45,10 +46,12 @@ Provider 응답을 받은 뒤 canonical commit transaction에서 다음을 다�
 
 Provider 호출 전 예외가 발생하면 mutation request를 `FAILED`로 바꾸고 lease를 즉시 만료시키되 provider attempt는 소비하지 않는다.
 
-Provider 실행 경계에 진입한 뒤 provider 또는 commit 전 단계에서 예외가 발생하면 해당 시도는 `attempt_count`에 남고 mutation request를 `FAILED`로 바꾸며 lease를 즉시 만료시켜 남은 횟수 범위에서 재시도를 허용한다.
+Provider 실행 경계에 진입한 뒤 provider 또는 commit 전 단계에서 예외가 발생하면 해당 시도는 `provider_attempt_count`에 남고 mutation request를 `FAILED`로 바꾸며 lease를 즉시 만료시켜 남은 횟수 범위에서 재시도를 허용한다.
 
-프로세스가 provider 시작 표시 직후 또는 provider 성공 직후 DB commit 전에 죽으면 실패 처리를 실행할 수 없다. 이 경우 lease가 만료된 뒤 다른 요청이 reservation을 회수할 수 있고 provider가 다시 호출될 수 있다. 따라서 외부 provider 호출은 strict exactly-once가 아니라 **bounded at-least-once**이며, reservation row의 `attempt_count`로 turn당 최대 3번까지 제한한다.
+프로세스가 provider 시작 표시 직후 또는 provider 성공 직후 DB commit 전에 죽으면 실패 처리를 실행할 수 없다. 이 경우 lease가 만료된 뒤 다른 요청이 reservation을 회수할 수 있고 provider가 다시 호출될 수 있다. 따라서 외부 provider 호출은 strict exactly-once가 아니라 **bounded at-least-once**이며, reservation row의 `provider_attempt_count`로 turn당 최대 3번까지 제한한다.
 
 provider 시작 표시와 실제 네트워크 I/O 사이의 프로세스 crash는 보수적으로 provider attempt를 소비한 것으로 본다. 이 경계를 DB transaction과 외부 provider 호출 사이에서 완전히 원자화할 수 없기 때문에, 중복 호출 상한을 지키는 방향으로 fail-safe 한다.
+
+V10 이전에 쌓인 `attempt_count`는 lease 획득 횟수였기 때문에 provider 호출 여부를 정확히 복원할 수 없다. V10은 이를 재해석하거나 초기화하지 않고 `provider_attempt_count`를 별도 추가해 배포 시 기존 데이터가 신규 상한을 잘못 소모하지 않도록 한다.
 
 반면 canonical state와 GameLog는 reservation owner 재검증, expected turn 검증, optimistic locking, turn unique constraint를 함께 사용하므로 이중 commit을 허용하지 않는다.

--- a/docs/architecture/game-turn-reservation.md
+++ b/docs/architecture/game-turn-reservation.md
@@ -14,18 +14,23 @@
 
 ## Turn reservation
 
-`game_turn_reservation`은 활성 turn lease만 담당한다.
+`game_turn_reservation`은 turn lease와 bounded provider attempt 수를 함께 보관한다.
 
 - key: `(session_id, expected_turn)`
-- owner: `request_id` + 매 시도마다 새로 생성되는 `lease_owner`
+- owner: `request_id` + 매 lease 획득마다 새로 생성되는 `lease_owner`
 - 기본 lease: 90초 (`app.game.turn-reservation.lease-seconds`)
 - 최대 provider 시도: 같은 turn reservation row 기준 3회
+- `attempt_count`: lease 획득 횟수가 아니라 실제 Narrative provider 실행 경계에 진입한 횟수
 
 서로 다른 idempotency key가 같은 turn을 요청해도 lease가 유효하면 후발 요청은 provider를 호출하지 않고 `409 MUTATION_IN_PROGRESS`를 받는다.
 
+Reservation 획득 자체는 provider attempt를 소비하지 않는다. session/turn 검증, choice/action 검증, rate limit, 전역 provider budget guard처럼 provider 호출 전에 끝나는 실패는 lease만 실패/만료 처리하며 `attempt_count`를 증가시키지 않는다.
+
+모든 pre-provider 검증과 budget guard를 통과한 뒤 Narrative provider를 실제 호출하기 직전에 현재 `request_id`/`lease_owner`가 여전히 유효한지 확인하면서 `attempt_count`를 원자적으로 증가시킨다. 이미 3회에 도달했거나 lease가 만료/회수된 owner는 provider 호출 구간에 진입할 수 없다.
+
 ## Transaction boundaries
 
-Reservation 획득은 짧은 DB transaction에서 끝난다. Gemini 네트워크 호출 동안 DB transaction이나 row lock을 유지하지 않는다.
+Reservation 획득과 provider attempt 시작 표시는 각각 짧은 DB transaction에서 끝난다. Gemini 네트워크 호출 동안 DB transaction이나 row lock을 유지하지 않는다.
 
 Provider 응답을 받은 뒤 canonical commit transaction에서 다음을 다시 검증한다.
 
@@ -38,8 +43,12 @@ Provider 응답을 받은 뒤 canonical commit transaction에서 다음을 다�
 
 ## Failure and crash semantics
 
-Provider 또는 commit 전 단계에서 예외가 발생하면 mutation request를 `FAILED`로 바꾸고 lease를 즉시 만료시켜 재시도를 허용한다.
+Provider 호출 전 예외가 발생하면 mutation request를 `FAILED`로 바꾸고 lease를 즉시 만료시키되 provider attempt는 소비하지 않는다.
 
-프로세스가 provider 성공 직후 DB commit 전에 죽으면 실패 처리를 실행할 수 없다. 이 경우 lease가 만료된 뒤 다른 요청이 reservation을 회수할 수 있고 provider가 다시 호출될 수 있다. 따라서 외부 provider 호출은 strict exactly-once가 아니라 **bounded at-least-once**이며, reservation row의 `attempt_count`로 turn당 최대 3번까지 제한한다.
+Provider 실행 경계에 진입한 뒤 provider 또는 commit 전 단계에서 예외가 발생하면 해당 시도는 `attempt_count`에 남고 mutation request를 `FAILED`로 바꾸며 lease를 즉시 만료시켜 남은 횟수 범위에서 재시도를 허용한다.
+
+프로세스가 provider 시작 표시 직후 또는 provider 성공 직후 DB commit 전에 죽으면 실패 처리를 실행할 수 없다. 이 경우 lease가 만료된 뒤 다른 요청이 reservation을 회수할 수 있고 provider가 다시 호출될 수 있다. 따라서 외부 provider 호출은 strict exactly-once가 아니라 **bounded at-least-once**이며, reservation row의 `attempt_count`로 turn당 최대 3번까지 제한한다.
+
+provider 시작 표시와 실제 네트워크 I/O 사이의 프로세스 crash는 보수적으로 provider attempt를 소비한 것으로 본다. 이 경계를 DB transaction과 외부 provider 호출 사이에서 완전히 원자화할 수 없기 때문에, 중복 호출 상한을 지키는 방향으로 fail-safe 한다.
 
 반면 canonical state와 GameLog는 reservation owner 재검증, expected turn 검증, optimistic locking, turn unique constraint를 함께 사용하므로 이중 commit을 허용하지 않는다.

--- a/src/main/java/com/uctale/uctale/application/cost/ProviderCallTelemetry.java
+++ b/src/main/java/com/uctale/uctale/application/cost/ProviderCallTelemetry.java
@@ -43,7 +43,18 @@ public class ProviderCallTelemetry {
             int retryCount,
             Supplier<T> invocation
     ) {
-        return observe(provider, defaultModel(provider), operation, context, retryCount, invocation);
+        return observe(provider, defaultModel(provider), operation, context, retryCount, () -> {}, invocation);
+    }
+
+    public <T> T observe(
+            String provider,
+            String operation,
+            CostRequestContext context,
+            int retryCount,
+            Runnable beforeInvocation,
+            Supplier<T> invocation
+    ) {
+        return observe(provider, defaultModel(provider), operation, context, retryCount, beforeInvocation, invocation);
     }
 
     public <T> T observe(
@@ -59,6 +70,7 @@ public class ProviderCallTelemetry {
                 defaultModel(provider),
                 operation,
                 context,
+                () -> {},
                 invocation,
                 successRetryCount,
                 failureRetryCount
@@ -73,11 +85,24 @@ public class ProviderCallTelemetry {
             int retryCount,
             Supplier<T> invocation
     ) {
+        return observe(provider, model, operation, context, retryCount, () -> {}, invocation);
+    }
+
+    public <T> T observe(
+            String provider,
+            String model,
+            String operation,
+            CostRequestContext context,
+            int retryCount,
+            Runnable beforeInvocation,
+            Supplier<T> invocation
+    ) {
         return observe(
                 provider,
                 model,
                 operation,
                 context,
+                beforeInvocation,
                 invocation,
                 ignored -> retryCount,
                 ignored -> retryCount
@@ -93,9 +118,32 @@ public class ProviderCallTelemetry {
             ToIntFunction<T> successRetryCount,
             ToIntFunction<RuntimeException> failureRetryCount
     ) {
+        return observe(
+                provider,
+                model,
+                operation,
+                context,
+                () -> {},
+                invocation,
+                successRetryCount,
+                failureRetryCount
+        );
+    }
+
+    public <T> T observe(
+            String provider,
+            String model,
+            String operation,
+            CostRequestContext context,
+            Runnable beforeInvocation,
+            Supplier<T> invocation,
+            ToIntFunction<T> successRetryCount,
+            ToIntFunction<RuntimeException> failureRetryCount
+    ) {
         if (budgetGuard != null) {
             budgetGuard.checkBeforeCall(operation);
         }
+        beforeInvocation.run();
         long startedAt = clock.millis();
         try {
             T result = invocation.get();

--- a/src/main/java/com/uctale/uctale/application/game/GameMutationRequestService.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameMutationRequestService.java
@@ -19,7 +19,7 @@ public class GameMutationRequestService {
 
     public static final String INIT = "INIT";
     public static final String PROGRESS = "PROGRESS";
-    private static final int MAX_RESERVATION_ATTEMPTS = 3;
+    private static final int MAX_PROVIDER_ATTEMPTS = 3;
     private static final Pattern IDEMPOTENCY_KEY_PATTERN = Pattern.compile("[A-Za-z0-9._:-]{8,128}");
 
     private final GameMutationRequestRepository repository;
@@ -95,9 +95,41 @@ public class GameMutationRequestService {
                 repository.save(request);
             }
             long retryAfter = currentRetryAfterSeconds(sessionId, expectedTurn, now);
-            throw new MutationInProgressException("같은 턴이 이미 처리 중이거나 재시도 한도에 도달했습니다.", retryAfter);
+            throw new MutationInProgressException("같은 턴이 이미 처리 중입니다.", retryAfter);
         }
         return BeginResult.process(request.getId(), leaseOwner);
+    }
+
+    @Transactional(noRollbackFor = MutationInProgressException.class)
+    public void markProviderAttemptStarted(Long requestId, String reservationOwner) {
+        if (reservationOwner == null) {
+            throw new IllegalArgumentException("provider attempt에는 reservationOwner가 필요합니다.");
+        }
+        int updated = jdbcTemplate.update("""
+                UPDATE game_turn_reservation
+                SET attempt_count = attempt_count + 1, updated_at = CURRENT_TIMESTAMP
+                WHERE request_id = ?
+                  AND lease_owner = ?
+                  AND lease_expires_at > CURRENT_TIMESTAMP
+                  AND attempt_count < ?
+                """, requestId, reservationOwner, MAX_PROVIDER_ATTEMPTS);
+        if (updated == 1) {
+            return;
+        }
+
+        Integer currentAttemptCount = jdbcTemplate.query(
+                """
+                        SELECT attempt_count
+                        FROM game_turn_reservation
+                        WHERE request_id = ? AND lease_owner = ?
+                        """,
+                rs -> rs.next() ? rs.getInt(1) : null,
+                requestId, reservationOwner
+        );
+        if (currentAttemptCount != null && currentAttemptCount >= MAX_PROVIDER_ATTEMPTS) {
+            throw new MutationInProgressException("같은 턴의 provider 재시도 한도에 도달했습니다.", 1);
+        }
+        throw new MutationInProgressException("턴 reservation이 만료되었거나 회수되었습니다.", 1);
     }
 
     @Transactional
@@ -165,16 +197,15 @@ public class GameMutationRequestService {
                     INSERT INTO game_turn_reservation (
                         session_id, expected_turn, request_id, lease_owner, lease_expires_at, attempt_count,
                         created_at, updated_at
-                    ) VALUES (?, ?, ?, ?, ?, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                    ) VALUES (?, ?, ?, ?, ?, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
                     ON CONFLICT (session_id, expected_turn) DO UPDATE SET
                         request_id = EXCLUDED.request_id,
                         lease_owner = EXCLUDED.lease_owner,
                         lease_expires_at = EXCLUDED.lease_expires_at,
-                        attempt_count = game_turn_reservation.attempt_count + 1,
                         updated_at = CURRENT_TIMESTAMP
                     WHERE game_turn_reservation.lease_expires_at <= ?
                       AND game_turn_reservation.attempt_count < ?
-                    """, sessionId, expectedTurn, requestId, leaseOwner, expiresAt, now, MAX_RESERVATION_ATTEMPTS);
+                    """, sessionId, expectedTurn, requestId, leaseOwner, expiresAt, now, MAX_PROVIDER_ATTEMPTS);
         }
 
         List<ReservationState> reservations = jdbcTemplate.query(
@@ -194,21 +225,20 @@ public class GameMutationRequestService {
                     INSERT INTO game_turn_reservation (
                         session_id, expected_turn, request_id, lease_owner, lease_expires_at, attempt_count,
                         created_at, updated_at
-                    ) VALUES (?, ?, ?, ?, ?, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                    ) VALUES (?, ?, ?, ?, ?, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
                     """, sessionId, expectedTurn, requestId, leaseOwner, expiresAt);
         }
 
         ReservationState reservation = reservations.getFirst();
-        if (reservation.leaseExpiresAt().isAfter(now) || reservation.attemptCount() >= MAX_RESERVATION_ATTEMPTS) {
+        if (reservation.leaseExpiresAt().isAfter(now) || reservation.attemptCount() >= MAX_PROVIDER_ATTEMPTS) {
             return 0;
         }
         return jdbcTemplate.update("""
                 UPDATE game_turn_reservation
-                SET request_id = ?, lease_owner = ?, lease_expires_at = ?,
-                    attempt_count = attempt_count + 1, updated_at = CURRENT_TIMESTAMP
+                SET request_id = ?, lease_owner = ?, lease_expires_at = ?, updated_at = CURRENT_TIMESTAMP
                 WHERE session_id = ? AND expected_turn = ?
                   AND lease_expires_at <= ? AND attempt_count < ?
-                """, requestId, leaseOwner, expiresAt, sessionId, expectedTurn, now, MAX_RESERVATION_ATTEMPTS);
+                """, requestId, leaseOwner, expiresAt, sessionId, expectedTurn, now, MAX_PROVIDER_ATTEMPTS);
     }
 
     private long currentRetryAfterSeconds(Long sessionId, int expectedTurn, LocalDateTime now) {

--- a/src/main/java/com/uctale/uctale/application/game/GameMutationRequestService.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameMutationRequestService.java
@@ -95,7 +95,7 @@ public class GameMutationRequestService {
                 repository.save(request);
             }
             long retryAfter = currentRetryAfterSeconds(sessionId, expectedTurn, now);
-            throw new MutationInProgressException("같은 턴이 이미 처리 중입니다.", retryAfter);
+            throw new MutationInProgressException("같은 턴이 이미 처리 중이거나 provider 재시도 한도에 도달했습니다.", retryAfter);
         }
         return BeginResult.process(request.getId(), leaseOwner);
     }
@@ -107,11 +107,11 @@ public class GameMutationRequestService {
         }
         int updated = jdbcTemplate.update("""
                 UPDATE game_turn_reservation
-                SET attempt_count = attempt_count + 1, updated_at = CURRENT_TIMESTAMP
+                SET provider_attempt_count = provider_attempt_count + 1, updated_at = CURRENT_TIMESTAMP
                 WHERE request_id = ?
                   AND lease_owner = ?
                   AND lease_expires_at > CURRENT_TIMESTAMP
-                  AND attempt_count < ?
+                  AND provider_attempt_count < ?
                 """, requestId, reservationOwner, MAX_PROVIDER_ATTEMPTS);
         if (updated == 1) {
             return;
@@ -119,7 +119,7 @@ public class GameMutationRequestService {
 
         Integer currentAttemptCount = jdbcTemplate.query(
                 """
-                        SELECT attempt_count
+                        SELECT provider_attempt_count
                         FROM game_turn_reservation
                         WHERE request_id = ? AND lease_owner = ?
                         """,
@@ -195,49 +195,50 @@ public class GameMutationRequestService {
         if (!isH2()) {
             return jdbcTemplate.update("""
                     INSERT INTO game_turn_reservation (
-                        session_id, expected_turn, request_id, lease_owner, lease_expires_at, attempt_count,
+                        session_id, expected_turn, request_id, lease_owner, lease_expires_at,
                         created_at, updated_at
-                    ) VALUES (?, ?, ?, ?, ?, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                    ) VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
                     ON CONFLICT (session_id, expected_turn) DO UPDATE SET
                         request_id = EXCLUDED.request_id,
                         lease_owner = EXCLUDED.lease_owner,
                         lease_expires_at = EXCLUDED.lease_expires_at,
                         updated_at = CURRENT_TIMESTAMP
                     WHERE game_turn_reservation.lease_expires_at <= ?
-                      AND game_turn_reservation.attempt_count < ?
+                      AND game_turn_reservation.provider_attempt_count < ?
                     """, sessionId, expectedTurn, requestId, leaseOwner, expiresAt, now, MAX_PROVIDER_ATTEMPTS);
         }
 
         List<ReservationState> reservations = jdbcTemplate.query(
                 """
-                        SELECT lease_expires_at, attempt_count
+                        SELECT lease_expires_at, provider_attempt_count
                         FROM game_turn_reservation
                         WHERE session_id = ? AND expected_turn = ?
                         """,
                 (rs, rowNum) -> new ReservationState(
                         rs.getTimestamp("lease_expires_at").toLocalDateTime(),
-                        rs.getInt("attempt_count")
+                        rs.getInt("provider_attempt_count")
                 ),
                 sessionId, expectedTurn
         );
         if (reservations.isEmpty()) {
             return jdbcTemplate.update("""
                     INSERT INTO game_turn_reservation (
-                        session_id, expected_turn, request_id, lease_owner, lease_expires_at, attempt_count,
+                        session_id, expected_turn, request_id, lease_owner, lease_expires_at,
                         created_at, updated_at
-                    ) VALUES (?, ?, ?, ?, ?, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                    ) VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
                     """, sessionId, expectedTurn, requestId, leaseOwner, expiresAt);
         }
 
         ReservationState reservation = reservations.getFirst();
-        if (reservation.leaseExpiresAt().isAfter(now) || reservation.attemptCount() >= MAX_PROVIDER_ATTEMPTS) {
+        if (reservation.leaseExpiresAt().isAfter(now)
+                || reservation.providerAttemptCount() >= MAX_PROVIDER_ATTEMPTS) {
             return 0;
         }
         return jdbcTemplate.update("""
                 UPDATE game_turn_reservation
                 SET request_id = ?, lease_owner = ?, lease_expires_at = ?, updated_at = CURRENT_TIMESTAMP
                 WHERE session_id = ? AND expected_turn = ?
-                  AND lease_expires_at <= ? AND attempt_count < ?
+                  AND lease_expires_at <= ? AND provider_attempt_count < ?
                 """, requestId, leaseOwner, expiresAt, sessionId, expectedTurn, now, MAX_PROVIDER_ATTEMPTS);
     }
 
@@ -263,7 +264,7 @@ public class GameMutationRequestService {
         }
     }
 
-    private record ReservationState(LocalDateTime leaseExpiresAt, int attemptCount) {}
+    private record ReservationState(LocalDateTime leaseExpiresAt, int providerAttemptCount) {}
 
     public record BeginResult(
             Long requestId,

--- a/src/main/java/com/uctale/uctale/application/game/GameMutationRequestService.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameMutationRequestService.java
@@ -105,14 +105,15 @@ public class GameMutationRequestService {
         if (reservationOwner == null) {
             throw new IllegalArgumentException("provider attempt에는 reservationOwner가 필요합니다.");
         }
+        LocalDateTime now = LocalDateTime.now(clock);
         int updated = jdbcTemplate.update("""
                 UPDATE game_turn_reservation
                 SET provider_attempt_count = provider_attempt_count + 1, updated_at = CURRENT_TIMESTAMP
                 WHERE request_id = ?
                   AND lease_owner = ?
-                  AND lease_expires_at > CURRENT_TIMESTAMP
+                  AND lease_expires_at > ?
                   AND provider_attempt_count < ?
-                """, requestId, reservationOwner, MAX_PROVIDER_ATTEMPTS);
+                """, requestId, reservationOwner, now, MAX_PROVIDER_ATTEMPTS);
         if (updated == 1) {
             return;
         }
@@ -139,12 +140,13 @@ public class GameMutationRequestService {
 
     @Transactional
     public void markFailed(Long requestId, String reservationOwner) {
+        LocalDateTime now = LocalDateTime.now(clock);
         if (reservationOwner != null) {
             int expired = jdbcTemplate.update("""
                     UPDATE game_turn_reservation
-                    SET lease_expires_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+                    SET lease_expires_at = ?, updated_at = CURRENT_TIMESTAMP
                     WHERE request_id = ? AND lease_owner = ?
-                    """, requestId, reservationOwner);
+                    """, now, requestId, reservationOwner);
             if (expired == 0) {
                 return;
             }
@@ -155,9 +157,9 @@ public class GameMutationRequestService {
             if (reservationOwner == null) {
                 jdbcTemplate.update("""
                         UPDATE game_turn_reservation
-                        SET lease_expires_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+                        SET lease_expires_at = ?, updated_at = CURRENT_TIMESTAMP
                         WHERE request_id = ?
-                        """, requestId);
+                        """, now, requestId);
             }
         });
     }
@@ -202,6 +204,7 @@ public class GameMutationRequestService {
                         request_id = EXCLUDED.request_id,
                         lease_owner = EXCLUDED.lease_owner,
                         lease_expires_at = EXCLUDED.lease_expires_at,
+                        attempt_count = LEAST(game_turn_reservation.attempt_count + 1, 3),
                         updated_at = CURRENT_TIMESTAMP
                     WHERE game_turn_reservation.lease_expires_at <= ?
                       AND game_turn_reservation.provider_attempt_count < ?
@@ -236,7 +239,9 @@ public class GameMutationRequestService {
         }
         return jdbcTemplate.update("""
                 UPDATE game_turn_reservation
-                SET request_id = ?, lease_owner = ?, lease_expires_at = ?, updated_at = CURRENT_TIMESTAMP
+                SET request_id = ?, lease_owner = ?, lease_expires_at = ?,
+                    attempt_count = CASE WHEN attempt_count < 3 THEN attempt_count + 1 ELSE 3 END,
+                    updated_at = CURRENT_TIMESTAMP
                 WHERE session_id = ? AND expected_turn = ?
                   AND lease_expires_at <= ? AND provider_attempt_count < ?
                 """, requestId, leaseOwner, expiresAt, sessionId, expectedTurn, now, MAX_PROVIDER_ATTEMPTS);

--- a/src/main/java/com/uctale/uctale/service/GameService.java
+++ b/src/main/java/com/uctale/uctale/service/GameService.java
@@ -118,6 +118,9 @@ public class GameService {
             costRateLimiter.check(CostOperation.NARRATIVE, providerContext);
             NarrativeTurn nextTurn = providerCallTelemetry.observe(
                     "gemini", "progress", providerContext, 0,
+                    () -> mutationRequestService.markProviderAttemptStarted(
+                            mutation.requestId(), mutation.reservationOwner()
+                    ),
                     () -> narrativeGenerator.createNextTurn(narrativeContext)
             );
             validateNarrativeTurn(nextTurn);

--- a/src/main/resources/db/migration/V10__align_turn_reservation_attempt_count.sql
+++ b/src/main/resources/db/migration/V10__align_turn_reservation_attempt_count.sql
@@ -1,0 +1,9 @@
+ALTER TABLE game_turn_reservation
+    DROP CONSTRAINT ck_game_turn_reservation_attempt_count;
+
+ALTER TABLE game_turn_reservation
+    ALTER COLUMN attempt_count SET DEFAULT 0;
+
+ALTER TABLE game_turn_reservation
+    ADD CONSTRAINT ck_game_turn_reservation_attempt_count
+        CHECK (attempt_count BETWEEN 0 AND 3);

--- a/src/main/resources/db/migration/V10__align_turn_reservation_attempt_count.sql
+++ b/src/main/resources/db/migration/V10__align_turn_reservation_attempt_count.sql
@@ -1,9 +1,6 @@
 ALTER TABLE game_turn_reservation
-    DROP CONSTRAINT ck_game_turn_reservation_attempt_count;
+    ADD COLUMN provider_attempt_count INTEGER NOT NULL DEFAULT 0;
 
 ALTER TABLE game_turn_reservation
-    ALTER COLUMN attempt_count SET DEFAULT 0;
-
-ALTER TABLE game_turn_reservation
-    ADD CONSTRAINT ck_game_turn_reservation_attempt_count
-        CHECK (attempt_count BETWEEN 0 AND 3);
+    ADD CONSTRAINT ck_game_turn_reservation_provider_attempt_count
+        CHECK (provider_attempt_count BETWEEN 0 AND 3);

--- a/src/test/java/com/uctale/uctale/application/cost/ProviderCallTelemetryTest.java
+++ b/src/test/java/com/uctale/uctale/application/cost/ProviderCallTelemetryTest.java
@@ -9,9 +9,13 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 class ProviderCallTelemetryTest {
 
@@ -83,6 +87,34 @@ class ProviderCallTelemetryTest {
 
         assertThat(result.value()).isEqualTo("ok");
         assertThat(events).singleElement().satisfies(event -> assertThat(event.retryCount()).isEqualTo(2));
+    }
+
+    @Test
+    @DisplayName("budget guard가 provider를 차단하면 호출 직전 훅도 실행하지 않는다")
+    void budgetGuardRejection_DoesNotRunBeforeInvocationHook() {
+        MutableClock clock = new MutableClock(Instant.parse("2026-08-30T06:00:00Z"));
+        ProviderUsageStore usageStore = mock(ProviderUsageStore.class);
+        given(usageStore.totalUnits(any(), any())).willReturn(10L);
+        ProviderBudgetPolicy policy = new ProviderBudgetPolicy(1, 10, 1, 10, 1, 1, "FAIL_CLOSED");
+        ProviderBudgetGuard guard = new ProviderBudgetGuard(usageStore, policy, clock);
+        ProviderCallTelemetry telemetry = new ProviderCallTelemetry(clock, event -> {}, guard, "flux");
+        AtomicBoolean beforeInvocation = new AtomicBoolean(false);
+        AtomicBoolean invocation = new AtomicBoolean(false);
+
+        assertThatThrownBy(() -> telemetry.observe(
+                "gemini",
+                "progress",
+                CostRequestContext.internal("owner-a", 42L, 2),
+                0,
+                () -> beforeInvocation.set(true),
+                () -> {
+                    invocation.set(true);
+                    return "unexpected";
+                }
+        )).isInstanceOf(ProviderBudgetExceededException.class);
+
+        assertThat(beforeInvocation).isFalse();
+        assertThat(invocation).isFalse();
     }
 
     private record RetryAwareResult(String value, int retryCount) {}

--- a/src/test/java/com/uctale/uctale/persistence/PostgresGameTurnReservationTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/PostgresGameTurnReservationTest.java
@@ -50,8 +50,89 @@ class PostgresGameTurnReservationTest extends PostgresIntegrationTestSupport {
                 SESSION_ID, EXPECTED_TURN, "b".repeat(64));
 
         assertThat(second.reservationOwner()).isNotEqualTo(first.reservationOwner());
-        assertThat(jdbcTemplate.queryForObject(
+        assertThat(attemptCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("provider 호출 전 실패는 여러 번 발생해도 provider attempt를 소비하지 않는다")
+    void preProviderFailures_DoNotConsumeProviderAttempts() {
+        for (int index = 1; index <= 4; index++) {
+            var reservation = service.begin(
+                    OWNER_KEY,
+                    GameMutationRequestService.PROGRESS,
+                    "precall-key-00" + index,
+                    SESSION_ID,
+                    EXPECTED_TURN,
+                    Integer.toString(index).repeat(64)
+            );
+            assertThat(attemptCount()).isZero();
+            service.markFailed(reservation.requestId(), reservation.reservationOwner());
+        }
+
+        var valid = service.begin(
+                OWNER_KEY,
+                GameMutationRequestService.PROGRESS,
+                "precall-valid-01",
+                SESSION_ID,
+                EXPECTED_TURN,
+                "f".repeat(64)
+        );
+        service.markProviderAttemptStarted(valid.requestId(), valid.reservationOwner());
+
+        assertThat(attemptCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("실제 provider 시작은 최대 세 번까지만 허용한다")
+    void providerAttempts_AreBoundedToThree() {
+        for (int index = 1; index <= 3; index++) {
+            var reservation = service.begin(
+                    OWNER_KEY,
+                    GameMutationRequestService.PROGRESS,
+                    "provider-key-00" + index,
+                    SESSION_ID,
+                    EXPECTED_TURN,
+                    Integer.toString(index).repeat(64)
+            );
+            service.markProviderAttemptStarted(reservation.requestId(), reservation.reservationOwner());
+            assertThat(attemptCount()).isEqualTo(index);
+            service.markFailed(reservation.requestId(), reservation.reservationOwner());
+        }
+
+        assertThatThrownBy(() -> service.begin(
+                OWNER_KEY,
+                GameMutationRequestService.PROGRESS,
+                "provider-key-004",
+                SESSION_ID,
+                EXPECTED_TURN,
+                "4".repeat(64)
+        )).isInstanceOf(MutationInProgressException.class);
+
+        assertThat(attemptCount()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("회수된 stale owner는 provider attempt를 시작할 수 없다")
+    void staleOwner_CannotStartProviderAttemptAfterTakeover() {
+        var first = service.begin(OWNER_KEY, GameMutationRequestService.PROGRESS, "stale-key-001",
+                SESSION_ID, EXPECTED_TURN, "a".repeat(64));
+        service.markFailed(first.requestId(), first.reservationOwner());
+
+        var second = service.begin(OWNER_KEY, GameMutationRequestService.PROGRESS, "stale-key-002",
+                SESSION_ID, EXPECTED_TURN, "b".repeat(64));
+
+        assertThatThrownBy(() -> service.markProviderAttemptStarted(first.requestId(), first.reservationOwner()))
+                .isInstanceOf(MutationInProgressException.class);
+        assertThat(attemptCount()).isZero();
+
+        service.markProviderAttemptStarted(second.requestId(), second.reservationOwner());
+        assertThat(attemptCount()).isEqualTo(1);
+    }
+
+    private int attemptCount() {
+        return jdbcTemplate.queryForObject(
                 "SELECT attempt_count FROM game_turn_reservation WHERE session_id = ? AND expected_turn = ?",
-                Integer.class, SESSION_ID, EXPECTED_TURN)).isEqualTo(2);
+                Integer.class, SESSION_ID, EXPECTED_TURN
+        );
     }
 }

--- a/src/test/java/com/uctale/uctale/persistence/PostgresGameTurnReservationTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/PostgresGameTurnReservationTest.java
@@ -50,7 +50,7 @@ class PostgresGameTurnReservationTest extends PostgresIntegrationTestSupport {
                 SESSION_ID, EXPECTED_TURN, "b".repeat(64));
 
         assertThat(second.reservationOwner()).isNotEqualTo(first.reservationOwner());
-        assertThat(attemptCount()).isZero();
+        assertThat(providerAttemptCount()).isZero();
     }
 
     @Test
@@ -65,7 +65,7 @@ class PostgresGameTurnReservationTest extends PostgresIntegrationTestSupport {
                     EXPECTED_TURN,
                     Integer.toString(index).repeat(64)
             );
-            assertThat(attemptCount()).isZero();
+            assertThat(providerAttemptCount()).isZero();
             service.markFailed(reservation.requestId(), reservation.reservationOwner());
         }
 
@@ -79,7 +79,7 @@ class PostgresGameTurnReservationTest extends PostgresIntegrationTestSupport {
         );
         service.markProviderAttemptStarted(valid.requestId(), valid.reservationOwner());
 
-        assertThat(attemptCount()).isEqualTo(1);
+        assertThat(providerAttemptCount()).isEqualTo(1);
     }
 
     @Test
@@ -95,7 +95,7 @@ class PostgresGameTurnReservationTest extends PostgresIntegrationTestSupport {
                     Integer.toString(index).repeat(64)
             );
             service.markProviderAttemptStarted(reservation.requestId(), reservation.reservationOwner());
-            assertThat(attemptCount()).isEqualTo(index);
+            assertThat(providerAttemptCount()).isEqualTo(index);
             service.markFailed(reservation.requestId(), reservation.reservationOwner());
         }
 
@@ -108,7 +108,7 @@ class PostgresGameTurnReservationTest extends PostgresIntegrationTestSupport {
                 "4".repeat(64)
         )).isInstanceOf(MutationInProgressException.class);
 
-        assertThat(attemptCount()).isEqualTo(3);
+        assertThat(providerAttemptCount()).isEqualTo(3);
     }
 
     @Test
@@ -123,15 +123,36 @@ class PostgresGameTurnReservationTest extends PostgresIntegrationTestSupport {
 
         assertThatThrownBy(() -> service.markProviderAttemptStarted(first.requestId(), first.reservationOwner()))
                 .isInstanceOf(MutationInProgressException.class);
-        assertThat(attemptCount()).isZero();
+        assertThat(providerAttemptCount()).isZero();
 
         service.markProviderAttemptStarted(second.requestId(), second.reservationOwner());
-        assertThat(attemptCount()).isEqualTo(1);
+        assertThat(providerAttemptCount()).isEqualTo(1);
     }
 
-    private int attemptCount() {
-        return jdbcTemplate.queryForObject(
+    @Test
+    @DisplayName("기존 attempt_count 값은 새 provider attempt 한도를 오염시키지 않는다")
+    void legacyAttemptCount_DoesNotBlockProviderAttemptAccounting() {
+        var first = service.begin(OWNER_KEY, GameMutationRequestService.PROGRESS, "legacy-key-001",
+                SESSION_ID, EXPECTED_TURN, "a".repeat(64));
+        jdbcTemplate.update("""
+                UPDATE game_turn_reservation
+                SET attempt_count = 3, lease_expires_at = CURRENT_TIMESTAMP - INTERVAL '1 second'
+                WHERE request_id = ? AND lease_owner = ?
+                """, first.requestId(), first.reservationOwner());
+
+        var second = service.begin(OWNER_KEY, GameMutationRequestService.PROGRESS, "legacy-key-002",
+                SESSION_ID, EXPECTED_TURN, "b".repeat(64));
+        service.markProviderAttemptStarted(second.requestId(), second.reservationOwner());
+
+        assertThat(providerAttemptCount()).isEqualTo(1);
+        assertThat(jdbcTemplate.queryForObject(
                 "SELECT attempt_count FROM game_turn_reservation WHERE session_id = ? AND expected_turn = ?",
+                Integer.class, SESSION_ID, EXPECTED_TURN)).isEqualTo(3);
+    }
+
+    private int providerAttemptCount() {
+        return jdbcTemplate.queryForObject(
+                "SELECT provider_attempt_count FROM game_turn_reservation WHERE session_id = ? AND expected_turn = ?",
                 Integer.class, SESSION_ID, EXPECTED_TURN
         );
     }

--- a/src/test/java/com/uctale/uctale/persistence/PostgresM2TurnIntegrityMatrixTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/PostgresM2TurnIntegrityMatrixTest.java
@@ -43,6 +43,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -54,6 +55,7 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
 
     private static final String OWNER_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
     private static final int LEASE_SECONDS = 30;
+    private static final long ASYNC_TIMEOUT_SECONDS = 5;
 
     @Autowired private GamePersistenceService persistenceService;
     @Autowired private GameMutationRequestRepository mutationRequestRepository;
@@ -161,16 +163,19 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
                     ready, start, rejected, "matrix-concurrent-key-b", request
             ));
 
-            ready.await();
+            awaitLatch(ready, "동시 요청 준비");
             start.countDown();
             narrativeGenerator.awaitProgressEntry();
-            rejected.await();
+            awaitLatch(rejected, "reservation 경쟁 요청 거부");
 
             assertThat(narrativeGenerator.progressCalls()).as("provider calls while lease is active").isEqualTo(1);
             assertThat(reservationCount(opening.sessionId(), 1)).as("active reservation rows").isEqualTo(1);
 
             narrativeGenerator.releaseProgress();
-            List<ProgressAttempt> attempts = List.of(first.get(), second.get());
+            List<ProgressAttempt> attempts = List.of(
+                    first.get(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    second.get(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            );
             List<ProgressAttempt> winners = attempts.stream().filter(ProgressAttempt::succeeded).toList();
             List<ProgressAttempt> losers = attempts.stream().filter(attempt -> !attempt.succeeded()).toList();
 
@@ -228,7 +233,11 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
             assertThat(jdbcTemplate.queryForObject(
                     "select attempt_count from game_turn_reservation where session_id = ? and expected_turn = ?",
                     Integer.class, opening.sessionId(), 1
-            )).as("reservation attempt_count session=%d turn=1", opening.sessionId()).isEqualTo(2);
+            )).as("legacy lease attempt_count session=%d turn=1", opening.sessionId()).isEqualTo(2);
+            assertThat(jdbcTemplate.queryForObject(
+                    "select provider_attempt_count from game_turn_reservation where session_id = ? and expected_turn = ?",
+                    Integer.class, opening.sessionId(), 1
+            )).as("provider attempt count session=%d turn=1", opening.sessionId()).isEqualTo(2);
 
             assertThatThrownBy(() -> commitWithReservation(
                     opening.sessionId(), crashedRequestId, staleOwner, "stale-owner-story"
@@ -237,7 +246,7 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
                     .hasMessageContaining("reservation");
 
             narrativeGenerator.releaseProgress();
-            GameResponse recovered = takeover.get();
+            GameResponse recovered = takeover.get(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
             assertThat(recovered.turnNumber()).isEqualTo(2);
             assertThat(narrativeGenerator.progressCalls())
@@ -260,7 +269,9 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
     ) {
         return () -> {
             ready.countDown();
-            start.await();
+            if (!start.await(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                return ProgressAttempt.failure(key, new IllegalStateException("동시 요청 시작 신호를 받지 못했습니다."));
+            }
             try {
                 GameResponse response = gameService.progressGame(
                         progressContext(key, request.sessionId()), request
@@ -273,6 +284,12 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
                 return ProgressAttempt.failure(key, exception);
             }
         };
+    }
+
+    private void awaitLatch(CountDownLatch latch, String phase) throws InterruptedException {
+        assertThat(latch.await(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                .as("%s latch가 제한 시간 안에 완료되어야 한다", phase)
+                .isTrue();
     }
 
     private GameResponse createOpening(String key) {
@@ -420,7 +437,9 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
             if (entered != null && release != null) {
                 entered.countDown();
                 try {
-                    release.await();
+                    if (!release.await(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                        throw new IllegalStateException("fake provider release 신호가 제한 시간 안에 오지 않았습니다.");
+                    }
                 } catch (InterruptedException exception) {
                     Thread.currentThread().interrupt();
                     throw new IllegalStateException("fake provider가 중단되었습니다.", exception);
@@ -437,7 +456,9 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
         void awaitProgressEntry() throws InterruptedException {
             CountDownLatch entered = progressEntered.get();
             if (entered != null) {
-                entered.await();
+                assertThat(entered.await(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                        .as("fake provider가 제한 시간 안에 진입해야 한다")
+                        .isTrue();
             }
         }
 
@@ -506,6 +527,21 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
                 throw outcome.blocked();
             }
             return outcome.result();
+        }
+
+        @Override
+        public void markProviderAttemptStarted(Long requestId, String reservationOwner) {
+            MutationInProgressException blocked = transactionTemplate.execute(status -> {
+                try {
+                    super.markProviderAttemptStarted(requestId, reservationOwner);
+                    return null;
+                } catch (MutationInProgressException exception) {
+                    return exception;
+                }
+            });
+            if (blocked != null) {
+                throw blocked;
+            }
         }
 
         @Override


### PR DESCRIPTION
## 왜 필요한가요?

`game_turn_reservation.attempt_count`가 reservation 획득 시점에 증가해, 실제 Narrative provider가 호출되기 전의 검증 실패·rate limit·budget guard 차단까지 provider 재시도 한도를 소모할 수 있었습니다. 그 결과 같은 canonical turn에서 정상 요청이 provider 호출 전에 영구적으로 막힐 수 있습니다.

- Closes #88

## 무엇이 바뀌나요?

- 게임 규칙·상태: canonical turn/state 규칙은 변경하지 않습니다.
- Backend / API / DB: reservation lease 획득과 provider attempt 소비를 분리하고, V10 migration으로 `provider_attempt_count`를 추가합니다. 실제 Narrative provider 호출 직전에만 현재 lease owner를 확인하며 카운트를 증가시킵니다.
- AI narrative / prompt: Narrative provider 호출 내용과 prompt 계약은 변경하지 않습니다.
- Image generation: 변경 없습니다.
- Frontend / UX: 변경 없습니다.
- Build / deploy / docs: reservation architecture 문서와 PostgreSQL 회귀 테스트를 갱신합니다.

## 책임 경계

게임 기능이나 AI 변경이 있다면 아래를 명확히 적어 주세요.

- **서버가 결정하는 사실:** reservation owner, lease 유효성, provider attempt 상한, canonical turn/state commit 여부
- **LLM이 서술하는 내용:** 기존과 동일하게 다음 narrative 내용과 선택지
- **LLM이 변경하면 안 되는 사실:** canonical turn/state, reservation 소유권, provider 재시도 한도

## 어떻게 검증했나요?

- [x] `./gradlew clean test`
- [x] `./gradlew build`
- [x] `cd frontend && npm ci && npm run lint && npm run build`
- [x] 정상 흐름을 직접 확인했습니다.
- [x] 잘못된 입력/실패 흐름을 확인했습니다.
- [x] 중복 요청 또는 상태 전이가 관련되면 이를 검증했습니다.

추가한 PostgreSQL 회귀 테스트는 pre-provider 실패 반복 후 정상 provider 시작 가능, 실제 provider 시작 최대 3회, stale owner 차단, legacy `attempt_count` 배포 호환성을 검증합니다. `ProviderCallTelemetryTest`에서는 budget guard 차단 시 provider 시작 훅이 실행되지 않는 것을 검증합니다.

첫 CI에서 PostgreSQL integration test가 20분 job timeout까지 대기한 원인을 추적해, reservation lifecycle의 시간 비교를 DB `CURRENT_TIMESTAMP`와 애플리케이션 `Clock`이 섞어 쓰던 문제로 확인했습니다. lease 유효성 판정과 실패 만료 시각을 주입된 `Clock`으로 통일했고, 동시성 테스트의 latch/future 대기에 5초 제한을 추가해 회귀 시 무한 대기를 방지했습니다. 수정 후 CI run #170에서 backend unit test, PostgreSQL integration test, backend build, frontend test/lint/build가 모두 통과했습니다.

PR 작성 전 비판적 리뷰에서 기존 `attempt_count`를 직접 0~3 provider 의미로 재해석하는 초기 구현이 운영 DB의 legacy lease 횟수를 provider 호출 횟수로 오인할 수 있음을 발견했습니다. 해당 지적을 타당하다고 판단해 기존 컬럼은 유지하고 V10에서 `provider_attempt_count`를 별도 추가하는 방식으로 수정했습니다.

## 게임 상태·AI 안전성

해당하지 않는 항목은 이유를 적어 주세요.

- [x] 게임의 결정적 상태는 서버에서 검증·저장됩니다.
- [x] LLM 출력만으로 HP, 보상, 성공/실패 등 결정적 상태가 임의 변경되지 않습니다.
- [x] AI 요청에 필요한 최소 문맥만 전달합니다.
- [x] AI 응답 파싱 실패와 provider 오류가 게임 상태를 오염시키지 않습니다.
- [x] 기존 저장 데이터 또는 GameState 호환성 영향을 확인했습니다.

## 보안·비용

- [x] API Key, 토큰, 비밀번호가 코드·로그·URL·클라이언트 응답에 노출되지 않습니다.
- [x] 외부 AI/Image 호출 횟수와 실패 시 동작을 검토했습니다.
- [x] 사용자 입력 길이와 외부 API 비용 증가 가능성을 검토했습니다.
- [x] CORS 또는 공개 endpoint 변경이 있다면 의도된 변경입니다.

## API·DB·운영 영향

- [x] API 계약 변경 시 Frontend 호출부와 문서를 함께 갱신했습니다.
- [x] DB schema 변경 시 migration 전략을 포함했습니다.
- [x] 환경변수는 이름과 용도만 문서화했고 실제 Secret은 포함하지 않았습니다.
- [x] 배포 후 확인할 smoke test가 있습니다.

## 화면 / 응답 예시

API 응답 계약과 UI 변경은 없습니다.
