### PR TITLE
feat(game): 타입 안전한 능력치와 Skill Check 규칙 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,17 +72,34 @@ M3의 첫 선행 작업인 #33이 main에 반영되어 `AvailableAction`과 `Pla
 - `/progress`는 현재 turn의 서버 발급 action과 요청 payload가 일치하는지 검증합니다.
 - 변조되거나 만료된 action은 provider 호출 전에 거절됩니다.
 - 기존 `choiceId` 기반 요청은 compatibility 경로로 유지합니다.
-- 실제 전투, 아이템 사용, Skill Check 같은 규칙 행동은 후속 M3 작업에서 이 경계 위에 추가합니다.
+- #7에서 typed stats와 pure Skill Check 규칙은 추가되지만, 실제 action/turn pipeline 연결은 #34/#37 후속 범위입니다.
+
+### 타입 안전한 능력치와 Skill Check
+
+#7에서 서버 소유 게임 규칙의 첫 순수 도메인 기반을 추가했습니다.
+
+- `StatType`: `MIGHT`, `AGILITY`, `INTELLECT`, `WILL`, `PRESENCE`
+- 신규·legacy 캐릭터는 기본 능력치 10을 사용합니다.
+- `CharacterStats`는 1~30 범위를 검증하고 `floor((score - 10) / 2)` modifier를 계산합니다.
+- `Difficulty`, `DiceRoll`, situational modifier가 각 허용 범위를 검증합니다.
+- `SkillCheck`는 `rawRoll + statModifier + situationalModifier >= DC`만으로 성공/실패를 결정합니다.
+- natural 1/20 특수 규칙은 사용하지 않습니다.
+- `SkillCheckResult`는 raw roll, modifier, DC, total, outcome, ruleset version을 보존합니다.
+- production random adapter는 `SecureRandom`, 테스트는 fixed/sequence `RandomSource`를 사용합니다.
+- Skill Check는 pure domain operation이며 Narrative provider를 호출하지 않습니다.
+
+아직 이 판정을 실제 `/progress`, `GameResult`, NarrativeContext, DB roll 저장, frontend에 연결하지 않습니다.
 
 ### GameState와 Story Memory
 
 서버는 세션별 canonical `GameState`를 JSON snapshot으로 저장하고 Narrative Engine에는 필요한 문맥만 전달합니다.
 
+- `PlayerCharacter`는 typed `CharacterStats`를 소유합니다.
 - `canonicalFacts`: 서버가 유지하는 장기 사실
 - `rollingSummary`: 오래된 진행 내용을 제한된 크기로 압축한 기록
 - `recentTurns`: 최근 진행 기록
 
-snapshot JSON은 schema/ruleset version을 가지며 legacy production snapshot을 deterministic upgrader로 읽을 수 있습니다. read-time upgrade는 in-memory에서만 수행하고 다음 정상 canonical write에서 최신 형식으로 저장합니다.
+snapshot JSON은 schema/ruleset version을 가지며 legacy production snapshot을 deterministic upgrader로 읽을 수 있습니다. typed stats 도입으로 현재 snapshot schema는 v2이며, v0/v1 stats는 읽을 때 순수 변환합니다. read-time upgrade는 in-memory에서만 수행하고 다음 정상 canonical write에서 최신 형식으로 저장합니다.
 
 ### 신뢰 가능한 턴 파이프라인
 
@@ -288,6 +305,6 @@ GitHub Actions CI도 backend unit test → PostgreSQL integration test → backe
 
 진행 중.
 
-현재 #33 `AvailableAction` / `PlayerAction` 경계는 main에 반영되었습니다. 다음 핵심 작업은 타입 안전한 캐릭터 능력치와 pure Skill Check(#7), `ActionResolver` / `GameResult` 경계(#34), 확정 결과 기반 NarrativeContext(#36), 실제 turn 통합(#37) 순으로 확장하는 것입니다.
+현재 #33 `AvailableAction` / `PlayerAction` 경계와 #7 typed `CharacterStats` / pure Skill Check 규칙 기반이 반영되었습니다. 다음 핵심 작업은 `ActionResolver` / `GameResult` 경계(#34), 확정 결과 기반 NarrativeContext(#36), 실제 Skill Check turn 통합(#37) 순으로 확장하는 것입니다.
 
 아직 구현되지 않은 전투·인벤토리·퀘스트·NPC 관계 기능은 현재 기능처럼 문서에 표시하지 않습니다.

--- a/docs/architecture/game-state-snapshot-evolution.md
+++ b/docs/architecture/game-state-snapshot-evolution.md
@@ -2,85 +2,84 @@
 
 ## 목적
 
-`game_state_snapshot.state_json`은 최신 canonical `GameState`를 빠르게 복구하기 위한 캐시성 snapshot이다. 도메인 필드가 확장되어도 기존 세션을 암묵적 Jackson 기본값에만 의존해 읽지 않도록 JSON 자체에 명시적인 version contract를 둔다.
+`game_state_snapshot.state_json`은 최신 canonical `GameState`를 빠르게 복구하기 위한 snapshot입니다. 도메인 구조가 확장되어도 기존 세션을 Jackson 기본값에 암묵적으로 의존해 읽지 않도록 JSON envelope에 명시적인 schema/ruleset version을 둡니다.
 
-이 변경은 DB 컬럼을 추가하지 않는다. 버전은 `state_json` envelope 안에 기록하므로 기존 PostgreSQL schema와 Flyway chain을 그대로 사용한다.
+DB 컬럼을 추가하지 않고 `state_json` 내부 형식만 진화시키므로 기존 PostgreSQL/Flyway schema는 그대로 유지합니다.
 
 ## 현재 snapshot 형식
 
-새 write는 항상 현재 형식만 기록한다.
+새 write는 schema `2`, ruleset `1`을 사용합니다.
 
 ```json
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "rulesetVersion": 1,
   "state": {
     "turnNumber": 1,
-    "playerCharacter": {},
+    "playerCharacter": {
+      "description": "캐릭터",
+      "stats": {
+        "might": 10,
+        "agility": 10,
+        "intellect": 10,
+        "will": 10,
+        "presence": 10
+      }
+    },
     "worldState": {},
     "storyMemory": {}
   }
 }
 ```
 
-- `schemaVersion`: snapshot JSON의 구조와 필드 의미가 어떤 evolution 단계인지 나타낸다.
-- `rulesetVersion`: 해당 snapshot을 해석할 때 전제로 삼는 결정적 게임 규칙 계약을 나타낸다. 오래된 ruleset을 현재 규칙으로 자동 재판정하는 용도가 아니다.
-- `state`: 해당 시점의 canonical `GameState` payload다.
+- `schemaVersion`: snapshot JSON 구조/필드 의미의 evolution version
+- `rulesetVersion`: 저장 상태를 해석하는 결정적 게임 규칙 계약 version
+- `state`: canonical `GameState`
 
-현재 지원 버전은 schema `1`, ruleset `1`이다.
+schema와 ruleset version은 서로 다른 축입니다. #7의 typed stats 추가는 저장 JSON 구조 변경이므로 schema를 2로 올렸지만, 과거 Skill Check 결과를 새로운 규칙으로 재판정하는 변경은 아니므로 ruleset은 1을 유지합니다.
 
-## legacy production snapshot
+## 지원 경로
 
-#31 이전 production 형식은 envelope 없이 `GameState` 자체를 `state_json`에 저장했다. 이 형식은 논리적인 schema version `0`으로 취급한다. 버전 필드가 없던 당시의 게임 규칙 의미는 **legacy ruleset baseline `1`** 로 고정하며, 향후 `CURRENT_RULESET_VERSION`이 증가해도 legacy snapshot의 ruleset 의미를 따라 올리지 않는다.
+### v0 raw GameState
 
-legacy 판별은 단순히 `schemaVersion` 누락 여부만 보지 않는다. 기존 raw `GameState`의 최상위 필드인 `turnNumber`, `playerCharacter`, `worldState`, `storyMemory`가 모두 존재하고 envelope 필드가 없어야 한다. 따라서 `schemaVersion`만 유실된 손상 envelope를 legacy로 오인하지 않는다.
+#31 이전 production 형식은 envelope 없이 `GameState` 자체를 저장했습니다. logical schema v0, legacy ruleset baseline 1로 취급합니다.
 
