### PR TITLE
docs: 현재 구현 상태에 맞게 문서 최신화

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,14 +23,16 @@
 
 ## 어떻게 검증했나요?
 
+- [ ] PR 작성 전 변경 diff를 비판적으로 검토하고 타당한 지적을 반영했습니다.
 - [ ] `./gradlew clean test`
+- [ ] `./gradlew postgresIntegrationTest`
 - [ ] `./gradlew build`
-- [ ] `cd frontend && npm ci && npm run lint && npm run build`
+- [ ] `cd frontend && npm ci && npm test && npm run lint && npm run build`
 - [ ] 정상 흐름을 직접 확인했습니다.
 - [ ] 잘못된 입력/실패 흐름을 확인했습니다.
 - [ ] 중복 요청 또는 상태 전이가 관련되면 이를 검증했습니다.
 
-테스트 명령과 결과, 수동 검증 시나리오를 짧게 적어 주세요.
+테스트 명령과 결과, 수동 검증 시나리오를 짧게 적어 주세요. 해당하지 않는 검증은 이유를 적어 주세요.
 
 ## 게임 상태·AI 안전성
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,22 +12,27 @@ UCTale은 LLM이 이야기를 생성하지만 게임의 결정적 상태는 서�
 - `docs`: 문서만 변경합니다.
 - `chore`: 그 외 개발 환경과 유지보수 작업입니다.
 
-커밋 메시지는 Conventional Commits 형식을 권장합니다.
+커밋 메시지는 Conventional Commits 형식을 사용하되, **제목과 설명은 식별자·기술 고유명사를 제외하면 한국어 기반으로 작성합니다.**
 
 ```text
-feat: add deterministic skill checks
-fix: return explicit session id in game response
-refactor: isolate narrative provider from game service
+feat(game): 타입 안전한 Skill Check 규칙 추가
+fix(api): 세션 응답 계약 수정
+docs: 현재 구현 상태에 맞게 문서 최신화
 ```
 
 ## 권장 작업 흐름
 
 1. Bug / Feature / Refactor / Game Design Issue 중 적절한 유형으로 문제와 완료 조건을 정의합니다.
-2. 큰 게임 시스템은 먼저 Game Design Issue에서 서버 규칙과 LLM 역할을 구분합니다.
+2. 큰 게임 시스템은 먼저 서버 규칙과 LLM 역할을 구분합니다.
 3. 작은 브랜치를 만들고 한 가지 목적만 해결합니다.
-4. 로컬 테스트와 lint/build를 통과시킵니다.
-5. PR에서 관련 Issue를 `Closes #번호`로 연결합니다.
-6. CI가 통과하고 PR 체크리스트를 확인한 뒤 main에 병합합니다.
+4. 필요한 로컬 테스트와 lint/build를 실행합니다.
+5. PR 작성 전에 변경 diff를 비판적으로 자체 리뷰하고, 타당한 지적은 먼저 반영합니다.
+6. PR 본문은 저장소 템플릿을 따르고 관련 Issue가 있으면 `Closes #번호`로 연결합니다.
+7. CI 결과와 PR 체크리스트를 실제 검증 근거에 맞게 갱신합니다.
+8. main에는 squash merge를 사용합니다.
+9. Issue 완료 조건은 구현·테스트 결과를 근거로 체크합니다.
+
+PR/Issue 체크리스트에는 체크 표시 이모지 대신 Markdown task box(`- [ ]`, `- [x]`)를 사용합니다.
 
 ## 브랜치 이름
 
@@ -35,15 +40,28 @@ refactor: isolate narrative provider from game service
 feat/skill-check
 fix/session-id-contract
 refactor/narrative-provider
-chore/github-ci
+docs/sync-current-state
 ```
 
 ## 로컬 검증
 
-### Backend
+### Backend unit / H2
 
 ```bash
 ./gradlew clean test
+```
+
+### PostgreSQL integration
+
+```bash
+./gradlew postgresIntegrationTest
+```
+
+Testcontainers 기반 PostgreSQL suite를 실행하므로 Docker-compatible container runtime이 필요합니다.
+
+### Backend build
+
+```bash
 ./gradlew build
 ```
 
@@ -52,9 +70,12 @@ chore/github-ci
 ```bash
 cd frontend
 npm ci
+npm test
 npm run lint
 npm run build
 ```
+
+문서만 변경하는 경우 관련 없는 로컬 테스트를 무조건 반복할 필요는 없지만, PR에서 왜 생략했는지와 CI 결과를 명확히 남깁니다.
 
 ## UCTale 설계 원칙
 
@@ -74,7 +95,11 @@ Gemini, Pollinations 등 외부 제공자의 DTO, URL, SDK 세부사항이 핵�
 
 AI/Image provider timeout, 잘못된 JSON, 중복 요청이 발생해도 한 턴이 두 번 적용되거나 불완전한 상태가 저장되지 않도록 설계합니다.
 
-### 5. Secret을 클라이언트에 전달하지 않습니다
+### 5. Retry와 concurrency는 canonical 결과를 바꾸지 않습니다
+
+Idempotency, turn reservation, stale-owner fencing, optimistic locking과 DB constraint를 함께 사용해 retry/concurrency/crash에서도 canonical commit이 하나로 수렴하도록 합니다.
+
+### 6. Secret을 클라이언트에 전달하지 않습니다
 
 API Key, 토큰, 비밀번호는 코드, 로그, query string 기반 public URL, frontend bundle 또는 API response에 포함하지 않습니다.
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,25 @@
 # UCTale
 
-> 사용자가 만든 세계와 캐릭터를 바탕으로 이야기를 이어가는 AI 텍스트 어드벤처
+> 사용자가 만든 세계와 캐릭터에서 시작해, 플레이어의 선택이 하나의 이야기로 이어지는 AI 텍스트 어드벤처
 
 <img alt="UCTale 프로젝트 로고" src="./docs/images/project_logo.png" width="600"/>
 
-UCTale은 사용자가 직접 입력한 세계관과 주인공 설정을 바탕으로 이야기를 생성하는 텍스트 어드벤처입니다.
-
-플레이어는 매 턴 제시되는 선택지 가운데 하나를 고르고, 선택에 따라 다음 장면과 선택지가 이어집니다. 장면에 시각적으로 보여줄 요소가 있을 때는 이야기와 함께 삽화도 생성합니다.
+UCTale은 사용자가 직접 입력한 세계관과 주인공 설정을 바탕으로 이야기를 생성하는 인터랙티브 텍스트 어드벤처입니다. 플레이어는 서버가 발급한 선택 행동 가운데 하나를 고르고, 선택 결과에 따라 다음 장면과 선택지가 이어집니다. 장면에 시각적으로 표현할 요소가 있으면 서버가 관리하는 image asset을 통해 삽화도 제공합니다.
 
 [서비스 바로가기](https://uctale.vercel.app/)
+
+---
+
+## 현재 방향
+
+UCTale의 핵심 원칙은 **게임의 결정적 사실과 규칙은 서버가 소유하고, LLM은 확정된 결과를 서술한다**는 것입니다.
+
+현재 main은 공유 베타 운영 안전망과 신뢰 가능한 턴 저장 기반의 구현 범위를 갖추었고, M3에서 서버 주도 행동 판정과 Skill Check를 확장하는 단계입니다.
+
+- 서버: 세션 소유권, 현재 턴, idempotency, reservation lease, canonical state, GameLog, provider attempt 상한을 검증합니다.
+- Narrative AI: 서버가 전달한 문맥을 바탕으로 이야기와 다음 선택지 표현을 생성합니다.
+- Image AI: 브라우저의 임의 prompt가 아니라 서버가 발급한 image asset 계약만 실행합니다.
+- Frontend: 서버가 반환한 선택 행동과 상태를 표시하고, 규칙을 재계산하지 않습니다.
 
 ---
 
@@ -32,14 +43,13 @@ UCTale은 사용자가 직접 입력한 세계관과 주인공 설정을 바탕�
 
 ## 플레이 방식
 
-1. 공유 베타 접근 비밀번호를 확인해 단기 접근 세션을 발급받습니다.
+1. 공유 베타 접근 비밀번호로 단기 접근 세션을 발급받습니다.
 2. 원하는 세계관과 주인공을 입력합니다.
-3. 서버가 입력 내용을 바탕으로 첫 장면과 선택지를 생성합니다.
-4. 플레이어가 선택지를 고르면 다음 턴이 진행됩니다.
-5. 서버는 현재 턴과 게임 상태를 저장하고, 필요한 문맥만 Narrative Engine에 전달합니다.
-6. 시각적으로 표현할 장면이 있으면 서버가 발급한 image asset을 통해 삽화를 제공합니다.
-
-현재 플레이는 AI가 모든 게임 상태를 임의로 결정하는 방식이 아니라, 장기적으로 서버가 게임의 사실과 규칙을 소유하고 LLM은 그 결과를 이야기로 표현하는 구조를 목표로 개발하고 있습니다.
+3. 서버가 첫 장면과 서버 발급 선택 행동을 생성합니다.
+4. 플레이어가 현재 턴에 유효한 행동을 선택합니다.
+5. 서버가 소유권, expected turn, idempotency, action payload를 검증합니다.
+6. 필요한 경우 Narrative provider를 호출하고 canonical state와 committed-turn log를 원자적으로 저장합니다.
+7. 시각적으로 표현할 장면이 있으면 서버가 발급한 image asset을 통해 삽화를 제공합니다.
 
 ---
 
@@ -48,69 +58,72 @@ UCTale은 사용자가 직접 입력한 세계관과 주인공 설정을 바탕�
 ### 공유 베타 접근 제어와 세션 소유권
 
 - 비밀번호 검증 성공 시 서버가 서명한 단기 접근 세션을 HttpOnly 쿠키로 발급합니다.
-- 별도의 장기 owner key로 게임 세션 소유권을 서버와 DB에서 관리합니다.
+- 별도의 장기 owner key로 게임 세션 소유권을 서버와 PostgreSQL에서 관리합니다.
 - 다른 owner는 session ID를 알아도 해당 세션을 조회하거나 진행할 수 없습니다.
-- 게임 시작, 턴 진행, 이미지 asset API는 유효한 접근 세션이 있어야 호출할 수 있습니다.
-- 운영 기본 CORS origin은 `https://uctale.vercel.app`만 허용하며, 허용 origin은 환경변수로 명시적으로 관리합니다.
-- 접근 세션이 만료되거나 유효하지 않으면 프론트엔드가 재인증 화면으로 전환합니다.
+- 게임 시작, 턴 진행, image asset API는 유효한 접근 세션이 있어야 호출할 수 있습니다.
+- 운영 CORS origin은 명시적으로 관리하며 기본 production origin은 `https://uctale.vercel.app`입니다.
 - 공유 비밀번호 인증 실패는 별도의 IP 기반 rate limit으로 보호합니다.
 
-### 이야기 생성과 선택지 진행
+### 서버 발급 행동 경계
 
-- 세계관과 캐릭터 설정을 입력해 새 게임 세션을 시작할 수 있습니다.
-- Gemini가 현재 문맥을 바탕으로 이야기와 다음 선택지를 생성합니다.
-- 클라이언트는 서버가 반환한 `sessionId`와 현재 턴을 기준으로 다음 진행 요청을 보냅니다.
-- 오래된 턴이나 중복 진행 요청은 서버에서 충돌로 처리합니다.
-- provider 응답의 필수 필드, 길이, 선택지 ID 중복 등을 저장 전에 검증합니다.
+M3의 첫 선행 작업인 #33이 main에 반영되어 `AvailableAction`과 `PlayerAction` 경계가 존재합니다.
+
+- 서버는 각 선택지에 action token/type/source turn/arguments를 발급할 수 있습니다.
+- `/progress`는 현재 turn의 서버 발급 action과 요청 payload가 일치하는지 검증합니다.
+- 변조되거나 만료된 action은 provider 호출 전에 거절됩니다.
+- 기존 `choiceId` 기반 요청은 compatibility 경로로 유지합니다.
+- 실제 전투, 아이템 사용, Skill Check 같은 규칙 행동은 후속 M3 작업에서 이 경계 위에 추가합니다.
 
 ### GameState와 Story Memory
 
-게임의 장기 문맥을 단순히 전체 대화 기록으로 다시 전달하지 않습니다.
-
-서버는 세션별 `GameState`를 저장하고, Narrative Engine에는 다음 정보를 구분해 전달합니다.
+서버는 세션별 canonical `GameState`를 JSON snapshot으로 저장하고 Narrative Engine에는 필요한 문맥만 전달합니다.
 
 - `canonicalFacts`: 서버가 유지하는 장기 사실
-- `rollingSummary`: 오래된 진행 내용을 압축한 기록
-- `recentTurns`: 가장 최근 6턴
+- `rollingSummary`: 오래된 진행 내용을 제한된 크기로 압축한 기록
+- `recentTurns`: 최근 진행 기록
 
-최신 상태는 `game_state_snapshot`에 JSON 스냅샷으로 저장하며, 세션과 턴 기록은 별도로 유지합니다.
+snapshot JSON은 schema/ruleset version을 가지며 legacy production snapshot을 deterministic upgrader로 읽을 수 있습니다. read-time upgrade는 in-memory에서만 수행하고 다음 정상 canonical write에서 최신 형식으로 저장합니다.
 
-현재 이 구조는 이후 능력치, 전투, 인벤토리, 퀘스트 같은 서버 주도 게임 규칙을 추가하기 위한 기반 단계입니다.
+### 신뢰 가능한 턴 파이프라인
 
-### 턴 저장과 무결성
+M2의 턴 무결성·복구 구현 범위와 완료 조건은 main에 반영되었습니다.
 