-v0 -> v1 upgrade는 JSON 구조 변환만 수행한다. provider 호출, 랜덤 판정, LLM 호출, 현재 ruleset에 따른 재판정은 수행하지 않는다.
+v0은 먼저 v1 의미로 승격한 뒤 v2 변환을 적용합니다.
+
+### v1 -> v2 typed stats
+
+v1의 `playerCharacter.stats`는 `Map<String,Integer>` 형태였습니다. production 신규 캐릭터는 이 Map을 빈 값으로 생성했습니다.
+
+v2 upgrade 규칙:
+
+- stats가 없거나 canonical stat 값이 누락되면 서버 기본값 `10` 사용
+- `MIGHT`, `AGILITY`, `INTELLECT`, `WILL`, `PRESENCE`와 현재 lowercase field 이름은 유효한 값이면 보존
+- 허용 범위 `1~30` 밖의 값이나 비정수는 추정하지 않고 명시적으로 실패
+- 알 수 없는 legacy key를 임의의 현재 stat으로 추정 매핑하지 않음
+- provider, 랜덤, 시간, LLM 호출 없이 순수 JSON 변환만 수행
 
 ## read / write 정책
 
-- **write:** 항상 현재 schema/ruleset version의 envelope만 저장한다.
-- **read:** 지원되는 과거 schema를 `GameStateUpgrader`에서 순수 변환한 뒤 현재 `GameState`로 역직렬화한다.
-- **미래 schema:** 현재 서버가 의미를 알 수 없으므로 명시적으로 실패한다.
-- **미지원 ruleset:** 임의 재판정을 피하기 위해 명시적으로 실패한다.
-- **누락/손상 version 또는 state:** legacy raw state로 명확히 식별되지 않는 한 명시적으로 실패한다.
+- **write:** 항상 현재 schema/ruleset version으로 저장
+- **read:** 지원되는 과거 schema를 `GameStateUpgrader`에서 순수 변환한 뒤 현재 `GameState`로 역직렬화
+- **미래 schema:** 명시적 실패
+- **미지원 ruleset:** 자동 재판정하지 않고 명시적 실패
+- **손상 snapshot:** legacy raw state로 명확히 식별되지 않으면 명시적 실패
 
-### upgrade 후 DB 재작성 정책
-
-읽기만으로 snapshot을 즉시 재작성하지 않는다.
-
-이유는 다음과 같다.
-
-1. `loadLatestTurn()`의 read-only 경계를 유지한다.
-2. 조회 트래픽만으로 DB write가 발생하거나 장애 시점에 대량 write가 생기는 것을 피한다.
-3. legacy 데이터를 읽을 수 있는 동안 rollback 가능성을 불필요하게 줄이지 않는다.
-
-대신 다음 canonical turn이 정상 commit될 때 기존 snapshot은 현재 버전 envelope로 자연스럽게 재작성된다. 따라서 **read-time upgrade는 in-memory only, next canonical write는 latest-only** 정책을 사용한다.
+읽기만으로 DB를 즉시 다시 쓰지 않습니다. read-time upgrade는 메모리에서만 수행하고, 다음 정상 canonical turn commit에서 최신 v2 envelope로 자연스럽게 재작성합니다.
 
 ## GameLog state version과의 관계
 
-#28에서 도입된 `GameLog.previous_state_version` / `state_version`과 snapshot version은 서로 다른 축이다.
+- `GameLog.state_version`: 세션 안의 canonical turn state 순서
+- snapshot `schemaVersion`: JSON 저장 형식 evolution
+- snapshot `rulesetVersion`: 결정적 규칙 계약 version
 
-- `GameLog.state_version`: 한 세션 안에서 어떤 canonical turn state인지 식별하는 순서 값이다. 현재 opening은 `0 -> 1`, 이후 완료 turn은 `N-1 -> N`으로 진행한다.
-- snapshot `schemaVersion`: JSON 저장 형식의 evolution version이다.
-- snapshot `rulesetVersion`: 결정적 게임 규칙 계약의 version이다.
+서로 비교하거나 대체하지 않습니다.
 
-세 값은 숫자가 우연히 같더라도 서로 비교하거나 대체해서는 안 된다. 예를 들어 turn 20의 state는 `state_version=20`이면서 snapshot은 `schemaVersion=1`, `rulesetVersion=1`일 수 있다.
+## snapshot 없는 session
 
-## snapshot 없는 session 복구와 migration 순서
+snapshot이 없으면 append-only `GameLog`를 통해 `GameStateRecovery`가 현재 상태를 복구합니다. 복구되는 신규 `PlayerCharacter`에는 서버 기본 `CharacterStats`가 적용되고 이후 정상 write에서 schema v2 snapshot이 생성됩니다.
 
-현재 `main`에는 #28의 append-only committed-turn ledger가 Flyway V6로 이미 반영되어 있다.
+## 향후 규칙
 
-정상 배포 순서는 다음과 같다.
-
-1. production Flyway migration을 V6 이상까지 적용한다.
-2. #31 애플리케이션을 배포한다.
-3. snapshot이 존재하면 v0/v1 snapshot read 경로를 사용한다.
-4. snapshot이 없으면 V6 committed `GameLog`의 `input_choice_text`, `previous_state_version`, `state_version`을 검증하며 `GameStateRecovery`가 state를 재구성한다.
-5. 이후 정상 turn commit 시 현재 snapshot envelope가 다시 생성된다.
-
-V1~V5 시절 snapshot raw JSON은 DB migration으로 일괄 변환하지 않는다. V6가 legacy `GameLog.user_choice`를 다음 committed row의 `input_choice_text`로 이관하기 때문에 snapshot 없는 기존 session도 #28 이후 원장 구조에서 결정적으로 복구할 수 있다.
-
-## 향후 schema 추가 규칙
-
-새 schema version을 도입할 때는 한 단계씩 순수 변환하는 upgrader를 추가하고 version별 fixture를 유지한다. upgrade 중 외부 provider, 시간 의존 값, 랜덤 값, LLM 결과를 사용해서는 안 된다. 데이터 의미를 복구할 수 없는 변경은 추정값을 만들어 넣지 말고 명시적 실패 또는 별도 migration 정책으로 처리한다.
+새 schema version은 한 단계씩 순수 변환하는 upgrader와 version별 fixture/test를 추가합니다. 의미를 복구할 수 없는 값은 추정하지 말고 명시적 실패 또는 별도 migration 정책으로 처리합니다.

--- a/docs/architecture/game-state-story-memory.md
+++ b/docs/architecture/game-state-story-memory.md
@@ -9,11 +9,41 @@ UCTale의 결정적 게임 상태는 서버가 소유하고, LLM은 그 상태�
 `GameState`는 한 세션의 복원 가능한 현재 상태입니다.
 
 - `turnNumber`: 현재 적용된 턴 번호
-- `PlayerCharacter`: 플레이어의 서버 소유 상태. #7에서 typed stats와 Skill Check 기반을 확장합니다.
+- `PlayerCharacter`: 설명과 서버 소유 `CharacterStats`
 - `WorldState`: 세계의 서버 소유 상태와 flags 확장 지점
 - `StoryMemory`: 장기 서사를 위한 제한된 내러티브 문맥
 
 운영 DB에는 `game_state_snapshot` JSON snapshot으로 저장합니다. `game_session`과 append-only `game_log`는 세션/턴 무결성과 committed-turn 원장 역할을 담당합니다.