-- 세션마다 현재 턴 번호와 optimistic-lock version을 관리합니다.
-- 진행 요청은 `expectedTurn`을 포함합니다.
-- 동일 세션에서 같은 턴이 중복 저장되지 않도록 DB 제약과 서버 검증을 함께 사용합니다.
-- AI 호출은 긴 DB transaction 밖에서 수행합니다.
-- AI 또는 저장 실패가 발생해도 불완전한 다음 턴이 남지 않도록 처리합니다.
-
-현재 M2에서는 여기서 더 나아가 idempotency key, turn reservation/lease, append-only committed-turn ledger와 PostgreSQL 동시성 회귀 검증을 추가하는 중입니다.
+- `Idempotency-Key`로 `/init`과 `/progress` mutation retry를 식별합니다.
+- 같은 key + 같은 payload의 완료 요청은 provider를 재호출하지 않고 canonical 결과를 replay합니다.
+- 같은 key를 다른 payload/operation에 재사용하면 provider 호출 전에 conflict로 거절합니다.
+- `(session_id, expected_turn)` reservation lease로 유효 lease 동안 중복 provider 진입을 억제합니다.
+- provider attempt는 reservation 획득 횟수와 분리된 `provider_attempt_count`로 관리하며 turn당 최대 3회로 제한합니다.
+- validation, rate limit, budget guard 같은 pre-provider 실패는 provider attempt를 소비하지 않습니다.
+- stale lease owner는 takeover 이후 canonical commit을 수행할 수 없습니다.
+- `GameLog`는 append-only committed-turn ledger이고 `GameStateSnapshot`은 최신 상태 복구용 materialized snapshot입니다.
+- `GameSession.currentTurn`, GameLog state version, snapshot, mutation result는 한 canonical commit으로 수렴합니다.
+- 외부 provider strict exactly-once는 보장하지 않지만 canonical DB commit exactly-once와 bounded provider retry를 보장합니다.
 
 ### 이미지 생성
 
-- Pollinations를 통해 게임 장면에 사용할 이미지를 생성합니다.
-- 클라이언트는 임의 prompt를 provider에 전달할 수 없고, 서버가 발급한 session/turn-scoped image asset만 요청할 수 있습니다.
-- Provider 토큰과 내부 URL은 서버 밖으로 노출하지 않습니다.
-- 동일 asset은 저장된 model, prompt, size, seed, style version을 재사용합니다.
-- 기본 정책은 `flux`, `768x432`, `uctale-charcoal-v2`이며 환경 설정으로 변경할 수 있습니다.
-- provider 오류가 발생해도 canonical game turn은 유지되고, 이전 이미지 또는 fallback으로 게임을 계속 진행할 수 있습니다.
+- Pollinations를 통해 게임 장면 이미지를 생성합니다.
+- 브라우저는 provider prompt나 secret을 전달받지 않고 서버 발급 asset URL만 사용합니다.
+- 동일 asset은 저장된 model, prompt, size, seed, safe, style version을 재사용합니다.
+- 기본 정책은 `flux`, `768x432`, `uctale-charcoal-v2`입니다.
+- provider 응답은 JPEG/PNG, 최대 8 MiB 계약을 검증합니다.
+- provider 오류가 발생해도 canonical game turn은 유지됩니다.
 
 ### 비용 보호와 관측성
 
-- Narrative와 Image 비용 API는 owner/IP/session 기준의 in-process rate limit을 적용합니다.
-- Narrative와 Image quota는 독립적으로 조정할 수 있습니다.
-- provider 호출마다 provider, operation, session, turn, request ID, latency, outcome, retry count를 구조화 로그로 기록합니다.
+- Narrative/Image 비용 API는 owner/IP/session 기준의 in-process rate limit을 적용합니다.
+- PostgreSQL `provider_usage_event` ledger로 일/월 provider 사용량을 누적합니다.
+- warning/critical budget threshold와 선택적 `FAIL_CLOSED` 정책을 지원합니다.
+- provider 호출마다 provider, model, operation, session, turn, request ID, latency, outcome, retry/attempt 수를 구조화 로그로 기록합니다.
 - prompt/응답 전문, 비밀번호, API key, access/owner token은 관측 로그에 남기지 않습니다.
-- 현재 limiter는 단일 애플리케이션 인스턴스 기준이며 multi-instance 환경에서는 전역 quota를 보장하지 않습니다.
 
 ### 프론트엔드 UX
 
-- Charcoal Folio 기반의 narrative-first single-column UI를 사용합니다.
-- `system | light | dark` 테마와 SUIT Variable typography를 지원합니다.
-- API 오류는 browser `alert()` 대신 화면 문맥 안에서 표시하고 가능한 경우 retry를 제공합니다.
-- 진행 중 중복 요청을 막고, typewriter skip 및 `prefers-reduced-motion`을 지원합니다.
-- image loading/failure, keyboard focus 이동, live-region 등 공유 베타용 accessibility behavior를 보강했습니다.
+- Charcoal Folio 기반 narrative-first single-column UI를 사용합니다.
+- React 19, Vite 8, plain CSS, SUIT Variable을 사용합니다.
+- `system | light | dark` 테마를 지원합니다.
+- API 오류는 화면 문맥 안에서 표시하고 가능한 경우 retry를 제공합니다.
+- 진행 중 중복 요청을 막고 typewriter skip 및 `prefers-reduced-motion`을 지원합니다.
+- image loading/failure, keyboard focus 이동, live-region 등 공유 베타 accessibility behavior를 포함합니다.
 - Vercel Web Analytics를 통해 production page view를 확인할 수 있습니다.
 
 ---
@@ -119,10 +132,10 @@ UCTale은 사용자가 직접 입력한 세계관과 주인공 설정을 바탕�
 
 | 영역 | 기술 |
 | :--- | :--- |
-| Frontend | React 19, React Router 7, Vite 8, Axios |
+| Frontend | React 19, React Router 7, Vite 8, Axios, plain CSS |
 | Backend | Java 21, Spring Boot 4.1, Spring Web MVC, Spring Data JPA |
 | Database | PostgreSQL, Flyway |
-| Test Database | H2, PostgreSQL integration test 도입 예정(M2) |
+| Test Database | H2 + Testcontainers PostgreSQL 17.6 |
 | Narrative AI | Google Gemini 2.5 Flash |
 | Image AI | Pollinations |
 | Deployment | Vercel, Render |
@@ -137,25 +150,26 @@ uctale/
 ├── src/main/java/            # Spring Boot 백엔드
 ├── src/main/resources/
 │   ├── application.properties
-│   └── db/                   # Flyway migration
-├── src/test/                 # 백엔드 테스트
-├── docs/                     # 설계 문서와 이미지
-├── scripts/                  # benchmark/검증 도구
+│   └── db/migration/          # Flyway migration
+├── src/test/                 # unit/H2/PostgreSQL integration tests
+├── docs/                     # architecture, testing, operations, benchmark 문서
+├── scripts/                  # benchmark/production smoke 도구
 ├── build.gradle
 └── README.md
 ```
 
-백엔드는 게임 진행 로직이 Gemini나 Pollinations의 구현 세부사항에 직접 의존하지 않도록 Provider 경계를 분리하고 있습니다.
+주요 설계 문서:
 
-핵심 방향은 다음과 같습니다.
-
-- 게임의 결정적인 상태는 서버가 소유합니다.
-- LLM은 확정된 문맥을 바탕으로 이야기를 생성합니다.
-- 외부 AI Provider의 DTO와 호출 방식은 게임 도메인과 분리합니다.
-- Provider 오류나 중복 요청이 저장된 게임 상태를 훼손하지 않도록 합니다.
-- API Key와 토큰은 프론트엔드나 공개 응답에 포함하지 않습니다.
-
-자세한 개발 원칙은 [CONTRIBUTING.md](./CONTRIBUTING.md), [GameState / Story Memory 설계 문서](./docs/architecture/game-state-story-memory.md), [비용 보호 문서](./docs/architecture/cost-controls.md), [이미지 생성 문서](./docs/architecture/image-generation.md)에서 확인할 수 있습니다.
+- [개발 원칙](./CONTRIBUTING.md)
+- [GameState / Story Memory](./docs/architecture/game-state-story-memory.md)
+- [Game mutation idempotency](./docs/architecture/game-mutation-idempotency.md)
+- [Turn reservation lease](./docs/architecture/game-turn-reservation.md)
+- [Committed-turn GameLog](./docs/architecture/game-log-ledger.md)
+- [Snapshot evolution](./docs/architecture/game-state-snapshot-evolution.md)
+- [비용 보호](./docs/architecture/cost-controls.md)
+- [이미지 생성](./docs/architecture/image-generation.md)
+- [PostgreSQL integration tests](./docs/testing/postgresql-integration-tests.md)
+- [Production smoke](./docs/operations/production-smoke.md)
 
 ---
 
@@ -164,8 +178,9 @@ uctale/
 ### 필요한 환경
 
 - Java 21
-- Node.js
+- Node.js 22 권장
 - PostgreSQL
+- Docker-compatible container runtime: PostgreSQL integration test 실행 시 필요
 - Google AI API Key
 - Pollinations Token
 
@@ -183,13 +198,9 @@ DATABASE_USERNAME=...
 DATABASE_PASSWORD=...
 ```
 
-`GAME_ACCESS_COOKIE_SECURE=false`는 로컬 HTTP 개발용입니다. 운영에서는 기본값 `true`를 사용해 `Secure; SameSite=None` HttpOnly 쿠키를 발급합니다. 운영 CORS 기본값은 `https://uctale.vercel.app`이며, 다른 origin을 허용해야 할 때만 `GAME_CORS_ALLOWED_ORIGINS`를 쉼표로 구분해 명시합니다.
-
-비용/인증/이미지 정책의 세부 환경변수는 `src/main/resources/application.properties`와 관련 architecture 문서를 기준으로 관리합니다.
+세부 정책 환경변수는 `src/main/resources/application.properties`와 관련 architecture 문서를 기준으로 관리합니다.
 
 ### 백엔드 실행
-
-macOS / Linux:
 
 ```bash
 ./gradlew bootRun
@@ -201,36 +212,39 @@ Windows:
 .\gradlew.bat bootRun
 ```
 
-기본 포트는 `8080`입니다.
-
 ### 프론트엔드 실행
 
 ```bash
 cd frontend
-npm install
+npm ci
 npm run dev
 ```
 
-로컬 백엔드를 사용할 경우 별도 설정 없이 `http://localhost:8080/api/game`을 사용합니다.
-
-다른 API 서버를 사용할 경우 `frontend` 환경 변수에 다음 값을 설정합니다.
-
-```env
-VITE_API_URL=https://example.com/api/game
-```
+기본 개발 API는 `http://localhost:8080/api/game`입니다. 다른 API 서버를 사용할 경우 `VITE_API_URL`을 설정합니다.
 
 ---
 
 ## 테스트와 빌드
 
-백엔드:
+Backend unit/H2 suite:
 
 ```bash
 ./gradlew clean test
+```
+
+PostgreSQL integration suite:
+
+```bash
+./gradlew postgresIntegrationTest
+```
+
+Backend build:
+
+```bash
 ./gradlew build
 ```
 
-프론트엔드:
+Frontend:
 
 ```bash
 cd frontend
@@ -240,7 +254,7 @@ npm run lint
 npm run build
 ```
 
-M2의 #73에서 실제 PostgreSQL 의미론을 검증하는 별도 integration-test task와 CI 실행 경계를 추가할 예정입니다.
+GitHub Actions CI도 backend unit test → PostgreSQL integration test → backend build 순서와 frontend test/lint/build를 실행합니다.
 
 ---
 
@@ -248,38 +262,32 @@ M2의 #73에서 실제 PostgreSQL 의미론을 검증하는 별도 integration-t
 
 ### M1 — 공유 베타 운영 안전망
 
-**완료.** production smoke test까지 통과한 상태입니다.
+구현 범위 완료.
 
-M1에서 완료한 주요 범위:
+- 공유 접근 세션과 owner 기반 세션 소유권
+- API/CORS/Secret 경계
+- image asset 보안
+- rate limit과 provider 관측성
+- Charcoal Folio UI 및 accessibility 마감
+- production post-deploy smoke 자동화
 
-- 비용 발생 API validation과 안정적인 오류 계약
-- 공유 접근 세션, CORS allowlist, 게임 세션 소유권
-- 서버 발급 image asset과 Pollinations 생성 계약 보강
-- Narrative/Image rate limit과 provider 관측성
-- 공유 비밀번호 인증 시도 rate limit
-- Charcoal Folio UI foundation과 interaction/accessibility UX
-- Vercel Web Analytics
-- production smoke에서 발견된 CORS/UI/image style 회귀 보완
+### M2 — 신뢰 가능한 턴 파이프라인
 
-### M2 — 턴 무결성·복구 기반
+구현 범위 완료.
 
-핵심 목표는 **같은 사용자 행동이 retry/concurrency/crash 상황에서도 canonical game state에 한 번만 commit되고, 저장된 결과를 복구·감사할 수 있게 하는 것**입니다.
+- PostgreSQL integration test harness
+- append-only committed-turn `GameLog`
+- snapshot schema/ruleset version과 upgrader
+- `/init`·`/progress` idempotency
+- turn reservation/lease와 stale-owner fencing
+- PostgreSQL 동시성·migration·crash regression matrix
+- global provider budget guard
+- provider attempt accounting과 pre-provider failure 회귀 수정
 
-권장 순서:
+### M3 — 서버 주도 행동 판정
 
-1. **#73** PostgreSQL integration test harness와 CI 기반
-2. **#28** append-only committed-turn `GameLog` 원장
-3. **#31** GameState snapshot schema/ruleset version + upgrader — #28과 병렬 가능
-4. **#29** `/init`·`/progress` 게임 mutation idempotency
-5. **#30** turn reservation/lease로 정상 동시 요청의 중복 provider 실행 억제
-6. **#32** M2 PostgreSQL 동시성·migration·복구 최종 회귀 matrix
+진행 중.
 
-운영 보강 트랙인 **#70 production post-deploy smoke 자동화**, **#71 전역 AI 비용 budget guard**는 위 핵심 체인의 선행조건이 아니므로 병렬 또는 후순위로 진행합니다.
+현재 #33 `AvailableAction` / `PlayerAction` 경계는 main에 반영되었습니다. 다음 핵심 작업은 타입 안전한 캐릭터 능력치와 pure Skill Check(#7), `ActionResolver` / `GameResult` 경계(#34), 확정 결과 기반 NarrativeContext(#36), 실제 turn 통합(#37) 순으로 확장하는 것입니다.
 
-M2에서 strict external-provider exactly-once까지 약속하지는 않습니다. DB lease만으로는 provider 성공 직후 commit 전 프로세스 장애 같은 구간에서 재호출 가능성을 완전히 제거할 수 없기 때문에, **canonical commit exactly-once + 유효 reservation 구간의 중복 provider 억제 + bounded recovery**를 현실적인 보장 범위로 둡니다.
-
-### 이후
-
-M2가 안정되면 다음 단계에서 서버 주도 `AvailableAction`, `PlayerAction`, `GameResult`, 타입 안전한 캐릭터 능력치와 Skill Check를 연결하고, 이후 전투·인벤토리·퀘스트·NPC 관계 시스템으로 확장합니다.
-
-아직 구현되지 않은 기능을 현재 기능처럼 문서에 표시하지 않고, 실제 main 코드와 완료된 작업을 기준으로 README를 갱신하는 것을 원칙으로 합니다.
+아직 구현되지 않은 전투·인벤토리·퀘스트·NPC 관계 기능은 현재 기능처럼 문서에 표시하지 않습니다.

--- a/docs/architecture/cost-controls.md
+++ b/docs/architecture/cost-controls.md
@@ -2,17 +2,17 @@
 
 ## 목적
 
-공유 베타에서 인증된 사용자의 반복 클릭·자동화 요청·재시도로 Narrative/Image provider 비용이 급증하는 상황을 줄이고, 실제 provider 호출을 turn 단위로 추적할 수 있게 한다.
+공유 베타에서 인증된 사용자의 반복 클릭·자동화 요청·재시도로 Narrative/Image provider 비용이 급증하는 상황을 줄이고, 실제 provider 호출을 turn 단위로 추적합니다.
 
-## Rate limit
+## Per-request rate limit
 
-현재 구현은 단일 application instance 메모리 안에서 동작하는 fixed-window limiter다.
+현재 구현은 단일 application instance 메모리 안에서 동작하는 fixed-window limiter입니다.
 
-- Narrative와 Image quota를 서로 분리한다.
-- owner principal, client IP, session(존재할 때) 각각에 같은 operation quota를 적용한다.
-- 어느 bucket 하나라도 한도를 넘으면 provider 호출 전에 `429 RATE_LIMIT_EXCEEDED`를 반환한다.
-- 응답에는 다음 window까지 남은 초를 `Retry-After` 헤더로 제공한다.
-- 이미 생성되어 DB에 저장된 image asset 조회는 provider 비용이 들지 않으므로 quota를 소비하지 않는다.
+- Narrative와 Image quota를 분리합니다.
+- owner principal, client IP, session(존재할 때) 각각에 operation quota를 적용합니다.
+- 어느 bucket 하나라도 한도를 넘으면 provider 호출 전에 `429 RATE_LIMIT_EXCEEDED`를 반환합니다.
+- 다음 window까지 남은 초를 `Retry-After` header로 제공합니다.
+- 이미 DB에 저장된 image asset 조회는 provider 비용이 없으므로 quota를 소비하지 않습니다.
 
 기본값:
 
@@ -28,15 +28,13 @@
 
 ### 접근 비밀번호 인증 rate limit
 
-`POST /api/game/verify-password`는 비용 API quota와 별도의 IP 기반 실패 limiter를 사용한다.
+`POST /api/game/verify-password`는 비용 API quota와 별도의 IP 기반 실패 limiter를 사용합니다.
 
-- 기본값은 300초 window에서 연속 실패 5회까지 허용하고, 다음 인증 시도부터 `429 ACCESS_RATE_LIMIT_EXCEEDED`를 반환한다.
-- 응답에는 현재 fixed window가 끝날 때까지의 초를 `Retry-After`로 제공한다.
-- 정상 인증이 성공하면 해당 IP의 실패 counter를 초기화한다.
-- 비밀번호 검증과 실패 counter 갱신은 하나의 원자적 limiter 경계에서 처리해 동시 요청 burst가 실패 한도를 우회하지 못하게 한다.
-- client IP는 비용 limiter와 동일한 `ClientIpResolver` 경계를 재사용한다.
-- 인증 실패는 Narrative/Image quota를 소비하지 않는다.
-- 비밀번호, request body, access/owner token은 limiter에서 로그로 남기지 않는다.
+- 기본값은 300초 window에서 연속 실패 5회입니다.
+- 한도를 넘으면 `429 ACCESS_RATE_LIMIT_EXCEEDED`와 `Retry-After`를 반환합니다.
+- 정상 인증 성공 시 해당 IP의 실패 counter를 초기화합니다.
+- 비밀번호 판정과 실패 counter 갱신은 하나의 limiter 경계에서 처리합니다.
+- 비밀번호, request body, access/owner token은 limiter 로그에 남기지 않습니다.
 
 환경변수:
 
@@ -45,23 +43,21 @@
 
 ### Rate limit 운영 한계
 
-이 limiter들은 Render 인스턴스 하나의 메모리에만 존재한다. 인스턴스가 여러 개가 되면 각 인스턴스가 독립 quota/counter를 가지므로 전역 한도를 보장하지 않는다. 현재 단일 인스턴스 공유 베타에 맞춘 burst 안전장치이며, multi-instance 전환 시 Redis 등 외부 shared store 기반 limiter로 교체한다.
+이 limiter들은 Render application instance 하나의 메모리에 존재합니다. 여러 instance가 되면 각 instance가 독립 quota/counter를 가지므로 전역 한도를 보장하지 않습니다. 현재 단일 instance 공유 베타의 burst 안전장치이며 multi-instance 전환 시 external shared store 기반 limiter를 검토합니다.
 
 ## 전역 AI budget guard
 
-#71부터 per-owner/IP/session rate limit과 별도로 PostgreSQL 기반 전역 usage ledger를 유지한다. 이 경계의 목적은 순간 burst 제한이 아니라 일/월 단위 총 provider 사용량을 관측하고 운영 예산 임계치를 적용하는 것이다.
+Per-owner/IP/session rate limit과 별도로 PostgreSQL `provider_usage_event` ledger를 유지합니다. 이 경계의 목적은 순간 burst 제한이 아니라 일/월 단위 전체 provider 사용량을 누적하고 운영 예산 임계치를 적용하는 것입니다.
 
 ### Budget metric
 
-초기 공유 베타에서는 provider 청구 금액을 직접 계산하지 않고 `budget unit`을 사용한다.
+현재는 provider 청구 금액을 직접 계산하지 않고 `budget unit`을 사용합니다.
 
-- 실제 provider attempt 1회에 operation별 설정 unit을 곱한다.
-- `attemptCount = retryCount + 1`이므로 최초 호출과 내부 retry가 모두 집계된다.
-- 성공/실패 모두 provider가 실제 호출되었다면 usage ledger에 기록한다.
-- ledger에는 `provider`, `model`, `operation`, `outcome`, `attempt_count`, `budget_units`, 발생 시각만 저장한다.
-- prompt/response 전문, API key, 비밀번호, access/owner token은 저장하지 않는다.
-
-기본 단위는 Narrative/Image 모두 attempt당 1 unit이다. provider 단가 차이를 반영해야 할 때 배포 설정으로 가중치를 조정한다.
+- 실제 provider attempt 1회에 operation별 설정 unit을 곱합니다.
+- adapter 내부 retry도 실제 시도 수에 포함합니다.
+- 성공/실패 모두 provider가 실제 호출되었다면 ledger에 기록합니다.
+- ledger에는 provider/model/operation/outcome/attempt count/budget units/발생 시각만 저장합니다.
+- prompt/response 전문, API key, 비밀번호, access/owner token은 저장하지 않습니다.
 
 환경변수:
 
@@ -73,29 +69,31 @@
 - `GAME_COST_BUDGET_IMAGE_ATTEMPT_UNITS`
 - `GAME_COST_BUDGET_CRITICAL_MODE` (`ALERT_ONLY` 또는 `FAIL_CLOSED`)
 
-일/월 경계는 UTC 기준이다.
+일/월 경계는 UTC입니다.
 
 ### Alert와 차단 정책
 
-usage 기록 후 warning 또는 critical threshold를 처음 넘어가는 호출에서 구조화 로그 `ai_budget_alert`를 생성한다.
+usage 기록 후 warning 또는 critical threshold를 처음 넘어가는 호출에서 구조화 로그 `ai_budget_alert`를 생성합니다.
 
 - warning: `level=WARNING`
 - critical: `level=CRITICAL`
 - ledger 저장 실패: `level=ACCOUNTING_FAILURE`
 
-기본 `critical-mode`는 `ALERT_ONLY`다. 공유 베타에서 임계치 설정 오류나 일시적 사용량 증가만으로 게임을 갑자기 중단하지 않기 위한 선택이다.
+기본 `critical-mode`는 `ALERT_ONLY`입니다. `FAIL_CLOSED`에서는 신규 provider 호출 직전에 현재 usage와 다음 1회 unit을 조회하고 critical을 넘는 신규 호출을 `503 AI_BUDGET_EXCEEDED`로 차단합니다.
 
-`FAIL_CLOSED`로 설정하면 신규 provider 호출 직전에 현재 UTC 일/월 usage와 다음 1회 attempt unit을 조회하고 critical을 넘는 호출을 `503 AI_BUDGET_EXCEEDED`로 차단한다. provider 내부 retry는 한 번의 adapter 호출 안에서 발생하므로 retry가 임계치를 넘긴 경우 해당 호출 자체를 중간 취소하지 않고, 실제 retry 수를 사후 ledger에 반영한 뒤 다음 신규 호출부터 차단한다.
+Narrative `/progress`에서는 budget guard가 provider attempt accounting보다 먼저 실행됩니다. 따라서 budget pre-call rejection은 turn reservation의 `provider_attempt_count`를 소비하지 않습니다.
+
+provider 내부 retry는 하나의 adapter 호출 안에서 발생하므로 retry 도중 threshold를 넘더라도 해당 호출을 중간 취소하지 않고 실제 retry 수를 사후 ledger에 반영한 뒤 다음 신규 호출부터 차단합니다.
 
 ### 정확도와 multi-instance 경계
 
-usage ledger와 일/월 합계는 PostgreSQL을 사용하므로 application 재시작으로 초기화되지 않으며 여러 application instance가 같은 DB를 사용할 때도 완료된 provider attempt 집계는 공유된다.
+usage ledger와 일/월 합계는 PostgreSQL을 사용하므로 application 재시작으로 초기화되지 않고 여러 application instance가 같은 DB를 사용할 때 완료된 usage 집계는 공유됩니다.
 
-다만 `FAIL_CLOSED`의 pre-check와 실제 provider 호출 사이에는 DB lock을 장시간 유지하지 않는다. 따라서 여러 instance가 critical 직전에서 동시에 호출하면 소수의 동시 요청이 임계치를 초과할 수 있다. 외부 provider 호출 동안 DB transaction/advisory lock을 유지하는 것은 connection pool과 장애 격리 비용이 더 크므로 M2 범위에서 제외한다. 엄격한 hard cap이 필요해지면 provider 호출 reservation 또는 distributed budget token store를 별도 도입한다.
+다만 `FAIL_CLOSED` pre-check와 실제 provider 호출 사이에는 장기 DB lock을 유지하지 않습니다. 여러 instance가 critical 직전에서 동시에 호출하면 소수의 동시 요청이 threshold를 초과할 수 있습니다. 외부 provider 호출 동안 DB transaction/advisory lock을 유지하는 대신 현재는 availability와 DB connection 비용을 우선합니다. 엄격한 hard cap이 필요해지면 distributed budget token/reservation을 별도 설계합니다.
 
 ## Provider 관측성
 
-provider 호출마다 다음 항목을 구조화된 key/value 로그로 기록한다.
+provider 호출마다 다음 항목을 구조화 로그로 기록합니다.
 
 - provider
 - model
@@ -109,15 +107,16 @@ provider 호출마다 다음 항목을 구조화된 key/value 로그로 기록�
 - retryCount
 - attemptCount
 
-사용자 world/character/action, provider prompt/응답 전문, access/owner token, API key는 로그에 기록하지 않는다.
+사용자 world/character/action, provider prompt/응답 전문, access/owner token, API key는 로그에 기록하지 않습니다.
 
-Narrative는 현재 provider 내부 retry가 없어 `retryCount=0`이다. Image는 #50부터 Pollinations bounded retry의 실제 횟수를 성공 결과 또는 최종 실패에서 추출해 같은 `provider_call` event에 기록한다. 이미지별 model/size/seed/status 등 상세 진단은 `image_provider_result` event를 함께 사용한다.
+Narrative는 현재 provider 내부 retry가 없어 `retryCount=0`입니다. Image는 Pollinations bounded retry의 실제 횟수를 성공 결과 또는 최종 실패에서 추출해 같은 `provider_call` event에 기록합니다. 이미지별 model/size/seed/status 등 상세 진단은 `image_provider_result` event를 사용합니다.
 
 ## 책임 경계
 