+
+## CharacterStats와 Skill Check
+
+#7 이후 `PlayerCharacter.stats`는 임의 문자열 Map이 아니라 다음 canonical stat을 가진 immutable `CharacterStats`입니다.
+
+- `MIGHT` — 근력
+- `AGILITY` — 민첩
+- `INTELLECT` — 지능
+- `WILL` — 의지
+- `PRESENCE` — 매력
+
+표시명은 frontend/UI 책임이며 canonical enum 이름과 분리합니다.
+
+현재 최소 규칙:
+
+- 신규/legacy 기본 stat score: `10`
+- stat score 허용 범위: `1~30`
+- stat modifier: `floor((score - 10) / 2)`
+- d20 roll: `1~20`
+- DC 허용 범위: `1~40`
+- situational modifier: `-20~20`
+- 판정: `rawRoll + statModifier + situationalModifier >= DC`
+- natural 1/20 특수 성공·실패 규칙 없음
+- Skill Check ruleset version: `1`
+
+`SkillCheckResult`에는 stat type, raw roll, stat modifier, situational modifier, DC, total, outcome, ruleset version을 모두 기록해 후속 감사 저장에 필요한 계산 근거를 보존합니다.
+
+랜덤은 `RandomSource` port로 분리합니다. production adapter는 `SecureRandom`을 사용하고 테스트는 fixed/sequence source로 결정적으로 검증합니다. 이 pure domain 판정은 Narrative provider를 호출하지 않습니다.
+
+#7 범위에서는 이 규칙을 실제 `/progress` turn pipeline, `GameResult`, NarrativeContext, DB roll ledger, frontend에 아직 연결하지 않습니다. 해당 통합은 #34/#36/#37/#38에서 수행합니다.
 
 ## Story Memory
 
@@ -46,50 +76,29 @@ LLM 응답 자체는 canonical state 변경 권한이 없습니다.
 #33 이후 main에는 `AvailableAction`과 `PlayerAction` 경계가 있습니다.
 
 - Narrative가 제안한 choice는 서버가 현재 turn에 속한 `AvailableAction`으로 발급합니다.
-- 응답에는 action token/type/source turn/arguments를 포함할 수 있습니다.
 - 다음 `/progress`에서 서버는 제출된 action이 현재 turn의 발급 action과 일치하는지 검증합니다.
 - 만료되거나 변조된 action은 Narrative provider 또는 향후 규칙 실행 전에 거절합니다.
 - 기존 choice ID는 compatibility adapter 경로로 유지합니다.
 
-현재 `ActionType`은 향후 규칙 행동을 위한 경계이며 Attack/UseItem/Skill Check의 실제 판정 규칙을 이미 구현했다는 의미는 아닙니다.
+현재 `ActionType`은 향후 규칙 행동을 위한 경계이며 #7의 Skill Check가 실제 turn에 이미 연결됐다는 의미는 아닙니다.
 
 ## 현재 턴 처리 흐름
 
 1. idempotency와 `(session_id, expected_turn)` reservation을 확인합니다.
 2. `expectedTurn`으로 현재 세션과 `GameState.turnNumber`를 검증합니다.
-3. 제출된 `PlayerAction`을 현재 서버 발급 `AvailableAction`과 대조해 표시 텍스트를 확정합니다.
+3. 제출된 `PlayerAction`을 현재 서버 발급 `AvailableAction`과 대조합니다.
 4. rate limit과 provider budget guard를 확인합니다.
 5. 현재 단계에서는 `GameState`와 action 문맥으로 `NarrativeContext`를 구성합니다.
 6. Narrative Engine이 이야기와 다음 choice 후보를 생성합니다.
 7. 서버가 다음 `GameState`와 server-issued available actions를 구성합니다.
-8. `game_log`, `game_session`, `game_state_snapshot`, mutation 완료 결과를 canonical transaction에서 저장합니다.
-9. reservation owner, expected turn, optimistic lock/unique constraint가 어긋나면 commit을 거절합니다.
+8. canonical transaction에서 저장합니다.
 
-M3의 #34/#36 이후에는 **규칙 결과와 다음 state를 Narrative 호출 전에 확정**하는 구조로 이 흐름을 더 강화합니다.
+M3의 #34/#36/#37 이후에는 action을 서버 규칙으로 먼저 resolve하고 확정된 `GameResult`와 다음 state를 Narrative 호출 전에 만드는 구조로 강화합니다.
 
 ## 기존 세션 호환성
 
-현재 snapshot은 versioned envelope를 사용합니다. #31 이전 raw `GameState` snapshot은 logical schema v0로 식별해 deterministic upgrader로 읽습니다.
+현재 snapshot schema는 v2입니다. #31 이전 raw `GameState`는 logical v0, typed stats 이전 envelope는 v1로 읽어 deterministic upgrader에서 v2로 승격합니다.
 
-snapshot이 없는 session은 committed `GameLog`를 turn 순서로 읽어 `GameStateRecovery`가 상태를 복구합니다. legacy snapshot read 자체는 DB를 다시 쓰지 않고, 다음 정상 canonical commit에서 최신 snapshot 형식으로 저장합니다.
+legacy stats가 없으면 기본값 10을 적용하고 canonical legacy stat 값이 있으면 검증 후 보존합니다. read 자체는 DB를 다시 쓰지 않고 다음 정상 canonical commit에서 최신 snapshot 형식으로 저장합니다.
 
 세부 내용은 [game-state-snapshot-evolution.md](./game-state-snapshot-evolution.md)를 기준으로 합니다.
-
-## 향후 확장
-
-다음 상태는 prompt 문자열이나 임시 service field가 아니라 `GameState`와 명시적 game rule로 확장합니다.
-
-- typed character stats와 deterministic Skill Check
-- inventory / equipment
-- HP / status effects
-- combat state
-- XP / level / skills
-- quest / world flags
-- NPC relationships
-
-## 아직 하지 않는 것
-
-- AI가 상태 변경 command/proposal을 직접 canonical state에 적용하는 기능
-- 전투 공식과 전체 encounter system
-- 아이템/퀘스트 대규모 content catalog
-- 복잡한 클래스/직업 트리