-- Access authentication: `AccessController`가 `ClientIpResolver`로 IP를 식별하고 `AccessAuthenticationRateLimiter` 안에서 비밀번호 판정과 실패 counter를 원자적으로 처리한다.
-- Per-request cost rate limit (#27): owner/IP/session별 짧은 fixed window에서 burst와 반복 요청을 제한한다. 단일 instance 메모리 경계다.
-- Global budget guard (#71): PostgreSQL usage ledger를 기준으로 UTC 일/월 전체 provider 사용량을 집계하고 warning/critical 운영 신호와 선택적 fail-closed를 제공한다.
-- Narrative: `GameService`가 소유권/turn 조회 후 rate limit을 확인하고 Gemini 호출만 telemetry로 감싼다.
-- Image: `ImageAssetService`가 asset 소유권과 기존 생성 결과를 먼저 확인한다. 미생성 asset에 대해서만 lock 내부에서 rate limit을 확인하고 Pollinations 호출을 telemetry로 감싼다.
-- DB에 저장된 이미지 재조회는 provider를 호출하지 않으므로 Image quota와 global budget unit을 소비하지 않는다.
+- Access authentication: `AccessAuthenticationRateLimiter`가 비밀번호 실패 burst를 제한합니다.
+- Per-request cost rate limit: owner/IP/session별 짧은 fixed window에서 반복 요청을 제한합니다.
+- Global budget guard: PostgreSQL usage ledger를 기준으로 UTC 일/월 provider 사용량과 warning/critical 정책을 관리합니다.
+- Turn provider attempt: `game_turn_reservation.provider_attempt_count`가 같은 canonical turn의 실제 Narrative provider 시작을 최대 3회로 제한합니다. 이는 전역 budget ledger와 별개의 무결성 경계입니다.
+- Narrative: `GameService`가 소유권/turn/action/rate limit을 확인하고 budget guard와 provider attempt 시작 경계를 통과한 호출만 Gemini telemetry로 감쌉니다.
+- Image: `ImageAssetService`가 asset 소유권과 기존 생성 결과를 먼저 확인하고 미생성 asset에 대해서만 rate limit과 provider 호출을 수행합니다.
+- DB에 저장된 이미지 재조회는 provider를 호출하지 않으므로 Image quota와 global budget unit을 소비하지 않습니다.

--- a/docs/architecture/game-log-ledger.md
+++ b/docs/architecture/game-log-ledger.md
@@ -2,12 +2,12 @@
 
 ## 책임
 
-UCTale의 persistence는 `GameLog`와 `GameStateSnapshot`을 서로 다른 목적으로 사용합니다.
+UCTale persistence는 `GameLog`와 `GameStateSnapshot`을 서로 다른 목적으로 사용합니다.
 
 - `GameLog`: 이미 commit된 canonical turn의 append-only 감사 원장
 - `GameStateSnapshot`: 최신 `GameState`를 빠르게 복구하기 위한 materialized snapshot
 
-`GameLog`는 request attempt, `PROCESSING`, `FAILED`, lease 같은 실행 상태를 저장하지 않습니다. 해당 책임은 M2의 idempotency/reservation 이슈(#29, #30)가 별도 request record로 소유합니다.
+`GameLog`는 request attempt, `PROCESSING`, `FAILED`, lease 같은 실행 상태를 저장하지 않습니다. 현재 이 책임은 `game_mutation_request`와 `game_turn_reservation`이 분리해 소유합니다.
 
 ## 한 turn record의 의미
 
@@ -25,41 +25,51 @@ Opening을 제외한 새 `GameLog` 한 행은 해당 turn을 만든 입력과 �
 
 Opening은 외부 입력이 없으므로 `input_choice_id`, `input_choice_text`가 `null`이고 state transition은 `0 -> 1`입니다.
 
-현재 ruleset에서 state version은 canonical `GameState.turnNumber`와 동일합니다. 이 값은 snapshot schema/ruleset version(#31)과 다른 개념입니다. `state_version`은 **어느 canonical turn state를 이 행이 commit했는지** 식별하고, snapshot version은 **JSON 형식과 ruleset evolution**을 식별합니다.
+현재 ruleset에서 state version은 canonical `GameState.turnNumber`와 동일합니다. 이 값은 snapshot schema/ruleset version과 다른 개념입니다.
 
 ## append-only 경계
 
-기존 구조는 turn N을 진행할 때 turn N의 `user_choice`를 뒤늦게 수정했습니다. V6 이후 application은 다음 순서를 사용합니다.
+V6 이후 application은 다음 순서를 사용합니다.
 
-1. 현재 turn과 `GameState`를 읽는다.
-2. 선택지 ID를 검증하고 표시 텍스트를 확정한다.
-3. Narrative 결과를 검증한다.
-4. application/domain에서 다음 `GameState`를 확정한다.
-5. `GameTurnCommit`으로 입력, 이전/다음 state, narrative 결과를 persistence에 전달한다.
-6. persistence는 현재 session/log state version, canonical previous state와 commit을 검증하고 새 `GameLog` 한 행과 snapshot/session을 원자적으로 저장한다.
+1. 현재 turn과 `GameState`를 읽습니다.
+2. 서버 발급 action을 검증하고 canonical 입력 ID/text를 확정합니다.
+3. Narrative 결과를 검증합니다.
+4. application/domain에서 다음 `GameState`를 구성합니다.
+5. `GameTurnCommit`으로 입력, 이전/다음 state, narrative 결과를 persistence에 전달합니다.
+6. persistence는 session/log state version, canonical previous state와 reservation owner를 검증하고 새 `GameLog` 한 행과 snapshot/session/request 결과를 원자적으로 저장합니다.
 
-`GamePersistenceService`는 `userChoice + storyText`를 받아 `GameState.advance(...)`를 호출하지 않습니다. 상태 전이를 계산하는 책임은 persistence 바깥에 있습니다. Snapshot이 없을 때의 기존 로그 복구 계산도 `GameStateRecovery`로 분리합니다.
+현재 M3는 이 구조 위에서 #34/#36을 통해 **Narrative provider 호출 전에 규칙 결과와 다음 state를 확정**하는 방향으로 경계를 강화합니다.
+
+`GamePersistenceService`는 사용자 문자열이나 story prose를 파싱해 게임 규칙을 계산하지 않습니다. Snapshot이 없을 때의 복구 계산도 `GameStateRecovery`로 분리합니다.
 
 Commit된 기존 `GameLog`를 수정하는 domain method는 제공하지 않으며 entity는 Hibernate `@Immutable`로 dirty update 대상에서도 제외합니다.
 
+## idempotency와 reservation의 관계
+
+- `game_mutation_request`: owner/idempotency key/fingerprint와 PROCESSING/COMPLETED/FAILED 상태를 관리합니다.
+- `game_turn_reservation`: `(session_id, expected_turn)` lease, owner fencing, provider attempt 상한을 관리합니다.
+- `GameLog`: 위 실행 상태가 아니라 **성공적으로 commit된 canonical history**만 기록합니다.
+
+완료된 idempotency retry는 기존 canonical `GameLog`를 사용해 응답을 replay하고 새 ledger row를 쓰지 않습니다. lease takeover가 발생해도 stale owner는 commit 단계에서 거절되므로 동일 `(session_id, turn_number)` ledger가 중복 생성되지 않습니다.
+
 ## legacy V1~V5 migration
 
-V1~V5에서는 선택 입력이 **선택이 발생한 행이 아니라 그 이전 행의 `user_choice`**에 저장되어 있었습니다. V6 migration은 이를 다음 committed turn 행의 `input_choice_text`로 이동합니다.
+V1~V5에서는 선택 입력이 선택이 발생한 행이 아니라 그 이전 행의 `user_choice`에 저장되어 있었습니다. V6 migration은 이를 다음 committed turn 행의 `input_choice_text`로 이동합니다.
 
-과거 schema에는 실제 `choiceId`가 저장되지 않았습니다. `choices_json`과 선택 텍스트를 조합해 추정할 수 있는 경우도 있지만, 중복 문구·과거 데이터 손상 가능성을 고려하면 migration이 ID를 만들어내는 것은 canonical history를 조작할 위험이 있습니다. 따라서:
+과거 schema에는 실제 `choiceId`가 저장되지 않았으므로 migration이 ID를 추정해 canonical history를 만들지 않습니다.
 
 - legacy `input_choice_text`: 정확히 이관
 - legacy `input_choice_id`: `null` = historical unknown
-- V6 이후 새 non-opening commit: application contract에서 ID와 text를 모두 필수 기록
+- V6 이후 새 non-opening commit: application contract에서 ID와 text를 모두 기록
 
 `previous_state_version`과 `state_version`은 기존 turn number에서 결정적으로 backfill합니다.
 
-기존 `user_choice` DB 컬럼은 즉시 drop하지 않습니다. 배포 롤백 시 이전 애플리케이션이 schema 자체 때문에 기동 불가해지는 위험을 줄이기 위한 **legacy compatibility column**으로 남겨 둡니다. V6 애플리케이션의 `GameLog` entity에는 매핑하지 않으며 새 commit에서는 읽거나 쓰지 않습니다. canonical ledger 의미는 새 `input_choice_*` 컬럼만 소유합니다.
+기존 `user_choice` DB 컬럼은 rollback compatibility를 위해 남겨두지만 현재 `GameLog` entity는 읽거나 쓰지 않습니다. canonical ledger 의미는 `input_choice_*` 컬럼이 소유합니다.
 
 ## 복구
 
 Snapshot이 존재하면 최신 상태 복구는 snapshot을 우선 사용합니다.
 
-Snapshot이 없다면 `GameLog`를 turn 순서로 읽고 각 **행 자체의** `input_choice_text`, story, state version을 사용해 `GameStateRecovery`가 현재 `GameState`를 복구합니다. 더 이상 이전 행을 수정해 둔 `user_choice`에 의존하지 않습니다.
+Snapshot이 없다면 `GameLog`를 turn 순서로 읽고 각 행의 `input_choice_text`, story, state version을 사용해 `GameStateRecovery`가 현재 `GameState`를 복구합니다. 이전 행의 legacy `user_choice`에 의존하지 않습니다.
 
 전체 event replay engine이나 Event Sourcing은 이 설계의 목표가 아닙니다.

--- a/docs/architecture/game-mutation-idempotency.md
+++ b/docs/architecture/game-mutation-idempotency.md
@@ -1,54 +1,68 @@
 # Game mutation idempotency
 
-`POST /api/game/init`과 `POST /api/game/progress`는 비용이 발생하고 canonical game state를 변경하므로 명시적인 idempotency 계약을 사용한다.
+`POST /api/game/init`과 `POST /api/game/progress`는 비용이 발생하고 canonical game state를 변경하므로 명시적인 idempotency 계약을 사용합니다.
 
 ## HTTP contract
 
-- 클라이언트는 `Idempotency-Key` header를 보낸다.
+- 클라이언트는 `Idempotency-Key` header를 보냅니다.
 - 허용 형식: `[A-Za-z0-9._:-]{8,128}`.
-- web client는 `crypto.randomUUID()`로 사용자 mutation 하나당 key 하나를 만든다.
-- 같은 사용자 mutation의 network/provider/persistence retry는 같은 key를 재사용한다.
-- 새 게임 시작이나 새 choice는 새 key를 사용한다.
-- 한 owner 안에서는 `/init`과 `/progress`를 포함한 모든 game mutation에서 key를 재사용하지 않는다.
-- GET 및 image asset fetch에는 이 header를 요구하지 않는다.
+- web client는 `crypto.randomUUID()`로 사용자 mutation 하나당 key 하나를 만듭니다.
+- 같은 사용자 mutation의 network/provider/persistence retry는 같은 key를 재사용합니다.
+- 새 게임 시작이나 새 action은 새 key를 사용합니다.
+- 한 owner 안에서는 `/init`과 `/progress`를 포함한 모든 game mutation에서 key를 재사용하지 않습니다.
+- GET 및 image asset fetch에는 이 header를 요구하지 않습니다.
 
-Header를 선택한 이유는 retry identity가 world/character/choice라는 게임 payload 자체가 아니라 HTTP mutation delivery 계약이기 때문이다. DTO에 transport-level retry metadata를 섞지 않고 `/init`과 `/progress`에 같은 규칙을 적용할 수 있다.
+retry identity는 world/character/action payload 자체가 아니라 HTTP mutation delivery 계약이므로 transport metadata를 DTO에 섞지 않고 header로 관리합니다.
 
 ## Persistence contract
 
-`game_mutation_request`는 append-only canonical `GameLog`와 별개의 request-processing record다.
+`game_mutation_request`는 append-only canonical `GameLog`와 별개의 request-processing record입니다.
 
 저장 항목:
 
 - owner key
 - operation (`INIT`, `PROGRESS`)
 - idempotency key
-- session / expected turn (해당 시)
+- session / expected turn
 - SHA-256 request fingerprint
 - processing status (`PROCESSING`, `COMPLETED`, `FAILED`)
 - 완료 결과를 찾기 위한 session / turn / title
 
-`(owner_key, idempotency_key)`는 PostgreSQL unique constraint로 보호한다. operation도 fingerprint 검증과 함께 비교하므로 같은 owner가 동일 key를 다른 endpoint에 재사용해도 conflict다. request fingerprint에는 raw world/character/story 전문을 저장하지 않는다. init fingerprint는 operation과 world/character의 line-ending-normalized 값을 length-prefix 형식으로 결합한 뒤 SHA-256으로 해시한다. progress fingerprint는 operation/session/choice/expectedTurn을 같은 방식으로 해시한다.
+`(owner_key, idempotency_key)`는 PostgreSQL unique constraint로 보호합니다. operation도 fingerprint와 함께 검증하므로 같은 owner가 동일 key를 다른 endpoint에 재사용해도 conflict입니다.
 
-완료된 같은 key + 같은 operation/fingerprint는 provider를 다시 호출하지 않고 result session/turn의 canonical `GameLog`를 읽어 `GameResponse`를 재구성한다. 같은 key가 다른 operation 또는 다른 fingerprint에 사용되면 provider 호출 전에 `409 IDEMPOTENCY_CONFLICT`로 거절한다. 실패한 동일 payload request는 같은 key로 다시 시도할 수 있다.
+완료된 같은 key + 같은 operation/fingerprint는 provider를 다시 호출하지 않고 result session/turn의 canonical `GameLog`를 읽어 `GameResponse`를 재구성합니다. 다른 operation 또는 다른 fingerprint에 사용하면 provider 호출 전에 `409 IDEMPOTENCY_CONFLICT`로 거절합니다. 실패한 동일 payload request는 같은 key로 재시도할 수 있습니다.
 
-`GameLog`에는 idempotency processing state를 저장하지 않는다.
+`GameLog`에는 request processing state를 저장하지 않습니다.
+
+## `/progress`와 turn reservation
+
+현재 `/progress`는 idempotency와 별도로 `(session_id, expected_turn)` turn reservation을 사용합니다.
+
+1. mutation request를 식별하고 fingerprint를 검증합니다.
+2. 같은 canonical turn의 reservation lease를 획득합니다.
+3. session/turn과 서버 발급 action을 검증합니다.
+4. rate limit과 provider budget guard를 통과합니다.
+5. 실제 Narrative provider 실행 직전에 reservation owner를 다시 확인하며 `provider_attempt_count`를 증가시킵니다.
+6. provider 응답 이후 canonical commit 시 같은 reservation owner인지 다시 검증합니다.
+
+active lease가 존재하면 다른 요청은 provider에 진입할 수 없습니다. lease expiry 후 takeover는 가능하지만 stale owner는 canonical commit을 수행할 수 없습니다.
+
+reservation 획득 횟수와 provider 실행 횟수는 분리합니다. validation, stale action, rate limit, budget guard 같은 pre-provider 실패는 provider quota를 소비하지 않으며 실제 provider 시작은 같은 turn에서 최대 3회입니다.
+
+세부 계약은 [game-turn-reservation.md](./game-turn-reservation.md)를 기준으로 합니다.
 
 ## Transaction boundary
 
-provider network call은 DB transaction 밖에서 수행한다. canonical session/snapshot/GameLog 저장과 request `COMPLETED` 전환은 같은 persistence transaction에서 수행한다. 따라서 응답 전송만 유실된 retry는 완료 request를 찾아 기존 결과를 재생할 수 있다.
+provider network call은 DB transaction 밖에서 수행합니다. canonical session/snapshot/GameLog 저장과 request `COMPLETED` 전환은 같은 persistence transaction에서 수행합니다. 따라서 응답 전송만 유실된 retry는 완료 request를 찾아 기존 결과를 replay할 수 있습니다.
 
-동시에 들어온 최초 요청을 reservation/lease로 정확히 하나의 provider 실행에 제한하거나 `PROCESSING` 상태의 대기/재시도 정책을 제공하는 것은 #30 범위다. #29는 완료된 retry reuse, payload/operation conflict, DB uniqueness 계약을 고정한다. 따라서 provider 완료 전에 프로세스가 중단된 `PROCESSING` 요청은 이후 retry에서 provider를 다시 호출할 수 있다.
+외부 provider 호출과 DB transaction을 하나의 원자적 transaction으로 묶지는 않습니다. provider 성공 후 process crash가 발생하면 lease expiry 후 provider 재호출 가능성이 있으므로 외부 호출 strict exactly-once가 아니라 bounded at-least-once입니다. canonical DB 결과는 reservation owner, expected turn, optimistic locking과 unique constraint를 통해 하나로 수렴합니다.
 
 ## Retention
 
-request record의 운영 보존 기간은 **24시간 이상**으로 정의한다. 현재 M2에서는 자동 삭제 job을 추가하지 않고 보존한다. 향후 cleanup을 추가할 때도 24시간보다 이른 삭제는 허용하지 않는다.
+request record의 운영 보존 기간은 **24시간 이상**으로 정의합니다. 현재 자동 cleanup job은 없으며, 향후 cleanup을 추가하더라도 24시간보다 이른 삭제는 허용하지 않습니다.
 
-## Deployment order
+## Deployment compatibility
 
-기존 production frontend는 `Idempotency-Key`를 보내지 않으므로 backend를 먼저 배포하면 `/init`과 `/progress`가 400이 될 수 있다. 한 번의 전환에서는 다음 순서를 사용한다.
+`Idempotency-Key`가 필수가 된 초기 전환에서는 frontend-first 배포가 필요했습니다. 현재 production frontend와 backend는 모두 해당 계약을 사용합니다.
 
-1. **frontend first**: 새 frontend를 배포한다. 기존 backend는 추가 header를 무시하므로 호환된다.
-2. **backend second**: V7 migration과 필수 `Idempotency-Key` 계약을 포함한 backend를 배포한다.
-
-CORS allowlist에도 `Idempotency-Key`가 포함되어야 한다.
+CORS allowlist에는 `Idempotency-Key`가 포함되어야 하며, 향후 mutation transport 계약을 변경할 때도 frontend/backend의 배포 순서와 rollback 호환성을 함께 검토합니다.

--- a/docs/architecture/game-state-story-memory.md
+++ b/docs/architecture/game-state-story-memory.md
@@ -2,77 +2,94 @@
 
 ## 목표
 
-UCTale의 결정적 게임 상태는 서버가 소유하고, LLM은 그 상태를 서사로 표현하는 Narrative Engine으로만 동작한다.
+UCTale의 결정적 게임 상태는 서버가 소유하고, LLM은 그 상태와 서버가 확정한 결과를 서사로 표현하는 Narrative Engine으로 동작합니다.
 
 ## canonical GameState
 
-`GameState`는 한 세션의 복원 가능한 현재 상태다.
+`GameState`는 한 세션의 복원 가능한 현재 상태입니다.
 
 - `turnNumber`: 현재 적용된 턴 번호
-- `PlayerCharacter`: 플레이어의 서버 소유 상태. #7부터 stats를 확장한다.
+- `PlayerCharacter`: 플레이어의 서버 소유 상태. #7에서 typed stats와 Skill Check 기반을 확장합니다.
 - `WorldState`: 세계의 서버 소유 상태와 flags 확장 지점
 - `StoryMemory`: 장기 서사를 위한 제한된 내러티브 문맥
 
-운영 DB에는 `game_state_snapshot`에 JSON 스냅샷으로 저장한다. `game_session`과 `game_log`는 세션/턴 무결성과 원장 역할을 계속 담당한다.
+운영 DB에는 `game_state_snapshot` JSON snapshot으로 저장합니다. `game_session`과 append-only `game_log`는 세션/턴 무결성과 committed-turn 원장 역할을 담당합니다.
 
 ## Story Memory
 
-Story Memory는 세 계층으로 구분한다.
+Story Memory는 세 계층으로 구분합니다.
 
 1. `canonicalFacts`
    - 서버가 진실로 승인한 장기 사실
-   - 현재는 최초 세계관과 플레이어 설정으로 시작한다.
-   - 향후 Game Engine의 검증된 command/proposal만 변경할 수 있다.
+   - 현재는 최초 세계관과 플레이어 설정으로 시작
+   - 향후 Game Engine의 검증된 state transition만 canonical truth를 변경
 2. `rollingSummary`
-   - 최근 문맥에서 밀려난 오래된 턴의 압축 기록
-   - 현재는 별도 AI 호출 없이 서버가 결정적으로 누적한다.
-   - 최대 4,000자로 제한한다.
+   - 최근 문맥에서 밀려난 오래된 턴의 제한된 압축 기록
+   - 현재 별도 AI 호출 없이 서버가 결정적으로 누적
+   - 최대 4,000자
 3. `recentTurns`
    - 가장 최근 6턴
-   - 플레이어 행동과 결과 본문만 보관한다.
+   - 플레이어 행동과 결과 본문 보관
 
-Narrative Engine에는 전체 `game_log` 대신 위 세 계층과 이번 플레이어 행동을 전달한다.
+Narrative Engine에는 전체 `game_log` 대신 위 계층과 현재 요청에 필요한 행동 문맥만 전달합니다.
 
 ## 메모리 우선순위
 
-충돌 시 다음 순서를 따른다.
+충돌 시 다음 순서를 따릅니다.
 
 `canonicalFacts > rollingSummary > recentTurns > LLM 생성 내용`
 
-LLM 응답 자체는 canonical state 변경 권한이 없다.
+LLM 응답 자체는 canonical state 변경 권한이 없습니다.
 
-## 턴 처리 흐름
+## 현재 행동 경계
 
-1. `expectedTurn`으로 현재 세션과 `GameState.turnNumber`를 검증한다.
-2. 선택지 ID를 서버가 기존 choices에서 실제 행동 문자열로 해석한다.
-3. `GameState`에서 `NarrativeContext`를 구성한다.
-4. Narrative Engine이 이야기와 다음 선택지만 생성한다.
-5. 서버가 다음 `GameState`를 결정적으로 구성한다.
-6. `game_log`, `game_session`, `game_state_snapshot`을 같은 transaction에서 저장한다.
-7. 낙관적 잠금/unique constraint 충돌 시 전체 저장을 롤백한다.
+#33 이후 main에는 `AvailableAction`과 `PlayerAction` 경계가 있습니다.
+
+- Narrative가 제안한 choice는 서버가 현재 turn에 속한 `AvailableAction`으로 발급합니다.
+- 응답에는 action token/type/source turn/arguments를 포함할 수 있습니다.
+- 다음 `/progress`에서 서버는 제출된 action이 현재 turn의 발급 action과 일치하는지 검증합니다.
+- 만료되거나 변조된 action은 Narrative provider 또는 향후 규칙 실행 전에 거절합니다.
+- 기존 choice ID는 compatibility adapter 경로로 유지합니다.
+
+현재 `ActionType`은 향후 규칙 행동을 위한 경계이며 Attack/UseItem/Skill Check의 실제 판정 규칙을 이미 구현했다는 의미는 아닙니다.
+
+## 현재 턴 처리 흐름
+
+1. idempotency와 `(session_id, expected_turn)` reservation을 확인합니다.
+2. `expectedTurn`으로 현재 세션과 `GameState.turnNumber`를 검증합니다.
+3. 제출된 `PlayerAction`을 현재 서버 발급 `AvailableAction`과 대조해 표시 텍스트를 확정합니다.
+4. rate limit과 provider budget guard를 확인합니다.
+5. 현재 단계에서는 `GameState`와 action 문맥으로 `NarrativeContext`를 구성합니다.
+6. Narrative Engine이 이야기와 다음 choice 후보를 생성합니다.
+7. 서버가 다음 `GameState`와 server-issued available actions를 구성합니다.
+8. `game_log`, `game_session`, `game_state_snapshot`, mutation 완료 결과를 canonical transaction에서 저장합니다.
+9. reservation owner, expected turn, optimistic lock/unique constraint가 어긋나면 commit을 거절합니다.
+
+M3의 #34/#36 이후에는 **규칙 결과와 다음 state를 Narrative 호출 전에 확정**하는 구조로 이 흐름을 더 강화합니다.
 
 ## 기존 세션 호환성
 
-V2 snapshot 도입 전 생성된 세션은 `game_state_snapshot`이 없을 수 있다. 이 경우 저장된 `game_log`를 턴 순서로 replay하여 최소 GameState를 복구한다. 다음 정상 저장부터 snapshot이 생성된다.
+현재 snapshot은 versioned envelope를 사용합니다. #31 이전 raw `GameState` snapshot은 logical schema v0로 식별해 deterministic upgrader로 읽습니다.
+
+snapshot이 없는 session은 committed `GameLog`를 turn 순서로 읽어 `GameStateRecovery`가 상태를 복구합니다. legacy snapshot read 자체는 DB를 다시 쓰지 않고, 다음 정상 canonical commit에서 최신 snapshot 형식으로 저장합니다.
+
+세부 내용은 [game-state-snapshot-evolution.md](./game-state-snapshot-evolution.md)를 기준으로 합니다.
 
 ## 향후 확장
 
-#7 이후 다음 상태는 `GameState` 내부에서 확장한다.
+다음 상태는 prompt 문자열이나 임시 service field가 아니라 `GameState`와 명시적 game rule로 확장합니다.
 
-- 캐릭터 stats와 deterministic Skill Check
+- typed character stats와 deterministic Skill Check
 - inventory / equipment
 - HP / status effects
 - combat state
 - XP / level / skills
-- quest flags
-- relationships
-
-이 기능들은 prompt 문자열이나 `GameService` 임시 필드가 아니라 서버 GameState에 구현한다.
+- quest / world flags
+- NPC relationships
 
 ## 아직 하지 않는 것
 
-- AI가 상태 변경 command/proposal을 직접 적용하는 기능
-- 세부 전투 공식
-- 아이템 카탈로그
-- 퀘스트 콘텐츠 대량 작성
+- AI가 상태 변경 command/proposal을 직접 canonical state에 적용하는 기능
+- 전투 공식과 전체 encounter system
+- 아이템/퀘스트 대규모 content catalog
 - 복잡한 클래스/직업 트리

--- a/docs/architecture/image-assets.md
+++ b/docs/architecture/image-assets.md
@@ -2,45 +2,58 @@
 
 ## 목적
 
-UCTale의 이미지 provider는 브라우저가 전달한 임의 prompt를 직접 실행하지 않는다. 게임 서버가 Narrative 결과에서 확정한 시각 정보로 prompt를 구성하고, 서버가 발급한 `imageAssetId`만 클라이언트에 노출한다.
+UCTale의 이미지 provider는 브라우저가 전달한 임의 prompt를 직접 실행하지 않습니다. 게임 서버가 Narrative 결과에서 확정한 시각 정보로 prompt를 구성하고, 서버가 발급한 `imageAssetId`만 클라이언트에 노출합니다.
 
 ## 요청 흐름
 
-1. `GameService`가 Narrative의 `visualAssets`에서 이미지 prompt를 구성한다.
-2. 서버가 UUID 기반 asset ID와 `/api/game/image-assets/{assetId}` URL을 발급한다.
-3. `GamePersistenceService`가 같은 transaction에서 asset을 `GameSession`과 turn에 연결하고 `GameLog.imageUrl`에는 asset URL만 저장한다.
-4. 브라우저는 asset URL만 GET 한다. prompt와 provider URL은 브라우저 요청에 포함되지 않는다.
-5. `ImageAssetService`는 `assetId + session.ownerKey`로 조회한 경우에만 provider를 호출한다.
+1. `GameService`가 Narrative의 `visualAssets`에서 이미지 prompt를 구성합니다.
+2. 서버가 UUID 기반 asset ID와 `/api/game/image-assets/{assetId}` URL을 발급합니다.
+3. `GamePersistenceService`가 같은 canonical transaction에서 asset을 `GameSession`과 turn에 연결하고 `GameLog.imageUrl`에는 asset URL만 저장합니다.
+4. 브라우저는 asset URL만 GET 합니다. prompt와 provider URL은 브라우저 요청에 포함되지 않습니다.
+5. `ImageAssetService`는 `assetId + session.ownerKey`로 조회한 경우에만 provider를 호출합니다.
 
 ## 소유권과 오류 정책
 
-- asset은 반드시 하나의 `GameSession` 및 발급 turn에 속한다.
-- 다른 접근 주체가 유효한 asset ID를 알아도 조회 결과는 `404 IMAGE_ASSET_NOT_FOUND`다.
-- 존재하지 않는 asset과 다른 owner의 asset은 같은 404 계약을 사용해 존재 여부 노출을 줄인다.
-- `/api/game/image-assets/**`는 access-session interceptor와 `X-UCTale-Client: web` 검증을 동일하게 적용한다.
+- asset은 하나의 `GameSession` 및 발급 turn에 속합니다.
+- 다른 owner가 유효한 asset ID를 알아도 조회 결과는 `404 IMAGE_ASSET_NOT_FOUND`입니다.
+- 존재하지 않는 asset과 다른 owner의 asset은 같은 404 계약을 사용해 존재 여부 노출을 줄입니다.
+- `/api/game/image-assets/**`는 access-session interceptor와 보호 client header 검증을 적용합니다.
+
+## 생성 계약
+
+asset 발급 시점의 생성 조건을 DB에 저장합니다.
+
+- prompt
+- model
+- width / height
+- seed
+- safe
+- style version
+
+현재 provider 실행 정책은 [image-generation.md](./image-generation.md)를 기준으로 하며 bounded retry, timeout, 최대 응답 크기와 허용 MIME 검증이 포함됩니다.
 
 ## 중복 호출 정책
 
-- 최초 정상 생성 결과의 bytes와 content type을 `image_asset`에 저장한다.
-- 이후 같은 asset 요청은 저장된 결과를 반환하며 provider를 다시 호출하지 않는다.
-- 같은 JVM에서 동시에 들어오는 최초 요청은 asset별 in-process lock으로 한 번만 생성하도록 억제한다.
-- provider 생성이 실패하면 결과를 저장하지 않으며 이후 같은 asset 요청은 다시 시도할 수 있다.
-- 현재 공유 베타는 단일 application instance를 전제로 한다. 여러 application instance가 같은 미생성 asset을 정확히 동시에 요청하는 경우 provider 호출의 완전한 단일화는 보장하지 않는다. 이 한계는 향후 분산 reservation/worker 도입 시 다룬다.
+- 최초 정상 생성 결과의 bytes와 content type을 `image_asset`에 저장합니다.
+- 이후 같은 asset 요청은 저장된 결과를 반환하며 provider를 다시 호출하지 않습니다.
+- 같은 JVM에서 동시에 들어오는 최초 요청은 asset별 in-process lock으로 한 번만 생성하도록 억제합니다.
+- provider 생성이 실패하면 결과를 저장하지 않으며 이후 같은 asset 요청은 재시도할 수 있습니다.
+- 현재 공유 베타는 단일 application instance를 전제로 합니다. 여러 instance가 같은 미생성 asset을 동시에 요청하는 경우 provider 호출의 전역 exactly-once는 보장하지 않습니다.
 
 ## 이미지 재사용
 
-Narrative가 새 시각 요소를 제공하지 않는 turn은 새 asset을 만들지 않고 이전 `GameLog.imageUrl`을 그대로 재사용한다. 시각 변화가 있는 turn만 새 asset을 발급한다.
+Narrative가 새 시각 요소를 제공하지 않는 turn은 새 asset을 만들지 않고 이전 `GameLog.imageUrl`을 그대로 재사용합니다. 시각 변화가 있는 turn만 새 asset을 발급합니다.
 
 ## 기존 데이터
 
-#25 이전의 익명 세션은 소유권 migration 정책에 따라 이미 접근 불가능하다. #26 이후 새로 생성되는 세션은 모두 asset 기반 URL을 사용한다. 배포 직전 #25 방식으로 생성된 세션의 legacy prompt URL은 보존 대상 save/resume 기능이 아직 제공되지 않는 현재 공유 베타 범위에서는 migration하지 않는다.
+#25 이전의 익명 세션은 소유권 migration 정책에 따라 접근 불가능합니다. #26 이후 새 세션은 asset 기반 URL을 사용합니다. save/resume 기능이 아직 제공되지 않는 공유 베타 범위에서는 과거 legacy prompt URL을 별도 migration하지 않습니다.
 
 ## 범위 밖
 
 - 객체 스토리지/CDN
 - 이미지 worker/queue
-- distributed lock
-- provider별 retry/backoff 및 최대 byte/MIME 정책 고도화
-- 이미지 모델/seed/style version 최적화
+- multi-instance distributed generation lock
+- 자동 시각 품질 판정 및 재생성
+- reference image 기반 캐릭터 일관성
 
-이 항목들은 후속 이미지 운영 이슈에서 확장한다.
+provider retry/backoff, 최대 byte, MIME 검증은 더 이상 범위 밖이 아니라 현재 이미지 생성 계약에 포함됩니다.

--- a/docs/benchmarks/pollinations-image-benchmark.md
+++ b/docs/benchmarks/pollinations-image-benchmark.md
@@ -2,7 +2,7 @@
 
 ## 목적
 
-UCTale 장면 삽화의 기본 model과 해상도를 감으로 바꾸지 않고 동일 prompt/seed 조건에서 비교하기 위한 절차다.
+UCTale 장면 삽화의 기본 model과 해상도를 감으로 바꾸지 않고 동일 prompt/seed 조건에서 비교하기 위한 절차와 2026-08-30 실측 기록입니다.
 
 비교 대상:
 
@@ -13,14 +13,14 @@ UCTale 장면 삽화의 기본 model과 해상도를 감으로 바꾸지 않고 
 
 ## 실행 조건
 
-2026-08-30에 실제 Pollinations 계정으로 benchmark를 실행했다.
+2026-08-30에 실제 Pollinations 계정으로 benchmark를 실행했습니다.
 
 - 총 요청: 96 (`16 fixtures × 3 models × 2 resolutions`)
 - 성공: 96
 - 실패: 0
-- 모든 조합에 같은 fixture prompt와 seed를 사용했다.
-- benchmark 결과 파일에는 token과 raw prompt를 기록하지 않았다.
-- Python `urllib` 기본 User-Agent가 provider에서 403으로 차단되는 것을 실측으로 발견해 benchmark client에 명시적 User-Agent/Accept를 추가했고, 401/402/403은 fail-fast하도록 보완했다.
+- 모든 조합에 같은 fixture prompt와 seed를 사용했습니다.
+- 결과 파일에는 token과 raw prompt를 기록하지 않았습니다.
+- Python `urllib` 기본 User-Agent가 provider에서 403으로 차단되는 것을 실측으로 발견해 benchmark client에 명시적 User-Agent/Accept를 추가했고, 401/402/403은 fail-fast하도록 보완했습니다.
 
 ## 성능 결과
 
@@ -35,29 +35,27 @@ UCTale 장면 삽화의 기본 model과 해상도를 감으로 바꾸지 않고 
 
 ## Blind review
 
-모델/해상도 이름을 숨긴 A~F 시트로 다시 섞어 prompt 준수도, charcoal style 일관성, 왜곡, 세부 묘사와 별도 재생성 없이 게임 삽화로 사용할 수 있는지를 비교했다.
+모델/해상도 이름을 숨긴 A~F 시트로 다시 섞어 prompt 준수도, charcoal style 일관성, 왜곡, 세부 묘사와 별도 재생성 없이 게임 삽화로 사용할 수 있는지를 비교했습니다.
 
 ### flux
 
-- UCTale의 `rough charcoal sketch`, 흑백, 거친 종이 질감과 story concept art 방향을 가장 안정적으로 유지했다.
-- 전투, 몬스터, 다수 인물과 판타지 장면에서 focal point와 silhouette가 비교적 명확했다.
-- 현실 장면 일부는 zimage보다 literal한 장소 표현이 약한 경우가 있었지만, 전체적인 house style과 장면 가독성의 균형이 가장 좋았다.
+- UCTale의 rough charcoal sketch, 흑백, 거친 종이 질감과 story concept art 방향을 가장 안정적으로 유지했습니다.
+- 전투, 몬스터, 다수 인물과 판타지 장면에서 focal point와 silhouette가 비교적 명확했습니다.
+- 현실 장면 일부는 zimage보다 literal한 장소 표현이 약한 경우가 있었지만 전체적인 house style과 장면 가독성의 균형이 가장 좋았습니다.
 
 ### zimage
 
-- 흑백 sketch 스타일과 공간 묘사가 안정적이고 일상/실내 장면의 prompt 준수도도 좋았다.
-- 다만 flux 대비 평균 지연 시간이 길고 현재 단가도 더 높으며, 판타지/액션 fixture에서 기본 모델을 교체할 만큼 일관된 품질 우위는 확인되지 않았다.
-- 향후 대체 후보 또는 특정 장면용 후보로는 유지할 가치가 있다.
+- 흑백 sketch 스타일과 공간 묘사가 안정적이고 일상/실내 장면의 prompt 준수도도 좋았습니다.
+- flux 대비 평균 지연 시간이 길고 당시 단가도 더 높았으며, 판타지/액션 fixture에서 기본 모델 교체를 정당화할 만큼 일관된 품질 우위는 확인되지 않았습니다.
 
 ### dreamshaper
 
-- 세 모델 중 가장 빠르고 응답 크기도 작았다.
-- 그러나 요청한 charcoal sketch보다 어두운 cinematic/photorealistic 이미지로 치우치는 경우가 반복되어 UCTale house style 일관성이 크게 떨어졌다.
-- 가격과 속도만으로 기본 모델을 바꾸기에는 품질 방향이 맞지 않아 기본 후보에서 제외한다.
+- 세 모델 중 가장 빠르고 응답 크기도 작았습니다.
+- 요청한 charcoal sketch보다 어두운 cinematic/photorealistic 이미지로 치우치는 경우가 반복되어 UCTale house style 일관성이 크게 떨어졌습니다.
 
 ## 비용
 
-실행 당시 Pollinations model registry 기준 flat image cost를 기준으로 계산한다.
+실행 당시 Pollinations model registry 기준 flat image cost를 기준으로 계산한 역사적 기록입니다. provider 가격은 변경될 수 있으므로 현재 고정 단가로 간주하지 않습니다.
 
 | Model | Cost/image | 이번 benchmark 32장 비용 |
 | --- | ---: | ---: |
@@ -65,36 +63,31 @@ UCTale 장면 삽화의 기본 model과 해상도를 감으로 바꾸지 않고 
 | zimage | 0.004 Pollen | 0.128 Pollen |
 | dreamshaper | 0.0001 Pollen | 0.0032 Pollen |
 
-총 예상 비용은 약 `0.1952 Pollen`이다. 실제 운영에서는 Pollinations account usage를 함께 확인하며 가격은 provider 변경 가능성이 있으므로 고정 상수로 간주하지 않는다.
-
-사용 가능한 이미지 한 장당 비용은 단순 최저 단가보다 house style 적합성을 포함해 판단한다. DreamShaper는 명목 단가는 가장 낮지만 charcoal style 불일치 때문에 UCTale 기준 usable 후보로 보기 어렵고, Z-Image는 Flux보다 높은 단가와 지연을 상쇄할 만큼 품질 우위가 확인되지 않았다. 따라서 현재 운영 선택에서는 Flux의 비용 대비 usable 품질이 가장 낫다고 판단한다.
+총 예상 비용은 약 `0.1952 Pollen`이었습니다.
 
 ## 해상도 결정
 
-`1024x576`은 일부 선과 배경 디테일이 조금 더 정돈되지만, UCTale의 현재 최대 표시 폭은 768 CSS px이고 품질 차이가 기본값 변경을 정당화할 정도로 크지 않았다.
+`1024x576`은 일부 선과 배경 디테일이 조금 더 정돈되지만 UCTale의 최대 표시 폭은 768 CSS px이고 품질 차이가 기본값 변경을 정당화할 정도로 크지 않았습니다.
 
-특히 Flux에서 1024x576은 768x432 대비:
+Flux에서 1024x576은 768x432 대비 평균 latency 약 6.6%, 평균 응답 크기 약 53.7% 증가했습니다. Z-Image에서도 각각 약 13.0%, 64.0% 증가했습니다.
 
-- 평균 latency 약 6.6% 증가
-- 평균 응답 크기 약 53.7% 증가
-
-Z-Image에서도 1024x576은:
-
-- 평균 latency 약 13.0% 증가
-- 평균 응답 크기 약 64.0% 증가
-
-따라서 네트워크/응답 크기 비용을 늘리면서 기본 해상도를 올릴 근거가 부족하다.
-
-## 최종 결정
-
-production 기본값을 변경하지 않는다.
+따라서 benchmark 시점의 model/resolution 결정은 다음과 같았습니다.
 
 - `GAME_IMAGE_MODEL=flux`
 - `GAME_IMAGE_WIDTH=768`
 - `GAME_IMAGE_HEIGHT=432`
-- `GAME_IMAGE_STYLE_VERSION=uctale-charcoal-v1`
 
-결론은 "기존 값이므로 유지"가 아니라, 실제 96장 benchmark에서 `flux + 768x432`가 품질, style 일관성, latency, 응답 크기와 비용의 균형이 가장 좋았기 때문에 유지한다는 것이다.
+## style version에 대한 역사 기록
+
+이 benchmark는 **`uctale-charcoal-v1` 시점의 model/resolution 비교**입니다. 따라서 당시 최종 결정에 v1이 기록되어 있었던 것은 맞으며, 이 문서의 96장 결과를 v2 결과로 재해석하지 않습니다.
+
+이후 production smoke에서 핵폭발·불꽃 등 색채 의미가 강한 장면이 컬러 일러스트로 드리프트하는 사례가 발견되어 prompt style contract만 `uctale-charcoal-v2`로 강화되었습니다. 현재 production 기본값은 다음과 같습니다.
+
+- model: `flux`
+- resolution: `768x432`
+- style: `uctale-charcoal-v2`
+
+즉 **benchmark가 결정한 model/resolution은 유지되고, style version만 후속 운영 검증을 통해 v2로 진화**했습니다. 현재 계약은 `docs/architecture/image-generation.md`가 authoritative source입니다.
 
 ## 재현 방법
 
@@ -108,4 +101,4 @@ POLLINATIONS_TOKEN=... python scripts/benchmark_pollinations_images.py
 - `build/pollinations-benchmark/raw.csv`: fixture/model/size/seed/status/latency/MIME/bytes
 - `build/pollinations-benchmark/summary.json`: model/size별 성공률, 평균·P95 지연
 
-운영 secret과 생성 이미지는 저장소에 commit하지 않는다.
+운영 secret과 생성 이미지는 저장소에 commit하지 않습니다. v2 style을 다시 정량/시각 비교하려면 기존 역사 결과를 덮어쓰지 않고 별도 output으로 재실행합니다.

--- a/docs/frontend/design-system.md
+++ b/docs/frontend/design-system.md
@@ -60,9 +60,7 @@ The production family is **SUIT Variable 2.0.5**, installed from the official `@
 - Story line-height is approximately `1.82`.
 - A system sans-serif fallback remains available while the webfont is loading.
 
-SUIT is distributed under the SIL Open Font License 1.1. The repository keeps a third-party notice in `frontend/THIRD_PARTY_NOTICES.md`; the package's own license remains available in the installed dependency.
-
-Pretendard remains a reasonable alternative, but using both families would add payload and reopen a decision that does not currently solve an observed readability problem.
+SUIT is distributed under the SIL Open Font License 1.1. The repository keeps a third-party notice in `frontend/THIRD_PARTY_NOTICES.md`.
 
 ## Component boundary
 
@@ -76,7 +74,7 @@ Screen presentation is separated into:
 - `ThemeSelector`
 - `BrandHeader`
 
-`GameImage` continues to own authenticated image fetching/object URL lifecycle. `TypewriterText` continues to own typing behavior. Their visual styles live in CSS rather than JSX.
+`GameImage` owns authenticated image fetching/object URL lifecycle. `TypewriterText` owns typing behavior. Their visual styles live in CSS rather than JSX.
 
 Generic `Button`, `Field`, `Surface`, or atomic-design wrappers are not introduced until repeated APIs/variants justify them.
 
@@ -84,10 +82,19 @@ Generic `Button`, `Field`, `Surface`, or atomic-design wrappers are not introduc
 
 This foundation deliberately does **not** add Tailwind, shadcn/ui, Radix UI, Lucide, CSS-in-JS, or a full design-system package.
 
-Native controls and plain CSS are sufficient for the current screens. A headless primitive can be reconsidered when a real complex interaction such as Dialog/Popover/Select appears (for example during later Save/Resume work).
+Native controls and plain CSS are sufficient for the current screens. A headless primitive can be reconsidered when a real complex interaction such as Dialog/Popover/Select appears.
 
-## Scope boundary with #48
+## Interaction and accessibility status
 
-This foundation owns visual identity, typography, theme, semantic tokens, base responsive composition, screen-level presentation boundaries, and visual focus/contrast/zoom baseline.
+#48의 공유 베타 interaction/accessibility 마감은 완료되어 현재 main에 다음 behavior가 포함되어 있습니다.
 
-Issue #48 remains responsible for behavior-level polish such as inline API error/retry, consistent loading/disabled states, typewriter skip/reduced motion, image failure recovery, `aria-live`/`aria-busy`, focus movement, and end-to-end keyboard flow.
+- browser `alert()` 대신 화면 문맥의 inline error/retry
+- init/progress 요청 중 중복 submit 차단과 disabled/loading 상태
+- typewriter 진행 중 명시적 skip과 완료 callback 단일 실행
+- `prefers-reduced-motion`에서 typing animation 생략
+- image loading/failure 상태와 16:9 frame 유지
+- `aria-live`, `aria-busy` 등 상태 전달
+- request 완료 후 주요 content로의 focus 이동
+- 인증 만료와 일반 API failure의 UX 분리
+
+이 문서는 visual foundation과 interaction contract의 현재 기준을 기록합니다. 이후 Save/Resume, Skill Check 결과 UI처럼 새로운 화면 요구가 생기면 기존 semantic token과 narrative-first hierarchy를 우선 재사용합니다.

--- a/docs/operations/production-smoke.md
+++ b/docs/operations/production-smoke.md
@@ -22,17 +22,17 @@ UCTale의 일반 CI는 테스트, lint, build를 검증하지만 실제 Vercel f
 
 ## 비용 정책
 
-자동 post-deploy smoke에서는 `/init`, `/progress`, image generation을 호출하지 않습니다. 이 경로들은 Gemini 또는 Pollinations provider 비용이 발생할 수 있으므로 코드 push마다 자동 반복하지 않습니다.
+자동 post-deploy smoke에서는 `/init`, `/progress`, image generation을 호출하지 않습니다. 이 경로들은 Gemini 또는 Pollinations provider 비용이 발생할 수 있으므로 code push마다 자동 반복하지 않습니다.
 
-따라서 자동 smoke의 provider 호출 수는 항상 0회입니다. 실제 narrative 생성, 턴 진행, image asset 생성은 기능 변경 또는 M2 종료 검증 시 수동 smoke 대상으로 유지합니다.
+따라서 자동 smoke의 provider 호출 수는 항상 0회입니다. 실제 narrative 생성, 턴 진행, image asset 생성은 해당 기능의 계약이 바뀌거나 milestone/release 종료 검증이 필요할 때 수동 smoke 대상으로 유지합니다.
 
 ## GitHub Actions secret
 
-Repository Actions secret에 다음 값을 한 번 등록해야 합니다.
+Repository Actions secret에 다음 값을 등록합니다.
 
-- `PRODUCTION_SMOKE_ACCESS_PASSWORD`: 현재 production `GAME_ACCESS_PASSWORD`와 같은 공유 베타 비밀번호
+- `PRODUCTION_SMOKE_ACCESS_PASSWORD`: production `GAME_ACCESS_PASSWORD`와 같은 공유 베타 비밀번호
 
-workflow와 스크립트는 secret 값을 출력하지 않습니다. 비밀번호 JSON과 cookie jar는 runner의 임시 디렉터리에만 만들고 종료 시 삭제합니다. response의 `Set-Cookie` header나 cookie 값도 로그에 출력하지 않습니다.
+workflow와 스크립트는 secret 값을 출력하지 않습니다. 비밀번호 JSON과 cookie jar는 runner 임시 디렉터리에만 만들고 종료 시 삭제합니다. response의 `Set-Cookie` header나 cookie 값도 로그에 출력하지 않습니다.
 
 ## 실행 조건
 
@@ -56,15 +56,15 @@ workflow와 스크립트는 secret 값을 출력하지 않습니다. 비밀번�
 
 ## 수동 smoke로 남기는 범위
 
-다음 항목은 #70 자동화 범위 밖에 둡니다.
+다음 항목은 자동화 범위 밖입니다.
 
-- 실제 `/init` narrative 생성
+- 실제 `/init` Narrative 생성
 - 실제 `/progress` 턴 진행
 - 실제 image asset provider fetch
 - 브라우저 UI interaction과 visual regression
 - production 실패 시 자동 rollback
 
-이 항목은 provider 비용 또는 브라우저 수준 검증이 필요합니다. 관련 기능을 변경했거나 milestone 종료 게이트를 확인할 때 수동으로 검증합니다.
+provider 비용 또는 browser 수준 검증이 필요한 항목입니다. 관련 기능을 변경했거나 release/milestone gate를 확인할 때 수동으로 검증합니다.
 
 ## 로컬 실행
 

--- a/docs/testing/postgresql-integration-tests.md
+++ b/docs/testing/postgresql-integration-tests.md
@@ -1,6 +1,6 @@
 # PostgreSQL integration tests
 
-UCTale의 기본 backend test suite는 빠른 회귀 검증을 위해 H2를 사용합니다. M2부터 persistence 계약을 변경하는 작업은 production PostgreSQL 의미론을 별도 integration suite에서 함께 검증합니다.
+UCTale의 기본 backend test suite는 빠른 회귀 검증을 위해 H2를 사용합니다. production PostgreSQL의 unique constraint, optimistic locking, Flyway migration, 동시성·lease 의미론은 별도 Testcontainers suite에서 검증합니다.
 
 ## 실행 명령
 
@@ -22,38 +22,39 @@ GitHub Actions도 같은 `./gradlew postgresIntegrationTest` 명령을 사용합
 
 ## 선택한 방식
 
-#73에서는 GitHub Actions의 PostgreSQL service container 대신 Testcontainers를 선택했습니다.
+#73에서 GitHub Actions의 PostgreSQL service container 대신 Testcontainers를 선택했습니다.
 
-이유:
-
-- 로컬과 CI가 동일한 Java test code와 동일한 database image를 사용합니다.
-- 포트, username, password를 CI workflow와 로컬 설정에 중복 정의하지 않습니다.
-- 후속 persistence tests가 공통 support class만 상속해 같은 환경을 재사용할 수 있습니다.
+- 로컬과 CI가 동일한 Java test code와 database image를 사용합니다.
+- 포트, username, password를 workflow와 로컬 설정에 중복 정의하지 않습니다.
+- persistence test가 공통 support class를 상속해 같은 환경을 재사용합니다.
 - 테스트가 production Neon DB에 연결될 가능성을 구조적으로 줄입니다.
 
-Testcontainers version은 BOM `2.0.5`, PostgreSQL image는 `postgres:17.6-alpine`으로 고정합니다. 버전 변경은 일반 dependency/image update처럼 PR에서 검증한 뒤 반영합니다.
+Testcontainers BOM은 `2.0.5`, PostgreSQL image는 `postgres:17.6-alpine`으로 고정합니다. 버전 변경은 일반 dependency/image update처럼 PR에서 검증합니다.
 
 ## 테스트 경계
 
 JUnit tag `postgres`를 경계로 사용합니다.
 
-- `test`: `postgres` tag를 제외하고 기존 H2/unit suite를 실행합니다.
-- `postgresIntegrationTest`: `postgres` tag만 실행합니다.
-- PostgreSQL 테스트는 `PostgresIntegrationTestSupport`를 상속해 datasource/Flyway/JPA 설정을 공유합니다.
+- `test`: `postgres` tag를 제외한 H2/unit suite
+- `postgresIntegrationTest`: `postgres` tag만 실행
+- PostgreSQL 테스트는 `PostgresIntegrationTestSupport`를 상속해 datasource/Flyway/JPA 설정을 공유
 
 현재 baseline은 다음 production 의미론을 검증합니다.
 
-- 빈 PostgreSQL에서 Flyway V1~V8 production migration chain 순차 적용
-- Hibernate `ddl-auto=validate`가 migration 결과와 현재 entity mapping을 검증
+- 빈 PostgreSQL에서 Flyway V1~V10 migration chain 순차 적용
+- Hibernate `ddl-auto=validate`와 현재 entity mapping
 - `uk_game_log_session_turn` unique constraint
-- `GameSession`의 `@Version` optimistic locking
-- owner 범위 `Idempotency-Key` unique constraint와 fingerprint conflict
-- `(session_id, expected_turn)` turn reservation unique/lease takeover 의미론
+- `GameSession` optimistic locking
+- owner 범위 `Idempotency-Key` uniqueness와 fingerprint conflict
+- `(session_id, expected_turn)` reservation unique/lease takeover
+- `provider_attempt_count` 기반 turn당 provider attempt 최대 3회
+- pre-provider 실패가 provider attempt quota를 소비하지 않는 계약
 - versioned `GameState` snapshot의 legacy 호환 및 latest schema round-trip
+- PostgreSQL 기반 provider usage ledger
 
 ## M2 regression matrix
 
-#32의 종료 게이트는 기존 개별 persistence 테스트를 제거하지 않고, cross-feature 경계를 `PostgresM2TurnIntegrityMatrixTest`와 legacy migration fixture로 추가 고정합니다.
+M2 종료 게이트는 기존 개별 persistence 테스트를 유지하면서 `PostgresM2TurnIntegrityMatrixTest`와 migration fixture로 cross-feature 경계를 고정합니다.
 
 | 계약 | PostgreSQL 검증 |
 | --- | --- |
@@ -62,33 +63,44 @@ JUnit tag `postgres`를 경계로 사용합니다.
 | 동일 key + 다른 payload | fingerprint mismatch를 provider 진입 전에 conflict로 거부 |
 | 같은 session/turn 최초 동시 요청 | active reservation은 하나만 유지되고 유효 lease 동안 provider 진입도 하나로 제한 |
 | crash + lease expiry | deterministic clock으로 takeover를 재현하고 stale reservation owner의 commit을 차단 |
+| provider attempt accounting | reservation 획득과 실제 provider 실행 횟수를 분리하고 실제 시작만 `provider_attempt_count`를 증가 |
+| pre-provider failure exhaustion | provider 전 실패를 3회 이상 반복해도 quota가 소모되지 않고 이후 정상 provider 시작 가능 |
+| bounded provider retry | 실제 provider 시작은 같은 canonical turn에서 최대 3회 |
 | canonical commit | `GameSession.currentTurn`, latest `GameLog.stateVersion`, snapshot turn, mutation request result turn이 같은 값으로 수렴 |
-| legacy production 형태 | V5 fixture를 V8까지 migration한 뒤 ledger 데이터와 frozen v0 snapshot이 복구 가능함을 검증 |
+| legacy production 형태 | legacy ledger/snapshot을 migration 후 현재 서버에서 복구 가능 |
 
-동시성 케이스는 짧은 wall-clock timeout이나 `Thread.sleep`에 의존하지 않습니다. 시작 barrier와 deterministic clock을 사용하고, fake provider 호출 횟수를 직접 세어 race 조건을 관찰합니다. 같은 session/turn 최초 요청 케이스는 반복 실행해 scheduling 순서가 바뀌어도 계약이 유지되는지 검증합니다.
+## 동시성 테스트의 시간 정책
+
+lease 만료 자체는 `MutableClock` 같은 deterministic clock으로 전진시켜 재현하며 `Thread.sleep`으로 시간을 맞추지 않습니다.
+
+동시에, 테스트 실패가 CI 전체 job timeout까지 무한 대기하지 않도록 latch와 `Future#get()`에는 짧은 방어용 timeout을 둡니다. 이 timeout은 게임/lease 의미론을 결정하는 시간이 아니라 **테스트 hang을 빠른 실패로 바꾸는 안전장치**입니다.
+
+#89 회귀에서 애플리케이션 `Clock`과 DB `CURRENT_TIMESTAMP`를 lease 판단에 섞어 사용하면 provider 진입 전에 실패한 뒤 latch가 풀리지 않을 수 있음을 확인했습니다. reservation lifecycle의 유효성/만료 판단은 주입된 application `Clock` 기준으로 통일했고, 해당 matrix가 CI에서 통과하는 것을 확인했습니다.
 
 ## provider exactly-once 경계
 
-turn reservation은 **유효한 lease 동안** 중복 provider 호출을 억제하고 canonical DB commit을 하나로 제한합니다. 하지만 provider 호출 성공 직후 프로세스가 죽고 lease가 만료되면 takeover 요청이 provider를 다시 호출할 수 있습니다.
+turn reservation은 유효 lease 동안 중복 provider 호출을 억제하고 canonical DB commit을 하나로 제한합니다. provider 호출 성공 직후 프로세스가 죽고 lease가 만료되면 takeover 요청이 provider를 다시 호출할 수 있습니다.
 
-따라서 M2가 보장하는 것은 다음과 같습니다.
+따라서 현재 보장은 다음과 같습니다.
 
 - active lease 동안 duplicate provider suppression
+- 실제 provider 시작 횟수의 turn당 bounded limit
 - stale reservation owner의 canonical commit 차단
-- canonical `GameSession` / `GameLog` / snapshot / completed request 결과는 단일 commit으로 수렴
+- canonical `GameSession` / `GameLog` / snapshot / completed request 결과의 단일 commit 수렴
 
-반대로 외부 provider에 대한 strict exactly-once 호출은 보장하지 않습니다. crash/takeover 테스트는 이 한계를 숨기지 않고 provider 호출이 두 번 발생할 수 있음을 명시적으로 assert합니다.
+외부 provider strict exactly-once는 보장하지 않습니다.
 
 ## 실패 진단
 
-CI의 `Run PostgreSQL integration tests` step은 일반 backend test와 분리되어 있습니다. 따라서 실패 시 먼저 다음을 구분합니다.
+CI의 `Run PostgreSQL integration tests` step은 일반 backend test와 분리되어 있습니다. 실패 시 다음을 구분합니다.
 
-1. container startup / Docker 문제
-2. Flyway migration 및 실패 version/schema
-3. Hibernate schema validation 실패
-4. PostgreSQL unique / optimistic locking assertion 실패
-5. idempotency request key/fingerprint 단계 실패
-6. reservation session/turn/attempt 단계 실패
-7. canonical `currentTurn` / ledger stateVersion / snapshot / request resultTurn 불일치
+1. container startup / Docker
+2. Flyway migration 및 schema version
+3. Hibernate schema validation
+4. PostgreSQL unique / optimistic locking
+5. idempotency key/fingerprint
+6. reservation lease/owner/provider attempt
+7. canonical state/log/snapshot/request 결과 불일치
+8. concurrency test의 bounded wait timeout
 
-M2 matrix assertion은 가능한 경우 `phase`, `request`, `session`, `turn` 또는 migration `schema` 문맥을 함께 출력합니다. Testcontainers와 Spring Boot가 container 및 datasource 초기화 로그를 남기며, DB password는 ephemeral fixture 값이고 production credential이나 application secret을 사용하지 않습니다.
+Testcontainers와 Spring Boot가 container 및 datasource 초기화 로그를 남기며 production credential이나 application secret은 사용하지 않습니다.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,43 +1,77 @@
 # UCTale Frontend
 
-UCTale(User Create Tale)의 프론트엔드 프로젝트입니다.
-React와 Vite를 기반으로 구축되었으며, 사용자와 AI 간의 상호작용을 위한 직관적인 채팅형 UI와 동적 이미지 렌더링을 담당합니다.
+UCTale의 공유 베타 웹 클라이언트입니다. 서버가 소유한 게임 상태와 서버 발급 action을 표시하고 전달하며, 브라우저에서 게임 규칙이나 provider prompt를 임의로 계산하지 않습니다.
 
-## 🛠 기술 스택
-- **Core:** React 18, Vite
-- **Language:** JavaScript (ES6+)
-- **Styling:** CSS Modules, Responsive Design (Mobile/PC)
-- **HTTP Client:** Axios
-- **Deployment:** Vercel
+## 기술 스택
 
-## 🚀 실행 방법
+- React 19
+- React Router 7
+- Vite 8
+- Axios
+- plain CSS
+- SUIT Variable 2.0.5
+- Vercel Web Analytics
+- Node.js built-in test runner (`node --test`)
 
-### 1. 사전 요구사항
-- Node.js 18.0.0 이상
-- npm 또는 yarn
+의존성의 정확한 버전 범위는 `package.json`과 lock file을 기준으로 합니다.
 
-### 2. 의존성 설치
+## UI 방향
+
+현재 화면은 Charcoal Folio 기반의 narrative-first single-column 구성을 사용합니다.
+
+- `AccessScreen`: 공유 베타 접근 인증
+- `GameSetupScreen`: 세계관/주인공 입력과 게임 시작
+- `GamePlayScreen`: 장면 이미지, story, 서버 발급 선택 행동 표시
+- `ThemeSelector`: system/light/dark 테마
+- `GameImage`: 인증된 image asset fetch와 loading/failure 처리
+- `TypewriterText`: story typing, skip, reduced-motion 처리
+
+디자인 계약은 `../docs/frontend/design-system.md`를 기준으로 합니다.
+
+## 실행
+
+Node.js 22 사용을 권장합니다.
+
 ```bash
-npm install
-```
-
-### 3. 개발 서버 실행
-```bash
+npm ci
 npm run dev
 ```
-실행 후 터미널에 표시되는 로컬 주소(예: http://localhost:5173)로 접속하여 테스트할 수 있습니다.
 
-### 4. 프로덕션 빌드
+기본 개발 서버는 Vite가 안내하는 local URL을 사용합니다.
+
+백엔드 기본 API는 `http://localhost:8080/api/game`이며 다른 서버를 사용할 때는 다음 환경변수를 설정합니다.
+
+```env
+VITE_API_URL=https://example.com/api/game
 ```
+
+## 검증
+
+```bash
+npm ci
+npm test
+npm run lint
 npm run build
 ```
-빌드된 파일은 dist 폴더에 생성됩니다.
 
-## 📂 주요 디렉토리 구조
-```bash
+GitHub Actions도 위 test/lint/build 경계를 검증합니다.
+
+## 주요 디렉터리
+
+```text
 src/
-├── api/            # 백엔드 API 통신 로직
-├── components/     # 재사용 가능한 UI 컴포넌트 (GameImage, TypewriterText 등)
-├── App.jsx         # 메인 게임 로직 및 상태 관리
-└── App.css         # 반응형 스타일링 및 테마 정의
+├── api/            # API 호출과 오류 계약
+├── components/     # BrandHeader, GameImage, ThemeSelector, TypewriterText
+├── screens/        # Access / Setup / Play 화면
+├── theme/          # theme 상태와 semantic token 연결
+├── App.jsx         # auth/game orchestration
+├── App.css         # 화면/컴포넌트 스타일
+└── interaction.css # interaction/accessibility 상태 스타일
 ```
+
+## 책임 경계
+
+- access/owner token은 HttpOnly cookie로 관리하며 Web Storage에 저장하지 않습니다.
+- `/progress`에는 서버가 반환한 action payload를 그대로 전달하며 성공/실패 판정을 frontend에서 재계산하지 않습니다.
+- image provider prompt, provider URL, API secret은 frontend에 노출하지 않습니다.
+- request 중 중복 진행을 막고, 실패 시 기존 화면 상태를 보존한 채 명시적 retry UX를 제공합니다.


### PR DESCRIPTION
## 왜 필요한가요?

#7 개발에 들어가기 전에 README와 하위 Markdown 문서가 현재 `main`의 구현 상태와 일치하도록 동기화합니다. 기존 문서에는 M2가 진행 중이거나 PostgreSQL integration test가 도입 예정인 것으로 남아 있고, frontend README는 React 18/CSS Modules 등 현재 스택과 다른 내용을 포함하고 있었습니다.

- 관련 Issue 없음 — #7 개발 전 문서 동기화

## 무엇이 바뀌나요?

- 게임 규칙·상태: M2 턴 무결성 구현 범위 완료와 M3 #33 `AvailableAction` / `PlayerAction` 반영 상태를 문서화합니다.
- Backend / API / DB: idempotency, reservation/provider attempt accounting, Flyway V1~V10, PostgreSQL integration test 경계를 현재 구현과 맞춥니다.
- AI narrative / prompt: 서버 발급 action과 향후 GameResult 기반 Narrative 경계를 현재/후속 상태로 구분합니다.
- Image generation: historical benchmark의 v1 결과는 보존하면서 현재 production `uctale-charcoal-v2` 상태를 명시합니다.
- Frontend / UX: React 19, React Router 7, Vite 8, plain CSS, 완료된 interaction/accessibility 상태로 갱신합니다.
- Build / deploy / docs: CONTRIBUTING과 PR 템플릿에 PostgreSQL integration 검증, 한국어 기반 commit message, PR 전 비판적 리뷰 규칙을 반영합니다.

## 책임 경계

- **서버가 결정하는 사실:** 코드 변경 없음. 현재 문서가 서버의 기존 canonical state/action/idempotency/reservation 계약을 정확히 설명하도록 정리합니다.
- **LLM이 서술하는 내용:** 변경 없음.
- **LLM이 변경하면 안 되는 사실:** 변경 없음.

## 어떻게 검증했나요?

- [x] PR 작성 전 변경 diff를 비판적으로 검토하고 타당한 지적을 반영했습니다.
- [x] `./gradlew clean test`
- [x] `./gradlew postgresIntegrationTest`
- [x] `./gradlew build`
- [x] `cd frontend && npm ci && npm test && npm run lint && npm run build`
- [ ] 정상 흐름을 직접 확인했습니다.
- [ ] 잘못된 입력/실패 흐름을 확인했습니다.
- [ ] 중복 요청 또는 상태 전이가 관련되면 이를 검증했습니다.

문서 전용 변경이라 수동 게임 흐름 검증은 대상이 아닙니다. CI #172에서 backend `clean test`, PostgreSQL integration test, backend build(`./gradlew build -x test`, 앞 단계 test 성공), frontend `npm ci` / `npm test` / lint / build가 모두 통과했습니다. `main` 대비 1개 commit, 13개 Markdown 파일만 변경되었는지도 확인했습니다. 비판적 리뷰에서 GitHub milestone 객체의 open/closed 상태와 실제 구현 완료 상태가 혼동될 수 있다는 지적을 타당하게 판단해 README 표현을 `구현 범위 완료`로 조정했습니다.

## 게임 상태·AI 안전성

해당하지 않는 항목은 이유를 적어 주세요.

- [x] 게임의 결정적 상태는 서버에서 검증·저장됩니다.
- [x] LLM 출력만으로 HP, 보상, 성공/실패 등 결정적 상태가 임의 변경되지 않습니다.
- [x] AI 요청에 필요한 최소 문맥만 전달합니다.
- [x] AI 응답 파싱 실패와 provider 오류가 게임 상태를 오염시키지 않습니다.
- [x] 기존 저장 데이터 또는 GameState 호환성 영향을 확인했습니다.

위 항목은 코드 변경이 없으며, 기존 계약을 문서에서 변경하지 않고 현재 구현과 동기화했음을 확인한 의미입니다.

## 보안·비용

- [x] API Key, 토큰, 비밀번호가 코드·로그·URL·클라이언트 응답에 노출되지 않습니다.
- [x] 외부 AI/Image 호출 횟수와 실패 시 동작을 검토했습니다.
- [x] 사용자 입력 길이와 외부 API 비용 증가 가능성을 검토했습니다.
- [x] CORS 또는 공개 endpoint 변경이 있다면 의도된 변경입니다.

문서 전용 변경으로 provider 호출·CORS·비용 동작 자체는 변경하지 않습니다. 실제 Secret 값은 포함하지 않습니다.

## API·DB·운영 영향

- [x] API 계약 변경 시 Frontend 호출부와 문서를 함께 갱신했습니다.
- [x] DB schema 변경 시 migration 전략을 포함했습니다.
- [x] 환경변수는 이름과 용도만 문서화했고 실제 Secret은 포함하지 않았습니다.
- [x] 배포 후 확인할 smoke test가 있습니다.

API/DB schema 변경은 없습니다. V1~V10 및 현재 API 계약을 설명하는 문서만 최신화했습니다. 기존 `Production Smoke` workflow와 `scripts/production-smoke.sh`가 있으며 CI에서 smoke script 문법 검증도 통과했습니다. 문서 전용 변경이므로 별도 runtime smoke 실행은 필요하지 않습니다.

## 화면 / 응답 예시

UI/API 응답 변경 없음.