--- a/src/main/java/com/uctale/uctale/application/game/GameStateSnapshotFormat.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameStateSnapshotFormat.java
@@ -4,7 +4,7 @@ final class GameStateSnapshotFormat {
 
     static final int LEGACY_SCHEMA_VERSION = 0;
     static final int LEGACY_RULESET_VERSION = 1;
-    static final int CURRENT_SCHEMA_VERSION = 1;
+    static final int CURRENT_SCHEMA_VERSION = 2;
     static final int CURRENT_RULESET_VERSION = 1;
 
     private GameStateSnapshotFormat() {

--- a/src/main/java/com/uctale/uctale/application/game/GameStateUpgrader.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameStateUpgrader.java
@@ -1,7 +1,10 @@
 package com.uctale.uctale.application.game;
 
+import com.uctale.uctale.domain.game.CharacterStats;
 import org.springframework.stereotype.Component;
 import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.ObjectNode;
 
 @Component
 public class GameStateUpgrader {
@@ -56,6 +59,7 @@ public class GameStateUpgrader {
     private VersionedState upgradeOneVersion(VersionedState source) {
         return switch (source.schemaVersion()) {
             case GameStateSnapshotFormat.LEGACY_SCHEMA_VERSION -> upgradeV0ToV1(source);
+            case 1 -> upgradeV1ToV2(source);
             default -> throw new GameStateSnapshotException(
                     "snapshot schemaVersion " + source.schemaVersion() + "의 다음 upgrade 경로가 없습니다."
             );
@@ -68,6 +72,52 @@ public class GameStateUpgrader {
                 legacy.rulesetVersion(),
                 legacy.state()
         );
+    }
+
+    private VersionedState upgradeV1ToV2(VersionedState source) {
+        if (!(source.state().deepCopy() instanceof ObjectNode state)) {
+            throw new GameStateSnapshotException("snapshot state가 object가 아닙니다.");
+        }
+        JsonNode playerNode = state.get("playerCharacter");
+        if (!(playerNode instanceof ObjectNode playerCharacter)) {
+            throw new GameStateSnapshotException("snapshot playerCharacter가 누락되었거나 손상되었습니다.");
+        }
+
+        JsonNode legacyStats = playerCharacter.get("stats");
+        if (legacyStats != null && !legacyStats.isObject()) {
+            throw new GameStateSnapshotException("snapshot playerCharacter.stats가 object가 아닙니다.");
+        }
+
+        ObjectNode normalizedStats = JsonNodeFactory.instance.objectNode();
+        normalizedStats.put("might", legacyScore(legacyStats, "MIGHT", "might"));
+        normalizedStats.put("agility", legacyScore(legacyStats, "AGILITY", "agility"));
+        normalizedStats.put("intellect", legacyScore(legacyStats, "INTELLECT", "intellect"));
+        normalizedStats.put("will", legacyScore(legacyStats, "WILL", "will"));
+        normalizedStats.put("presence", legacyScore(legacyStats, "PRESENCE", "presence"));
+        playerCharacter.set("stats", normalizedStats);
+
+        return new VersionedState(2, source.rulesetVersion(), state);
+    }
+
+    private int legacyScore(JsonNode stats, String enumKey, String fieldKey) {
+        if (stats == null) {
+            return CharacterStats.DEFAULT_SCORE;
+        }
+        JsonNode value = stats.get(fieldKey);
+        if (value == null) {
+            value = stats.get(enumKey);
+        }
+        if (value == null) {
+            return CharacterStats.DEFAULT_SCORE;
+        }
+        if (!value.isIntegralNumber()) {
+            throw new GameStateSnapshotException("snapshot 능력치 " + enumKey + "가 정수가 아닙니다.");
+        }
+        int score = value.asInt();
+        if (score < CharacterStats.MIN_SCORE || score > CharacterStats.MAX_SCORE) {
+            throw new GameStateSnapshotException("snapshot 능력치 " + enumKey + "가 허용 범위를 벗어났습니다: " + score);
+        }
+        return score;
     }
 
     private boolean looksLikeLegacyState(JsonNode snapshotJson) {

--- a/src/main/java/com/uctale/uctale/application/game/GameStateUpgrader.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameStateUpgrader.java
@@ -67,11 +67,7 @@ public class GameStateUpgrader {
     }
 
     private VersionedState upgradeV0ToV1(VersionedState legacy) {
-        return new VersionedState(
-                1,
-                legacy.rulesetVersion(),
-                legacy.state()
-        );
+        return new VersionedState(1, legacy.rulesetVersion(), legacy.state());
     }
 
     private VersionedState upgradeV1ToV2(VersionedState source) {
@@ -113,11 +109,11 @@ public class GameStateUpgrader {
         if (!value.isIntegralNumber()) {
             throw new GameStateSnapshotException("snapshot 능력치 " + enumKey + "가 정수가 아닙니다.");
         }
-        int score = value.asInt();
+        long score = value.asLong();
         if (score < CharacterStats.MIN_SCORE || score > CharacterStats.MAX_SCORE) {
             throw new GameStateSnapshotException("snapshot 능력치 " + enumKey + "가 허용 범위를 벗어났습니다: " + score);
         }
-        return score;
+        return (int) score;
     }
 
     private boolean looksLikeLegacyState(JsonNode snapshotJson) {

--- a/src/main/java/com/uctale/uctale/application/game/SecureRandomSource.java
+++ b/src/main/java/com/uctale/uctale/application/game/SecureRandomSource.java
@@ -1,0 +1,32 @@
+package com.uctale.uctale.application.game;
+
+import com.uctale.uctale.domain.game.RandomSource;
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+
+@Component
+public class SecureRandomSource implements RandomSource {
+
+    private final SecureRandom secureRandom;
+
+    public SecureRandomSource() {
+        this(new SecureRandom());
+    }
+
+    SecureRandomSource(SecureRandom secureRandom) {
+        this.secureRandom = secureRandom;
+    }
+
+    @Override
+    public int nextIntInclusive(int minInclusive, int maxInclusive) {
+        if (minInclusive > maxInclusive) {
+            throw new IllegalArgumentException("랜덤 범위의 최소값은 최대값보다 클 수 없습니다.");
+        }
+        long bound = (long) maxInclusive - minInclusive + 1L;
+        if (bound > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("랜덤 범위가 너무 큽니다.");
+        }
+        return secureRandom.nextInt((int) bound) + minInclusive;
+    }
+}

--- a/src/main/java/com/uctale/uctale/domain/game/CharacterStats.java
+++ b/src/main/java/com/uctale/uctale/domain/game/CharacterStats.java
@@ -12,6 +12,8 @@ public record CharacterStats(
     public static final int DEFAULT_SCORE = 10;
     public static final int MIN_SCORE = 1;
     public static final int MAX_SCORE = 30;
+    public static final int MIN_MODIFIER = Math.floorDiv(MIN_SCORE - 10, 2);
+    public static final int MAX_MODIFIER = Math.floorDiv(MAX_SCORE - 10, 2);
 
     public CharacterStats {
         validateScore("might", might);

--- a/src/main/java/com/uctale/uctale/domain/game/CharacterStats.java
+++ b/src/main/java/com/uctale/uctale/domain/game/CharacterStats.java
@@ -1,0 +1,48 @@
+package com.uctale.uctale.domain.game;
+
+import java.util.Objects;
+
+public record CharacterStats(
+        int might,
+        int agility,
+        int intellect,
+        int will,
+        int presence
+) {
+    public static final int DEFAULT_SCORE = 10;
+    public static final int MIN_SCORE = 1;
+    public static final int MAX_SCORE = 30;
+
+    public CharacterStats {
+        validateScore("might", might);
+        validateScore("agility", agility);
+        validateScore("intellect", intellect);
+        validateScore("will", will);
+        validateScore("presence", presence);
+    }
+
+    public static CharacterStats defaults() {
+        return new CharacterStats(DEFAULT_SCORE, DEFAULT_SCORE, DEFAULT_SCORE, DEFAULT_SCORE, DEFAULT_SCORE);
+    }
+
+    public int score(StatType statType) {
+        Objects.requireNonNull(statType, "statType은 필수입니다.");
+        return switch (statType) {
+            case MIGHT -> might;
+            case AGILITY -> agility;
+            case INTELLECT -> intellect;
+            case WILL -> will;
+            case PRESENCE -> presence;
+        };
+    }
+
+    public int modifier(StatType statType) {
+        return Math.floorDiv(score(statType) - 10, 2);
+    }
+
+    private static void validateScore(String name, int score) {
+        if (score < MIN_SCORE || score > MAX_SCORE) {
+            throw new IllegalArgumentException(name + " 능력치는 " + MIN_SCORE + "~" + MAX_SCORE + " 범위여야 합니다.");
+        }
+    }
+}

--- a/src/main/java/com/uctale/uctale/domain/game/DiceRoll.java
+++ b/src/main/java/com/uctale/uctale/domain/game/DiceRoll.java
@@ -1,0 +1,19 @@
+package com.uctale.uctale.domain.game;
+
+public record DiceRoll(int value) {
+    public static final int MIN_D20 = 1;
+    public static final int MAX_D20 = 20;
+
+    public DiceRoll {
+        if (value < MIN_D20 || value > MAX_D20) {
+            throw new IllegalArgumentException("d20 결과는 1~20 범위여야 합니다.");
+        }
+    }
+
+    public static DiceRoll d20(RandomSource randomSource) {
+        if (randomSource == null) {
+            throw new IllegalArgumentException("RandomSource는 필수입니다.");
+        }
+        return new DiceRoll(randomSource.nextIntInclusive(MIN_D20, MAX_D20));
+    }
+}

--- a/src/main/java/com/uctale/uctale/domain/game/Difficulty.java
+++ b/src/main/java/com/uctale/uctale/domain/game/Difficulty.java
@@ -1,0 +1,12 @@
+package com.uctale.uctale.domain.game;
+
+public record Difficulty(int dc) {
+    public static final int MIN_DC = 1;
+    public static final int MAX_DC = 40;
+
+    public Difficulty {
+        if (dc < MIN_DC || dc > MAX_DC) {
+            throw new IllegalArgumentException("DC는 " + MIN_DC + "~" + MAX_DC + " 범위여야 합니다.");
+        }
+    }
+}

--- a/src/main/java/com/uctale/uctale/domain/game/PlayerCharacter.java
+++ b/src/main/java/com/uctale/uctale/domain/game/PlayerCharacter.java
@@ -1,12 +1,14 @@
 package com.uctale.uctale.domain.game;
 
+import java.util.Objects;
+
 public record PlayerCharacter(
         String description,
         CharacterStats stats
 ) {
     public PlayerCharacter {
         description = description == null ? "" : description.trim();
-        stats = stats == null ? CharacterStats.defaults() : stats;
+        Objects.requireNonNull(stats, "stats는 필수입니다.");
     }
 
     public static PlayerCharacter initial(String characterSetting) {

--- a/src/main/java/com/uctale/uctale/domain/game/PlayerCharacter.java
+++ b/src/main/java/com/uctale/uctale/domain/game/PlayerCharacter.java
@@ -1,17 +1,15 @@
 package com.uctale.uctale.domain.game;
 
-import java.util.Map;
-
 public record PlayerCharacter(
         String description,
-        Map<String, Integer> stats
+        CharacterStats stats
 ) {
     public PlayerCharacter {
         description = description == null ? "" : description.trim();
-        stats = stats == null ? Map.of() : Map.copyOf(stats);
+        stats = stats == null ? CharacterStats.defaults() : stats;
     }
 
     public static PlayerCharacter initial(String characterSetting) {
-        return new PlayerCharacter(characterSetting, Map.of());
+        return new PlayerCharacter(characterSetting, CharacterStats.defaults());
     }
 }

--- a/src/main/java/com/uctale/uctale/domain/game/RandomSource.java
+++ b/src/main/java/com/uctale/uctale/domain/game/RandomSource.java
@@ -1,0 +1,5 @@
+package com.uctale.uctale.domain.game;
+
+public interface RandomSource {
+    int nextIntInclusive(int minInclusive, int maxInclusive);
+}

--- a/src/main/java/com/uctale/uctale/domain/game/SkillCheck.java
+++ b/src/main/java/com/uctale/uctale/domain/game/SkillCheck.java
@@ -1,0 +1,43 @@
+package com.uctale.uctale.domain.game;
+
+import java.util.Objects;
+
+public record SkillCheck(
+        StatType statType,
+        Difficulty difficulty,
+        int situationalModifier
+) {
+    public static final int RULESET_VERSION = 1;
+    public static final int MIN_SITUATIONAL_MODIFIER = -20;
+    public static final int MAX_SITUATIONAL_MODIFIER = 20;
+
+    public SkillCheck {
+        Objects.requireNonNull(statType, "statType은 필수입니다.");
+        Objects.requireNonNull(difficulty, "difficulty는 필수입니다.");
+        if (situationalModifier < MIN_SITUATIONAL_MODIFIER || situationalModifier > MAX_SITUATIONAL_MODIFIER) {
+            throw new IllegalArgumentException(
+                    "상황 modifier는 " + MIN_SITUATIONAL_MODIFIER + "~" + MAX_SITUATIONAL_MODIFIER + " 범위여야 합니다."
+            );
+        }
+    }
+
+    public SkillCheckResult resolve(CharacterStats stats, RandomSource randomSource) {
+        Objects.requireNonNull(stats, "stats는 필수입니다.");
+        DiceRoll roll = DiceRoll.d20(randomSource);
+        int statModifier = stats.modifier(statType);
+        int total = roll.value() + statModifier + situationalModifier;
+        SkillCheckOutcome outcome = total >= difficulty.dc()
+                ? SkillCheckOutcome.SUCCESS
+                : SkillCheckOutcome.FAILURE;
+        return new SkillCheckResult(
+                statType,
+                roll.value(),
+                statModifier,
+                situationalModifier,
+                difficulty.dc(),
+                total,
+                outcome,
+                RULESET_VERSION
+        );
+    }
+}

--- a/src/main/java/com/uctale/uctale/domain/game/SkillCheckOutcome.java
+++ b/src/main/java/com/uctale/uctale/domain/game/SkillCheckOutcome.java
@@ -1,0 +1,6 @@
+package com.uctale.uctale.domain.game;
+
+public enum SkillCheckOutcome {
+    SUCCESS,
+    FAILURE
+}

--- a/src/main/java/com/uctale/uctale/domain/game/SkillCheckResult.java
+++ b/src/main/java/com/uctale/uctale/domain/game/SkillCheckResult.java
@@ -17,6 +17,9 @@ public record SkillCheckResult(
         Objects.requireNonNull(outcome, "outcome은 필수입니다.");
         new DiceRoll(rawRoll);
         new Difficulty(dc);
+        if (statModifier < CharacterStats.MIN_MODIFIER || statModifier > CharacterStats.MAX_MODIFIER) {
+            throw new IllegalArgumentException("stat modifier가 허용 범위를 벗어났습니다.");
+        }
         if (situationalModifier < SkillCheck.MIN_SITUATIONAL_MODIFIER
                 || situationalModifier > SkillCheck.MAX_SITUATIONAL_MODIFIER) {
             throw new IllegalArgumentException("상황 modifier가 허용 범위를 벗어났습니다.");

--- a/src/main/java/com/uctale/uctale/domain/game/SkillCheckResult.java
+++ b/src/main/java/com/uctale/uctale/domain/game/SkillCheckResult.java
@@ -1,0 +1,35 @@
+package com.uctale.uctale.domain.game;
+
+import java.util.Objects;
+
+public record SkillCheckResult(
+        StatType statType,
+        int rawRoll,
+        int statModifier,
+        int situationalModifier,
+        int dc,
+        int total,
+        SkillCheckOutcome outcome,
+        int rulesetVersion
+) {
+    public SkillCheckResult {
+        Objects.requireNonNull(statType, "statType은 필수입니다.");
+        Objects.requireNonNull(outcome, "outcome은 필수입니다.");
+        new DiceRoll(rawRoll);
+        new Difficulty(dc);
+        if (situationalModifier < SkillCheck.MIN_SITUATIONAL_MODIFIER
+                || situationalModifier > SkillCheck.MAX_SITUATIONAL_MODIFIER) {
+            throw new IllegalArgumentException("상황 modifier가 허용 범위를 벗어났습니다.");
+        }
+        if (rulesetVersion != SkillCheck.RULESET_VERSION) {
+            throw new IllegalArgumentException("지원하지 않는 Skill Check rulesetVersion입니다: " + rulesetVersion);
+        }
+        if (total != rawRoll + statModifier + situationalModifier) {
+            throw new IllegalArgumentException("Skill Check total이 계산 근거와 일치하지 않습니다.");
+        }
+        SkillCheckOutcome expected = total >= dc ? SkillCheckOutcome.SUCCESS : SkillCheckOutcome.FAILURE;
+        if (outcome != expected) {
+            throw new IllegalArgumentException("Skill Check outcome이 total/DC와 일치하지 않습니다.");
+        }
+    }
+}

--- a/src/main/java/com/uctale/uctale/domain/game/StatType.java
+++ b/src/main/java/com/uctale/uctale/domain/game/StatType.java
@@ -1,0 +1,9 @@
+package com.uctale.uctale.domain.game;
+
+public enum StatType {
+    MIGHT,
+    AGILITY,
+    INTELLECT,
+    WILL,
+    PRESENCE
+}

--- a/src/test/java/com/uctale/uctale/application/game/GameStateCodecCompatibilityTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/GameStateCodecCompatibilityTest.java
@@ -1,0 +1,33 @@
+package com.uctale.uctale.application.game;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GameStateCodecCompatibilityTest {
+
+    private final GameStateCodec codec = new GameStateCodec(new ObjectMapper(), new GameStateUpgrader());
+
+    @Test
+    @DisplayName("현재 schema v2에서 stats가 누락된 손상 snapshot은 기본값으로 숨기지 않는다")
+    void currentSchemaMissingStats_FailsExplicitly() {
+        String json = """
+                {
+                  "schemaVersion": 2,
+                  "rulesetVersion": 1,
+                  "state": {
+                    "turnNumber": 1,
+                    "playerCharacter": {"description": "캐릭터"},
+                    "worldState": {"premise": "세계관", "flags": {}},
+                    "storyMemory": {"canonicalFacts": [], "rollingSummary": "", "recentTurns": []}
+                  }
+                }
+                """;
+
+        assertThatThrownBy(() -> codec.deserialize(json))
+                .isInstanceOf(GameStateSnapshotException.class)
+                .hasMessageContaining("역직렬화");
+    }
+}

--- a/src/test/java/com/uctale/uctale/application/game/GameStateUpgraderTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/GameStateUpgraderTest.java
@@ -19,40 +19,104 @@ class GameStateUpgraderTest {
     private final GameStateUpgrader upgrader = new GameStateUpgrader();
 
     @Test
-    @DisplayName("production legacy raw GameState를 schema v1로 순수 upgrade한다")
+    @DisplayName("production legacy raw GameState를 schema v2와 기본 능력치로 순수 upgrade한다")
     void legacyRawState_IsUpgradedToCurrentSchema() throws Exception {
         JsonNode legacy = objectMapper.readTree(legacyStateJson());
 
         GameStateUpgrader.UpgradedSnapshot upgraded = upgrader.upgrade(legacy);
 
-        assertThat(upgraded.schemaVersion()).isEqualTo(1);
+        assertThat(upgraded.schemaVersion()).isEqualTo(2);
         assertThat(upgraded.rulesetVersion()).isEqualTo(1);
-        assertThat(upgraded.state()).isEqualTo(legacy);
+        assertThat(upgraded.state().get("playerCharacter").get("stats").get("might").asInt()).isEqualTo(10);
+        assertThat(upgraded.state().get("playerCharacter").get("stats").get("presence").asInt()).isEqualTo(10);
     }
 
     @Test
-    @DisplayName("schema v1 snapshot은 state를 그대로 읽는다")
-    void schemaV1_IsReadWithoutMutation() throws Exception {
+    @DisplayName("schema v1 legacy stats의 canonical 키는 v2 typed stats로 보존한다")
+    void schemaV1Stats_AreNormalizedWithoutLosingCanonicalValues() throws Exception {
         JsonNode snapshot = objectMapper.readTree("""
                 {
                   "schemaVersion": 1,
                   "rulesetVersion": 1,
-                  "state": %s
+                  "state": {
+                    "turnNumber": 1,
+                    "playerCharacter": {
+                      "description": "캐릭터",
+                      "stats": {"MIGHT": 14, "agility": 12}
+                    },
+                    "worldState": {"premise": "세계관", "flags": {}},
+                    "storyMemory": {
+                      "canonicalFacts": [],
+                      "rollingSummary": "",
+                      "recentTurns": []
+                    }
+                  }
                 }
-                """.formatted(legacyStateJson()));
+                """);
+
+        GameStateUpgrader.UpgradedSnapshot upgraded = upgrader.upgrade(snapshot);
+        JsonNode stats = upgraded.state().get("playerCharacter").get("stats");
+
+        assertThat(upgraded.schemaVersion()).isEqualTo(2);
+        assertThat(stats.get("might").asInt()).isEqualTo(14);
+        assertThat(stats.get("agility").asInt()).isEqualTo(12);
+        assertThat(stats.get("intellect").asInt()).isEqualTo(10);
+        assertThat(stats.get("will").asInt()).isEqualTo(10);
+        assertThat(stats.get("presence").asInt()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("schema v2 snapshot은 state를 그대로 읽는다")
+    void schemaV2_IsReadWithoutMutation() throws Exception {
+        JsonNode snapshot = objectMapper.readTree("""
+                {
+                  "schemaVersion": 2,
+                  "rulesetVersion": 1,
+                  "state": {
+                    "turnNumber": 1,
+                    "playerCharacter": {
+                      "description": "캐릭터",
+                      "stats": {"might":10,"agility":10,"intellect":10,"will":10,"presence":10}
+                    },
+                    "worldState": {"premise": "세계관", "flags": {}},
+                    "storyMemory": {"canonicalFacts": [], "rollingSummary": "", "recentTurns": []}
+                  }
+                }
+                """);
 
         GameStateUpgrader.UpgradedSnapshot upgraded = upgrader.upgrade(snapshot);
 
-        assertThat(upgraded.schemaVersion()).isEqualTo(1);
+        assertThat(upgraded.schemaVersion()).isEqualTo(2);
         assertThat(upgraded.rulesetVersion()).isEqualTo(1);
-        assertThat(upgraded.state().get("turnNumber").asInt()).isEqualTo(1);
+        assertThat(upgraded.state()).isEqualTo(snapshot.get("state"));
+    }
+
+    @Test
+    @DisplayName("legacy 능력치가 허용 범위를 벗어나면 추정하지 않고 실패한다")
+    void invalidLegacyStat_FailsExplicitly() throws Exception {
+        JsonNode snapshot = objectMapper.readTree("""
+                {
+                  "schemaVersion": 1,
+                  "rulesetVersion": 1,
+                  "state": {
+                    "turnNumber": 1,
+                    "playerCharacter": {"description": "캐릭터", "stats": {"MIGHT": 999}},
+                    "worldState": {"premise": "세계관", "flags": {}},
+                    "storyMemory": {"canonicalFacts": [], "rollingSummary": "", "recentTurns": []}
+                  }
+                }
+                """);
+
+        assertThatThrownBy(() -> upgrader.upgrade(snapshot))
+                .isInstanceOf(GameStateSnapshotException.class)
+                .hasMessageContaining("MIGHT");
     }
 
     @Test
     @DisplayName("미래 schema version은 기본값 처리하지 않고 실패한다")
     void futureSchemaVersion_FailsExplicitly() throws Exception {
         JsonNode snapshot = objectMapper.readTree("""
-                {"schemaVersion": 2, "rulesetVersion": 1, "state": {}}
+                {"schemaVersion": 3, "rulesetVersion": 1, "state": {}}
                 """);
 
         assertThatThrownBy(() -> upgrader.upgrade(snapshot))
@@ -64,7 +128,7 @@ class GameStateUpgraderTest {
     @DisplayName("미지원 ruleset version은 자동 재판정하지 않고 실패한다")
     void unsupportedRulesetVersion_FailsExplicitly() throws Exception {
         JsonNode snapshot = objectMapper.readTree("""
-                {"schemaVersion": 1, "rulesetVersion": 2, "state": {}}
+                {"schemaVersion": 2, "rulesetVersion": 2, "state": {}}
                 """);
 
         assertThatThrownBy(() -> upgrader.upgrade(snapshot))
@@ -88,7 +152,7 @@ class GameStateUpgraderTest {
     @DisplayName("schemaVersion이 있어도 state가 누락되면 손상 snapshot으로 실패한다")
     void missingState_FailsExplicitly() throws Exception {
         JsonNode snapshot = objectMapper.readTree("""
-                {"schemaVersion": 1, "rulesetVersion": 1}
+                {"schemaVersion": 2, "rulesetVersion": 1}
                 """);
 
         assertThatThrownBy(() -> upgrader.upgrade(snapshot))

--- a/src/test/java/com/uctale/uctale/application/game/SecureRandomSourceTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/SecureRandomSourceTest.java
@@ -1,0 +1,21 @@
+package com.uctale.uctale.application.game;
+
+import com.uctale.uctale.domain.game.DiceRoll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SecureRandomSourceTest {
+
+    @Test
+    @DisplayName("production SecureRandom adapter는 요청 범위 안의 값을 반환한다")
+    void secureRandomSource_ReturnsValueWithinRequestedRange() {
+        SecureRandomSource randomSource = new SecureRandomSource();
+
+        for (int i = 0; i < 100; i++) {
+            int value = randomSource.nextIntInclusive(DiceRoll.MIN_D20, DiceRoll.MAX_D20);
+            assertThat(value).isBetween(DiceRoll.MIN_D20, DiceRoll.MAX_D20);
+        }
+    }
+}

--- a/src/test/java/com/uctale/uctale/domain/game/SkillCheckTest.java
+++ b/src/test/java/com/uctale/uctale/domain/game/SkillCheckTest.java
@@ -1,0 +1,129 @@
+package com.uctale.uctale.domain.game;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SkillCheckTest {
+
+    @Test
+    @DisplayName("신규 캐릭터는 모든 능력치 10의 서버 기본값을 사용한다")
+    void defaults_AreAppliedToNewCharacter() {
+        PlayerCharacter character = PlayerCharacter.initial("캐릭터");
+
+        assertThat(character.stats()).isEqualTo(CharacterStats.defaults());
+        assertThat(character.stats().score(StatType.MIGHT)).isEqualTo(10);
+        assertThat(character.stats().score(StatType.PRESENCE)).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("능력치 modifier는 10 기준 2점당 1이며 음수는 내림 계산한다")
+    void statModifier_UsesFloorDivision() {
+        CharacterStats stats = new CharacterStats(9, 10, 11, 12, 30);
+
+        assertThat(stats.modifier(StatType.MIGHT)).isEqualTo(-1);
+        assertThat(stats.modifier(StatType.AGILITY)).isZero();
+        assertThat(stats.modifier(StatType.INTELLECT)).isZero();
+        assertThat(stats.modifier(StatType.WILL)).isEqualTo(1);
+        assertThat(stats.modifier(StatType.PRESENCE)).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("고정 roll과 동일 입력은 같은 감사 가능한 SkillCheckResult를 만든다")
+    void fixedRoll_IsDeterministicAndAuditable() {
+        CharacterStats stats = new CharacterStats(14, 10, 10, 10, 10);
+        SkillCheck check = new SkillCheck(StatType.MIGHT, new Difficulty(15), 1);
+
+        SkillCheckResult first = check.resolve(stats, new FixedRandomSource(12));
+        SkillCheckResult second = check.resolve(stats, new FixedRandomSource(12));
+
+        assertThat(first).isEqualTo(second);
+        assertThat(first.rawRoll()).isEqualTo(12);
+        assertThat(first.statModifier()).isEqualTo(2);
+        assertThat(first.situationalModifier()).isEqualTo(1);
+        assertThat(first.dc()).isEqualTo(15);
+        assertThat(first.total()).isEqualTo(15);
+        assertThat(first.outcome()).isEqualTo(SkillCheckOutcome.SUCCESS);
+        assertThat(first.rulesetVersion()).isEqualTo(SkillCheck.RULESET_VERSION);
+    }
+
+    @Test
+    @DisplayName("natural 1과 20에 특수 성공 실패 규칙을 적용하지 않는다")
+    void naturalOneAndTwenty_HaveNoSpecialRule() {
+        CharacterStats neutral = CharacterStats.defaults();
+
+        SkillCheckResult naturalOneSuccess = new SkillCheck(
+                StatType.MIGHT, new Difficulty(20), 19
+        ).resolve(neutral, new FixedRandomSource(1));
+        SkillCheckResult naturalTwentyFailure = new SkillCheck(
+                StatType.MIGHT, new Difficulty(21), 0
+        ).resolve(neutral, new FixedRandomSource(20));
+
+        assertThat(naturalOneSuccess.total()).isEqualTo(20);
+        assertThat(naturalOneSuccess.outcome()).isEqualTo(SkillCheckOutcome.SUCCESS);
+        assertThat(naturalTwentyFailure.total()).isEqualTo(20);
+        assertThat(naturalTwentyFailure.outcome()).isEqualTo(SkillCheckOutcome.FAILURE);
+    }
+
+    @Test
+    @DisplayName("sequence RandomSource는 테스트에서 roll 순서를 결정적으로 제어한다")
+    void sequenceRandomSource_ControlsRollOrder() {
+        SequenceRandomSource random = new SequenceRandomSource(3, 19);
+        SkillCheck check = new SkillCheck(StatType.AGILITY, new Difficulty(10), 0);
+
+        assertThat(check.resolve(CharacterStats.defaults(), random).rawRoll()).isEqualTo(3);
+        assertThat(check.resolve(CharacterStats.defaults(), random).rawRoll()).isEqualTo(19);
+    }
+
+    @Test
+    @DisplayName("능력치 DC roll 상황 modifier invariant를 생성 시점에 검증한다")
+    void invalidRuleValues_AreRejected() {
+        assertThatThrownBy(() -> new CharacterStats(0, 10, 10, 10, 10))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new CharacterStats(10, 10, 10, 10, 31))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new Difficulty(0)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new Difficulty(41)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new DiceRoll(0)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new DiceRoll(21)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new SkillCheck(StatType.WILL, new Difficulty(10), 21))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private record FixedRandomSource(int value) implements RandomSource {
+        @Override
+        public int nextIntInclusive(int minInclusive, int maxInclusive) {
+            if (value < minInclusive || value > maxInclusive) {
+                throw new IllegalArgumentException("고정 랜덤 값이 요청 범위를 벗어났습니다.");
+            }
+            return value;
+        }
+    }
+
+    private static final class SequenceRandomSource implements RandomSource {
+        private final Deque<Integer> values = new ArrayDeque<>();
+
+        private SequenceRandomSource(int... values) {
+            for (int value : values) {
+                this.values.addLast(value);
+            }
+        }
+
+        @Override
+        public int nextIntInclusive(int minInclusive, int maxInclusive) {
+            Integer value = values.pollFirst();
+            if (value == null) {
+                throw new IllegalStateException("테스트 랜덤 sequence가 소진되었습니다.");
+            }
+            if (value < minInclusive || value > maxInclusive) {
+                throw new IllegalArgumentException("sequence 랜덤 값이 요청 범위를 벗어났습니다.");
+            }
+            return value;
+        }
+    }
+}

--- a/src/test/java/com/uctale/uctale/persistence/PostgresGameStateSnapshotCompatibilityTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/PostgresGameStateSnapshotCompatibilityTest.java
@@ -3,6 +3,7 @@ package com.uctale.uctale.persistence;
 import com.uctale.uctale.application.game.GamePersistenceService;
 import com.uctale.uctale.application.game.GameTurnCommit;
 import com.uctale.uctale.domain.GameSession;
+import com.uctale.uctale.domain.game.CharacterStats;
 import com.uctale.uctale.domain.game.GameState;
 import com.uctale.uctale.support.PostgresIntegrationTestSupport;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,7 +36,7 @@ class PostgresGameStateSnapshotCompatibilityTest extends PostgresIntegrationTest
     }
 
     @Test
-    @DisplayName("기존 production raw snapshot을 데이터 손실 없이 읽고 다음 write에서 최신 envelope로 저장한다")
+    @DisplayName("기존 production raw snapshot을 기본 typed stats로 읽고 다음 write에서 schema v2로 저장한다")
     void legacyRawSnapshot_IsReadAndRewrittenOnNextCanonicalWrite() throws Exception {
         GameSession session = gamePersistenceService.saveOpening(
                 OWNER_KEY, "세계관", "캐릭터", "첫 이야기", "[]", null
@@ -46,9 +47,11 @@ class PostgresGameStateSnapshotCompatibilityTest extends PostgresIntegrationTest
                 session.getId()
         );
         JsonNode openingSnapshot = objectMapper.readTree(openingSnapshotJson);
-        assertThat(openingSnapshot.get("schemaVersion").asInt()).isEqualTo(1);
+        assertThat(openingSnapshot.get("schemaVersion").asInt()).isEqualTo(2);
         assertThat(openingSnapshot.get("rulesetVersion").asInt()).isEqualTo(1);
         assertThat(openingSnapshot.get("state").get("turnNumber").asInt()).isEqualTo(1);
+        assertThat(openingSnapshot.get("state").get("playerCharacter").get("stats").get("might").asInt())
+                .isEqualTo(CharacterStats.DEFAULT_SCORE);
 
         GameState initialState = gamePersistenceService.loadLatestTurn(OWNER_KEY, session.getId(), 1).gameState();
         String legacyRawJson = legacyStateJson();
@@ -61,6 +64,7 @@ class PostgresGameStateSnapshotCompatibilityTest extends PostgresIntegrationTest
         GameState recovered = gamePersistenceService.loadLatestTurn(OWNER_KEY, session.getId(), 1).gameState();
 
         assertThat(recovered).isEqualTo(initialState);
+        assertThat(recovered.playerCharacter().stats()).isEqualTo(CharacterStats.defaults());
         assertThat(jdbcTemplate.queryForObject(
                 "select state_json from game_state_snapshot where session_id = ?",
                 String.class,
@@ -80,13 +84,15 @@ class PostgresGameStateSnapshotCompatibilityTest extends PostgresIntegrationTest
                 session.getId()
         );
         JsonNode rewritten = objectMapper.readTree(rewrittenJson);
-        assertThat(rewritten.get("schemaVersion").asInt()).isEqualTo(1);
+        assertThat(rewritten.get("schemaVersion").asInt()).isEqualTo(2);
         assertThat(rewritten.get("rulesetVersion").asInt()).isEqualTo(1);
         assertThat(rewritten.get("state").get("turnNumber").asInt()).isEqualTo(2);
+        assertThat(rewritten.get("state").get("playerCharacter").get("stats").get("presence").asInt())
+                .isEqualTo(CharacterStats.DEFAULT_SCORE);
     }
 
     @Test
-    @DisplayName("snapshot 없는 기존 session은 append-only GameLog 원장에서 현재 GameState를 복구한다")
+    @DisplayName("snapshot 없는 기존 session은 append-only GameLog 원장에서 현재 GameState와 기본 stats를 복구한다")
     void snapshotlessSession_RecoversFromCommittedTurnLedger() {
         GameSession session = gamePersistenceService.saveOpening(
                 OWNER_KEY, "세계관", "캐릭터", "첫 이야기", "[]", null
@@ -103,6 +109,7 @@ class PostgresGameStateSnapshotCompatibilityTest extends PostgresIntegrationTest
         GameState recovered = gamePersistenceService.loadLatestTurn(OWNER_KEY, session.getId(), 2).gameState();
 
         assertThat(recovered).isEqualTo(nextState);
+        assertThat(recovered.playerCharacter().stats()).isEqualTo(CharacterStats.defaults());
         assertThat(recovered.storyMemory().recentTurns().getLast().playerAction()).isEqualTo("진행");
     }
 


### PR DESCRIPTION
## 왜 필요한가요?

현재 `PlayerCharacter.stats`는 문자열 Map 기반 임시 모델이고 서버가 판정 결과를 소유하는 typed rule model이 없습니다. 전투/아이템 규칙을 붙이기 전에 재현 가능한 최소 능력치와 Skill Check 규칙을 pure domain으로 고정합니다.

- Closes #7

## 무엇이 바뀌나요?

- 게임 규칙·상태: `StatType`, immutable `CharacterStats`, `Difficulty`, `DiceRoll`, `SkillCheck`, `SkillCheckResult`, `RandomSource`를 추가합니다. 기본 stat 10, score 1~30, d20 1~20, DC 1~40, 상황 modifier -20~20, `total >= DC` 규칙을 고정합니다.
- Backend / API / DB: `PlayerCharacter.stats`를 typed `CharacterStats`로 교체하고 snapshot schema를 v2로 올립니다. DB schema/API 계약 변경은 없습니다.
- AI narrative / prompt: 변경 없음. Skill Check는 Narrative provider를 호출하지 않는 pure domain operation입니다.
- Image generation: 변경 없음.
- Frontend / UX: 기능 변경 없음. 한국어 표시명은 canonical enum과 분리한다는 계약만 문서화합니다.
- Build / deploy / docs: README와 GameState/snapshot 문서를 현재 규칙 및 v0/v1 → v2 호환 정책에 맞게 갱신합니다.

## 책임 경계

- **서버가 결정하는 사실:** canonical stat score, stat modifier, d20 raw roll, situational modifier, DC, total, 성공/실패, Skill Check ruleset version.
- **LLM이 서술하는 내용:** 이번 PR에서는 Skill Check 결과를 LLM에 전달하지 않습니다.
- **LLM이 변경하면 안 되는 사실:** Skill Check의 roll, 계산 근거, total, outcome 및 canonical stats.

## 어떻게 검증했나요?

- [x] PR 작성 전 변경 diff를 비판적으로 검토하고 타당한 지적을 반영했습니다.
- [x] `./gradlew clean test`
- [x] `./gradlew postgresIntegrationTest`
- [x] `./gradlew build`
- [x] `cd frontend && npm ci && npm test && npm run lint && npm run build`
- [ ] 정상 흐름을 직접 확인했습니다.
- [x] 잘못된 입력/실패 흐름을 확인했습니다.
- [x] 중복 요청 또는 상태 전이가 관련되면 이를 검증했습니다.

CI #174에서 backend `clean test`, PostgreSQL integration test, backend build(`./gradlew build -x test`, 앞 단계 unit test 성공), frontend `npm ci` / `npm test` / lint / build가 모두 통과했습니다.

추가한 테스트는 stat/DC/roll/modifier invariant, fixed/sequence RandomSource 결정성, natural 1/20 비특수 규칙, audit result 필드, production SecureRandom adapter 범위, legacy raw/v1 snapshot 기본값·canonical 값 보존, current v2 손상 stats 거절, PostgreSQL legacy snapshot 재작성 경계를 검증합니다.

PR 전 비판적 리뷰에서 다음 지적을 타당하게 판단해 반영했습니다.

- README가 #7을 아직 다음 작업으로 표시하던 상태를 현재 구현 상태로 갱신
- current schema v2의 누락 stats를 기본값으로 은폐하지 않도록 `PlayerCharacter`에서 null 거절
- 직접 생성된 `SkillCheckResult`도 stat modifier 범위를 검증
- 매우 큰 legacy 정수가 `asInt()` truncation으로 정상 범위처럼 보이지 않도록 long으로 선검증

## 게임 상태·AI 안전성

해당하지 않는 항목은 이유를 적어 주세요.

- [x] 게임의 결정적 상태는 서버에서 검증·저장됩니다.
- [x] LLM 출력만으로 HP, 보상, 성공/실패 등 결정적 상태가 임의 변경되지 않습니다.
- [x] AI 요청에 필요한 최소 문맥만 전달합니다.
- [x] AI 응답 파싱 실패와 provider 오류가 게임 상태를 오염시키지 않습니다.
- [x] 기존 저장 데이터 또는 GameState 호환성 영향을 확인했습니다.

Skill Check는 provider와 독립된 pure domain 규칙이며, 이번 PR에서 실제 `/progress`나 NarrativeContext에 연결하지 않습니다. 기존 v0/v1 snapshot은 deterministic upgrader로 v2 typed stats에 승격합니다.

## 보안·비용

- [x] API Key, 토큰, 비밀번호가 코드·로그·URL·클라이언트 응답에 노출되지 않습니다.
- [x] 외부 AI/Image 호출 횟수와 실패 시 동작을 검토했습니다.
- [x] 사용자 입력 길이와 외부 API 비용 증가 가능성을 검토했습니다.
- [x] CORS 또는 공개 endpoint 변경이 있다면 의도된 변경입니다.

외부 provider 호출/API/CORS 변경은 없습니다. production random adapter는 JDK `SecureRandom`을 사용합니다.

## API·DB·운영 영향

- [x] API 계약 변경 시 Frontend 호출부와 문서를 함께 갱신했습니다.
- [x] DB schema 변경 시 migration 전략을 포함했습니다.
- [x] 환경변수는 이름과 용도만 문서화했고 실제 Secret은 포함하지 않았습니다.
- [x] 배포 후 확인할 smoke test가 있습니다.

API와 DB schema 변경은 없습니다. snapshot JSON schema만 v1 → v2로 올리며 read-time upgrader와 PostgreSQL compatibility test를 제공합니다. runtime endpoint 변경이 없어 기존 production smoke 계약은 그대로 유지됩니다.

## 화면 / 응답 예시

UI/API 응답 변경 없음.