### PR TITLE
refactor(game): ActionResolver와 GameResult 경계 도입

### DIFF
--- a/docs/architecture/action-resolution.md
+++ b/docs/architecture/action-resolution.md
@@ -1,0 +1,104 @@
+# Action Resolution / Turn Resolution 경계
+
+## 목적
+
+UCTale의 결정적 게임 규칙은 Narrative provider가 아니라 서버가 소유한다. `/progress`는 서버가 발급한 `PlayerAction`을 먼저 규칙으로 해석하고, 그 결과와 canonical state transition을 확정한 뒤 Narrative provider를 호출한다.
+
+현재 #34에서는 첫 규칙 경계만 도입한다. 실제 action type은 `NARRATIVE_CHOICE` 하나이므로 resolver registry나 범용 Rule Engine은 만들지 않는다.
+
+## 책임
+
+### `ActionResolver`
+
+순수 domain operation이다.
+
+입력:
+
+- 현재 `GameState`
+- 검증된 `PlayerAction`
+
+출력:
+
+- `TurnResolution`
+  - `GameResult`
+  - `StateTransition`
+
+현재 `GameResult`는 다음 최소 정보를 가진다.
+
+- 서버가 resolve한 `PlayerAction`
+- `Outcome.RESOLVED`
+- 이번 action이 만든 canonical facts
+- domain events
+- typed state changes
+- Narrative Engine이 활용할 수 있는 narrative cues
+
+`NARRATIVE_CHOICE`는 아직 성공/실패·HP·아이템 같은 규칙을 만들지 않으므로 새 canonical fact는 없고, `ACTION_RESOLVED` event와 `TurnAdvanced` state change만 생성한다.
+
+### `TurnProcessor`
+
+application 단계에서 `ActionResolver` 호출과 resolved transition의 narrative transcript 완성을 연결한다. 현재 resolver가 하나뿐이고 상태가 없으므로 registry나 Spring bean graph를 추가하지 않는다.
+
+### `GameService`
+
+다음 순서만 조정한다.
+
+1. mutation/idempotency와 reservation 획득
+2. 현재 session/turn/canonical state 로드
+3. 서버 발급 action 검증
+4. `TurnProcessor.resolve()`로 `GameResult`와 canonical `StateTransition` 확정
+5. rate limit / provider attempt accounting 확인
+6. Narrative provider 호출
+7. provider 응답 검증
+8. 확정된 transition에 narrative transcript를 부착하고 다음 server-issued actions 구성
+9. `GameTurnCommit`으로 원자적 persistence 호출
+
+`GameService`는 action type별 규칙 공식이나 상태 변경 세부 구현을 알지 않는다.
+
+### Persistence
+
+`GameTurnCommit`은 문자열에서 상태를 계산하지 않고 `StateTransition`을 소유한다. `GamePersistenceService.saveNextTurn()`은 저장 직전에 다음을 재검증한 뒤 한 transaction에서 commit한다.
+
+- reservation owner
+- expected turn
+- previous/next state version
+- DB의 canonical previous state와 transition의 previous state equality
+- optimistic lock / unique turn constraint
+
+Persistence는 user choice text나 story prose를 파싱해 규칙 결과를 계산하지 않는다.
+
+## Narrative provider 전후 경계
+
+### Provider 호출 전에 확정되는 것
+
+- resolved `PlayerAction`
+- `GameResult.outcome`
+- canonical facts/events
+- 규칙이 만드는 state changes
+- canonical next turn/state transition
+- narrative cues
+
+외부 provider 실패나 다른 prose가 위 값을 다시 판정하지 않는다.
+
+### Provider 호출 뒤 허용되는 것
+
+현재 `StoryMemory.recentTurns`는 기존 장기 narrative 호환을 위해 provider가 만든 story prose를 transcript로 보관한다. 이 단계는 이미 확정된 turn number, player/world state, canonical facts, `GameResult`를 변경하지 않는다.
+
+즉 #34에서는 **규칙 state transition**과 **narrative-memory transcript 완성**을 타입으로 분리했다. `StoryMemory`가 현재 `GameState` snapshot 안에 함께 저장되는 기존 schema는 유지한다. 이를 제거하거나 `NarrativeContext`를 `GameResult` projection으로 전환하는 작업은 #36/#46의 별도 범위다.
+
+## Transaction boundary
+
+Narrative/Image provider 네트워크 호출 동안 DB transaction을 열지 않는다.
+
+- load/reservation 검증: 짧은 DB transaction
+- action resolution: pure in-memory domain operation
+- Narrative/Image provider: DB transaction 밖
+- final commit: `GameTurnCommit`을 단일 persistence transaction으로 저장
+
+provider 호출 성공 후 commit 전 crash window에서 외부 provider가 재호출될 수 있다는 기존 bounded at-least-once 정책과 stale-owner fencing은 변경하지 않는다.
+
+## 호환성
+
+- API wire contract와 기존 `NARRATIVE_CHOICE` 선택 흐름은 변경하지 않는다.
+- `GameState.advance(playerAction, storyText)`는 legacy log recovery와 기존 테스트 호환을 위해 남기되, 내부적으로 `advanceTurn()` + `recordNarrativeTurn()`을 사용한다.
+- snapshot schema/DB migration은 변경하지 않는다.
+- Skill Check 실제 turn 연결과 roll 감사 저장은 #37 범위다.

--- a/docs/architecture/game-state-story-memory.md
+++ b/docs/architecture/game-state-story-memory.md
@@ -43,7 +43,7 @@ UCTale의 결정적 게임 상태는 서버가 소유하고, LLM은 그 상태�
 
 랜덤은 `RandomSource` port로 분리합니다. production adapter는 `SecureRandom`을 사용하고 테스트는 fixed/sequence source로 결정적으로 검증합니다. 이 pure domain 판정은 Narrative provider를 호출하지 않습니다.
 
-#7 범위에서는 이 규칙을 실제 `/progress` turn pipeline, `GameResult`, NarrativeContext, DB roll ledger, frontend에 아직 연결하지 않습니다. 해당 통합은 #34/#36/#37/#38에서 수행합니다.
+#7 범위에서는 이 규칙을 실제 `/progress` turn pipeline, `GameResult`, NarrativeContext, DB roll ledger, frontend에 아직 연결하지 않습니다. Skill Check의 실제 통합은 #37/#38에서 수행합니다.
 
 ## Story Memory
 
@@ -69,7 +69,7 @@ Narrative Engine에는 전체 `game_log` 대신 위 계층과 현재 요청에 �
 
 `canonicalFacts > rollingSummary > recentTurns > LLM 생성 내용`
 
-LLM 응답 자체는 canonical state 변경 권한이 없습니다.
+LLM 응답 자체는 canonical rule state 변경 권한이 없습니다.
 
 ## 현재 행동 경계
 
@@ -77,28 +77,34 @@ LLM 응답 자체는 canonical state 변경 권한이 없습니다.
 
 - Narrative가 제안한 choice는 서버가 현재 turn에 속한 `AvailableAction`으로 발급합니다.
 - 다음 `/progress`에서 서버는 제출된 action이 현재 turn의 발급 action과 일치하는지 검증합니다.
-- 만료되거나 변조된 action은 Narrative provider 또는 향후 규칙 실행 전에 거절합니다.
+- 만료되거나 변조된 action은 Narrative provider 또는 규칙 실행 전에 거절합니다.
 - 기존 choice ID는 compatibility adapter 경로로 유지합니다.
 
-현재 `ActionType`은 향후 규칙 행동을 위한 경계이며 #7의 Skill Check가 실제 turn에 이미 연결됐다는 의미는 아닙니다.
+#34 이후 검증된 `PlayerAction`은 `ActionResolver`에서 `TurnResolution(GameResult, StateTransition)`으로 resolve됩니다. 현재 `ActionType`은 `NARRATIVE_CHOICE` 하나이므로 resolver registry는 두지 않습니다.
 
 ## 현재 턴 처리 흐름
 
 1. idempotency와 `(session_id, expected_turn)` reservation을 확인합니다.
 2. `expectedTurn`으로 현재 세션과 `GameState.turnNumber`를 검증합니다.
 3. 제출된 `PlayerAction`을 현재 서버 발급 `AvailableAction`과 대조합니다.
-4. rate limit과 provider budget guard를 확인합니다.
-5. 현재 단계에서는 `GameState`와 action 문맥으로 `NarrativeContext`를 구성합니다.
-6. Narrative Engine이 이야기와 다음 choice 후보를 생성합니다.
-7. 서버가 다음 `GameState`와 server-issued available actions를 구성합니다.
-8. canonical transaction에서 저장합니다.
+4. `ActionResolver`가 `GameResult`와 canonical next `StateTransition`을 pure domain operation으로 확정합니다.
+5. rate limit과 provider budget/attempt 경계를 확인합니다.
+6. 현재 #36 이전 compatibility 경로에서는 기존 state/action 문맥으로 `NarrativeContext`를 구성합니다.
+7. Narrative Engine이 이야기와 다음 choice 후보를 생성합니다.
+8. 검증된 story prose는 확정된 rule transition을 변경하지 않고 `StoryMemory` transcript에만 부착합니다.
+9. 서버가 다음 server-issued available actions를 구성합니다.
+10. `GameTurnCommit`이 `StateTransition`을 소유한 채 canonical transaction에서 저장됩니다.
 
-M3의 #34/#36/#37 이후에는 action을 서버 규칙으로 먼저 resolve하고 확정된 `GameResult`와 다음 state를 Narrative 호출 전에 만드는 구조로 강화합니다.
+세부 책임과 provider/transaction 경계는 [action-resolution.md](./action-resolution.md)를 기준으로 합니다.
+
+#36에서는 `NarrativeContext`를 확정된 `GameResult`와 state projection 기반으로 전환해 provider가 성공/실패·roll·state change를 더 직접적으로 서술하도록 강화합니다. #37은 그 위에 Skill Check vertical slice를 연결합니다.
 
 ## 기존 세션 호환성
 
 현재 snapshot schema는 v2입니다. #31 이전 raw `GameState`는 logical v0, typed stats 이전 envelope는 v1로 읽어 deterministic upgrader에서 v2로 승격합니다.
 
 legacy stats가 없으면 기본값 10을 적용하고 canonical legacy stat 값이 있으면 검증 후 보존합니다. read 자체는 DB를 다시 쓰지 않고 다음 정상 canonical commit에서 최신 snapshot 형식으로 저장합니다.
+
+`GameState.advance(playerAction, storyText)`는 legacy `GameLog` recovery에서 동일한 StoryMemory를 복원해야 하므로 compatibility method로 유지합니다. 새 turn pipeline은 규칙 단계의 `advanceTurn()`과 provider 이후의 `recordNarrativeTurn()`을 분리해 사용합니다.
 
 세부 내용은 [game-state-snapshot-evolution.md](./game-state-snapshot-evolution.md)를 기준으로 합니다.

--- a/src/main/java/com/uctale/uctale/application/game/GameTurnCommit.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameTurnCommit.java
@@ -2,13 +2,13 @@ package com.uctale.uctale.application.game;
 
 import com.uctale.uctale.application.image.ImageAssetService;
 import com.uctale.uctale.domain.game.GameState;
+import com.uctale.uctale.domain.game.StateTransition;
 
 public record GameTurnCommit(
         int expectedTurn,
         int inputChoiceId,
         String inputChoiceText,
-        GameState previousState,
-        GameState nextState,
+        StateTransition stateTransition,
         String storyText,
         String choicesJson,
         ImageAssetService.AssetReference imageAsset
@@ -23,13 +23,13 @@ public record GameTurnCommit(
         if (inputChoiceText == null || inputChoiceText.isBlank()) {
             throw new IllegalArgumentException("inputChoiceText는 비어 있을 수 없습니다.");
         }
-        if (previousState == null || nextState == null) {
-            throw new IllegalArgumentException("state transition은 null일 수 없습니다.");
+        if (stateTransition == null) {
+            throw new IllegalArgumentException("stateTransition은 null일 수 없습니다.");
         }
-        if (previousState.turnNumber() != expectedTurn) {
+        if (stateTransition.previousState().turnNumber() != expectedTurn) {
             throw new IllegalArgumentException("previousState turn과 expectedTurn이 일치해야 합니다.");
         }
-        if (nextState.turnNumber() != expectedTurn + 1) {
+        if (stateTransition.nextState().turnNumber() != expectedTurn + 1) {
             throw new IllegalArgumentException("nextState는 expectedTurn의 다음 turn이어야 합니다.");
         }
         if (storyText == null || storyText.isBlank()) {
@@ -40,11 +40,33 @@ public record GameTurnCommit(
         }
     }
 
+    public GameTurnCommit(
+            int expectedTurn,
+            int inputChoiceId,
+            String inputChoiceText,
+            GameState previousState,
+            GameState nextState,
+            String storyText,
+            String choicesJson,
+            ImageAssetService.AssetReference imageAsset
+    ) {
+        this(expectedTurn, inputChoiceId, inputChoiceText, new StateTransition(previousState, nextState),
+                storyText, choicesJson, imageAsset);
+    }
+
+    public GameState previousState() {
+        return stateTransition.previousState();
+    }
+
+    public GameState nextState() {
+        return stateTransition.nextState();
+    }
+
     public int previousStateVersion() {
-        return previousState.turnNumber();
+        return previousState().turnNumber();
     }
 
     public int nextStateVersion() {
-        return nextState.turnNumber();
+        return nextState().turnNumber();
     }
 }

--- a/src/main/java/com/uctale/uctale/application/game/TurnProcessor.java
+++ b/src/main/java/com/uctale/uctale/application/game/TurnProcessor.java
@@ -5,20 +5,10 @@ import com.uctale.uctale.domain.game.ActionResolver;
 import com.uctale.uctale.domain.game.GameState;
 import com.uctale.uctale.domain.game.StateTransition;
 import com.uctale.uctale.domain.game.TurnResolution;
-import org.springframework.stereotype.Component;
 
-@Component
-public class TurnProcessor {
+public final class TurnProcessor {
 
-    private final ActionResolver actionResolver;
-
-    public TurnProcessor() {
-        this(new ActionResolver());
-    }
-
-    TurnProcessor(ActionResolver actionResolver) {
-        this.actionResolver = actionResolver;
-    }
+    private final ActionResolver actionResolver = new ActionResolver();
 
     public TurnResolution resolve(GameState state, PlayerAction action) {
         return actionResolver.resolve(state, action);

--- a/src/main/java/com/uctale/uctale/application/game/TurnProcessor.java
+++ b/src/main/java/com/uctale/uctale/application/game/TurnProcessor.java
@@ -1,0 +1,33 @@
+package com.uctale.uctale.application.game;
+
+import com.uctale.uctale.domain.action.PlayerAction;
+import com.uctale.uctale.domain.game.ActionResolver;
+import com.uctale.uctale.domain.game.GameState;
+import com.uctale.uctale.domain.game.StateTransition;
+import com.uctale.uctale.domain.game.TurnResolution;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TurnProcessor {
+
+    private final ActionResolver actionResolver;
+
+    public TurnProcessor() {
+        this(new ActionResolver());
+    }
+
+    TurnProcessor(ActionResolver actionResolver) {
+        this.actionResolver = actionResolver;
+    }
+
+    public TurnResolution resolve(GameState state, PlayerAction action) {
+        return actionResolver.resolve(state, action);
+    }
+
+    public StateTransition attachNarrative(TurnResolution resolution, String storyText) {
+        if (resolution == null) {
+            throw new IllegalArgumentException("TurnResolution은 필수입니다.");
+        }
+        return resolution.attachNarrative(storyText);
+    }
+}

--- a/src/main/java/com/uctale/uctale/domain/game/ActionResolver.java
+++ b/src/main/java/com/uctale/uctale/domain/game/ActionResolver.java
@@ -1,0 +1,42 @@
+package com.uctale.uctale.domain.game;
+
+import com.uctale.uctale.domain.action.ActionType;
+import com.uctale.uctale.domain.action.PlayerAction;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public final class ActionResolver {
+
+    public TurnResolution resolve(GameState state, PlayerAction action) {
+        Objects.requireNonNull(state, "GameState는 필수입니다.");
+        Objects.requireNonNull(action, "PlayerAction은 필수입니다.");
+        if (action.sourceTurn() != state.turnNumber()) {
+            throw new IllegalArgumentException("PlayerAction source turn이 현재 GameState와 일치하지 않습니다.");
+        }
+        if (action.type() != ActionType.NARRATIVE_CHOICE) {
+            throw new IllegalArgumentException("지원하지 않는 action type입니다: " + action.type());
+        }
+        validateNarrativeChoice(action);
+
+        GameState nextState = state.advanceTurn();
+        GameResult result = new GameResult(
+                action,
+                GameResult.Outcome.RESOLVED,
+                List.of(),
+                List.of(GameResult.GameEvent.ACTION_RESOLVED),
+                List.of(new GameResult.TurnAdvanced(state.turnNumber(), nextState.turnNumber())),
+                List.of(action.displayText())
+        );
+        return new TurnResolution(result, new StateTransition(state, nextState));
+    }
+
+    private void validateNarrativeChoice(PlayerAction action) {
+        Map<String, String> arguments = action.arguments();
+        String choiceId = arguments.get("choiceId");
+        if (arguments.size() != 1 || !Integer.toString(action.legacyChoiceId()).equals(choiceId)) {
+            throw new IllegalArgumentException("NARRATIVE_CHOICE arguments가 action과 일치하지 않습니다.");
+        }
+    }
+}

--- a/src/main/java/com/uctale/uctale/domain/game/GameResult.java
+++ b/src/main/java/com/uctale/uctale/domain/game/GameResult.java
@@ -1,0 +1,42 @@
+package com.uctale.uctale.domain.game;
+
+import com.uctale.uctale.domain.action.PlayerAction;
+
+import java.util.List;
+import java.util.Objects;
+
+public record GameResult(
+        PlayerAction resolvedAction,
+        Outcome outcome,
+        List<CanonicalFact> canonicalFacts,
+        List<GameEvent> events,
+        List<StateChange> stateChanges,
+        List<String> narrativeCues
+) {
+    public GameResult {
+        Objects.requireNonNull(resolvedAction, "resolvedAction은 필수입니다.");
+        Objects.requireNonNull(outcome, "outcome은 필수입니다.");
+        canonicalFacts = canonicalFacts == null ? List.of() : List.copyOf(canonicalFacts);
+        events = events == null ? List.of() : List.copyOf(events);
+        stateChanges = stateChanges == null ? List.of() : List.copyOf(stateChanges);
+        narrativeCues = narrativeCues == null ? List.of() : List.copyOf(narrativeCues);
+    }
+
+    public enum Outcome {
+        RESOLVED
+    }
+
+    public enum GameEvent {
+        ACTION_RESOLVED
+    }
+
+    public sealed interface StateChange permits TurnAdvanced {}
+
+    public record TurnAdvanced(int previousTurn, int nextTurn) implements StateChange {
+        public TurnAdvanced {
+            if (previousTurn < 1 || nextTurn != previousTurn + 1) {
+                throw new IllegalArgumentException("turn state change가 올바르지 않습니다.");
+            }
+        }
+    }
+}

--- a/src/main/java/com/uctale/uctale/domain/game/GameState.java
+++ b/src/main/java/com/uctale/uctale/domain/game/GameState.java
@@ -34,9 +34,6 @@ public record GameState(
     }
 
     public GameState recordNarrativeTurn(String playerAction, String storyText) {
-        if (storyText == null || storyText.isBlank()) {
-            throw new IllegalArgumentException("storyText는 비어 있을 수 없습니다.");
-        }
         if (!storyMemory.recentTurns().isEmpty()
                 && storyMemory.recentTurns().getLast().turnNumber() >= turnNumber) {
             throw new IllegalStateException("현재 turn의 narrative가 이미 기록되어 있습니다.");

--- a/src/main/java/com/uctale/uctale/domain/game/GameState.java
+++ b/src/main/java/com/uctale/uctale/domain/game/GameState.java
@@ -24,13 +24,32 @@ public record GameState(
         );
     }
 
-    public GameState advance(String playerAction, String storyText) {
-        int nextTurn = turnNumber + 1;
+    public GameState advanceTurn() {
         return new GameState(
-                nextTurn,
+                turnNumber + 1,
                 playerCharacter,
                 worldState,
-                storyMemory.append(new GameTurn(nextTurn, playerAction, storyText))
+                storyMemory
         );
+    }
+
+    public GameState recordNarrativeTurn(String playerAction, String storyText) {
+        if (storyText == null || storyText.isBlank()) {
+            throw new IllegalArgumentException("storyText는 비어 있을 수 없습니다.");
+        }
+        if (!storyMemory.recentTurns().isEmpty()
+                && storyMemory.recentTurns().getLast().turnNumber() >= turnNumber) {
+            throw new IllegalStateException("현재 turn의 narrative가 이미 기록되어 있습니다.");
+        }
+        return new GameState(
+                turnNumber,
+                playerCharacter,
+                worldState,
+                storyMemory.append(new GameTurn(turnNumber, playerAction, storyText))
+        );
+    }
+
+    public GameState advance(String playerAction, String storyText) {
+        return advanceTurn().recordNarrativeTurn(playerAction, storyText);
     }
 }

--- a/src/main/java/com/uctale/uctale/domain/game/StateTransition.java
+++ b/src/main/java/com/uctale/uctale/domain/game/StateTransition.java
@@ -16,6 +16,9 @@ public record StateTransition(GameState previousState, GameState nextState) {
 
     public StateTransition attachNarrative(PlayerAction resolvedAction, String storyText) {
         Objects.requireNonNull(resolvedAction, "resolvedAction은 필수입니다.");
+        if (storyText == null || storyText.isBlank()) {
+            throw new IllegalArgumentException("storyText는 비어 있을 수 없습니다.");
+        }
         if (resolvedAction.sourceTurn() != previousState.turnNumber()) {
             throw new IllegalArgumentException("resolvedAction source turn이 transition과 일치하지 않습니다.");
         }

--- a/src/main/java/com/uctale/uctale/domain/game/StateTransition.java
+++ b/src/main/java/com/uctale/uctale/domain/game/StateTransition.java
@@ -1,0 +1,24 @@
+package com.uctale.uctale.domain.game;
+
+import com.uctale.uctale.domain.action.PlayerAction;
+
+import java.util.Objects;
+
+public record StateTransition(GameState previousState, GameState nextState) {
+
+    public StateTransition {
+        Objects.requireNonNull(previousState, "previousState는 필수입니다.");
+        Objects.requireNonNull(nextState, "nextState는 필수입니다.");
+        if (nextState.turnNumber() != previousState.turnNumber() + 1) {
+            throw new IllegalArgumentException("nextState는 previousState의 다음 turn이어야 합니다.");
+        }
+    }
+
+    public StateTransition attachNarrative(PlayerAction resolvedAction, String storyText) {
+        Objects.requireNonNull(resolvedAction, "resolvedAction은 필수입니다.");
+        if (resolvedAction.sourceTurn() != previousState.turnNumber()) {
+            throw new IllegalArgumentException("resolvedAction source turn이 transition과 일치하지 않습니다.");
+        }
+        return new StateTransition(previousState, nextState.recordNarrativeTurn(resolvedAction.displayText(), storyText));
+    }
+}

--- a/src/main/java/com/uctale/uctale/domain/game/TurnResolution.java
+++ b/src/main/java/com/uctale/uctale/domain/game/TurnResolution.java
@@ -1,0 +1,18 @@
+package com.uctale.uctale.domain.game;
+
+import java.util.Objects;
+
+public record TurnResolution(GameResult gameResult, StateTransition stateTransition) {
+
+    public TurnResolution {
+        Objects.requireNonNull(gameResult, "gameResult는 필수입니다.");
+        Objects.requireNonNull(stateTransition, "stateTransition은 필수입니다.");
+        if (gameResult.resolvedAction().sourceTurn() != stateTransition.previousState().turnNumber()) {
+            throw new IllegalArgumentException("resolved action과 state transition의 source turn이 일치하지 않습니다.");
+        }
+    }
+
+    public StateTransition attachNarrative(String storyText) {
+        return stateTransition.attachNarrative(gameResult.resolvedAction(), storyText);
+    }
+}

--- a/src/main/java/com/uctale/uctale/service/GameService.java
+++ b/src/main/java/com/uctale/uctale/service/GameService.java
@@ -10,13 +10,15 @@ import com.uctale.uctale.application.game.GameMutationRequestService;
 import com.uctale.uctale.application.game.GamePersistenceService;
 import com.uctale.uctale.application.game.GameTurnCommit;
 import com.uctale.uctale.application.game.ImagePromptComposer;
+import com.uctale.uctale.application.game.TurnProcessor;
 import com.uctale.uctale.application.image.ImageAssetService;
 import com.uctale.uctale.application.narrative.InvalidNarrativeResponseException;
 import com.uctale.uctale.application.narrative.NarrativeContext;
 import com.uctale.uctale.application.narrative.NarrativeGenerator;
 import com.uctale.uctale.application.narrative.NarrativeTurn;
 import com.uctale.uctale.domain.action.PlayerAction;
-import com.uctale.uctale.domain.game.GameState;
+import com.uctale.uctale.domain.game.StateTransition;
+import com.uctale.uctale.domain.game.TurnResolution;
 import com.uctale.uctale.dto.GameChoice;
 import com.uctale.uctale.dto.GameInitRequest;
 import com.uctale.uctale.dto.GameProgressRequest;
@@ -44,6 +46,7 @@ public class GameService {
     private final ImageAssetService imageAssetService;
     private final GamePersistenceService gamePersistenceService;
     private final ChoiceCodec choiceCodec;
+    private final TurnProcessor turnProcessor;
     private final ImagePromptComposer imagePromptComposer;
     private final CostRateLimiter costRateLimiter;
     private final ProviderCallTelemetry providerCallTelemetry;
@@ -113,7 +116,8 @@ public class GameService {
             );
 
             PlayerAction playerAction = choiceCodec.resolve(loadedTurn.choicesJson(), request);
-            String userChoiceText = playerAction.displayText();
+            TurnResolution resolution = turnProcessor.resolve(loadedTurn.gameState(), playerAction);
+            String userChoiceText = resolution.gameResult().resolvedAction().displayText();
             NarrativeContext narrativeContext = NarrativeContext.from(loadedTurn.gameState(), userChoiceText);
             costRateLimiter.check(CostOperation.NARRATIVE, providerContext);
             NarrativeTurn nextTurn = providerCallTelemetry.observe(
@@ -124,6 +128,7 @@ public class GameService {
                     () -> narrativeGenerator.createNextTurn(narrativeContext)
             );
             validateNarrativeTurn(nextTurn);
+            StateTransition committedTransition = turnProcessor.attachNarrative(resolution, nextTurn.storyText());
             List<GameChoice> choices = choiceCodec.issue(nextTurn.choices(), request.expectedTurn() + 1);
 
             ImageAssetService.AssetReference imageAsset = null;
@@ -138,10 +143,9 @@ public class GameService {
                 log.info("시각적 변화 없음 -> 이전 이미지 asset 재사용");
             }
 
-            GameState nextState = loadedTurn.gameState().advance(userChoiceText, nextTurn.storyText());
             GameTurnCommit commit = new GameTurnCommit(
-                    request.expectedTurn(), playerAction.legacyChoiceId(), userChoiceText, loadedTurn.gameState(), nextState,
-                    nextTurn.storyText(), choiceCodec.serialize(choices), imageAsset
+                    request.expectedTurn(), resolution.gameResult().resolvedAction().legacyChoiceId(), userChoiceText,
+                    committedTransition, nextTurn.storyText(), choiceCodec.serialize(choices), imageAsset
             );
 
             int savedTurn = gamePersistenceService.saveNextTurn(

--- a/src/main/java/com/uctale/uctale/service/GameService.java
+++ b/src/main/java/com/uctale/uctale/service/GameService.java
@@ -46,7 +46,7 @@ public class GameService {
     private final ImageAssetService imageAssetService;
     private final GamePersistenceService gamePersistenceService;
     private final ChoiceCodec choiceCodec;
-    private final TurnProcessor turnProcessor;
+    private final TurnProcessor turnProcessor = new TurnProcessor();
     private final ImagePromptComposer imagePromptComposer;
     private final CostRateLimiter costRateLimiter;
     private final ProviderCallTelemetry providerCallTelemetry;

--- a/src/test/java/com/uctale/uctale/application/game/TurnProcessorTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/TurnProcessorTest.java
@@ -1,0 +1,47 @@
+package com.uctale.uctale.application.game;
+
+import com.uctale.uctale.domain.action.ActionType;
+import com.uctale.uctale.domain.action.PlayerAction;
+import com.uctale.uctale.domain.game.GameResult;
+import com.uctale.uctale.domain.game.GameState;
+import com.uctale.uctale.domain.game.StateTransition;
+import com.uctale.uctale.domain.game.TurnResolution;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TurnProcessorTest {
+
+    private final TurnProcessor turnProcessor = new TurnProcessor();
+
+    @Test
+    @DisplayName("application processor는 resolution을 먼저 만들고 narrative를 같은 transition에 부착한다")
+    void resolveThenAttachNarrative_PreservesResolvedOutcome() {
+        GameState state = GameState.initial("세계관", "캐릭터", "오프닝");
+        PlayerAction action = new PlayerAction(
+                4,
+                "token",
+                ActionType.NARRATIVE_CHOICE,
+                1,
+                Map.of("choiceId", "4"),
+                "계단을 오른다"
+        );
+
+        TurnResolution resolution = turnProcessor.resolve(state, action);
+        GameResult resolvedResult = resolution.gameResult();
+        GameState canonicalNextState = resolution.stateTransition().nextState();
+
+        StateTransition committed = turnProcessor.attachNarrative(resolution, "계단 끝에서 낡은 문을 발견했다.");
+
+        assertThat(resolution.gameResult()).isSameAs(resolvedResult);
+        assertThat(resolvedResult.outcome()).isEqualTo(GameResult.Outcome.RESOLVED);
+        assertThat(committed.nextState().turnNumber()).isEqualTo(canonicalNextState.turnNumber());
+        assertThat(committed.nextState().playerCharacter()).isEqualTo(canonicalNextState.playerCharacter());
+        assertThat(committed.nextState().worldState()).isEqualTo(canonicalNextState.worldState());
+        assertThat(committed.nextState().storyMemory().recentTurns().getLast().storyText())
+                .isEqualTo("계단 끝에서 낡은 문을 발견했다.");
+    }
+}

--- a/src/test/java/com/uctale/uctale/domain/game/ActionResolverTest.java
+++ b/src/test/java/com/uctale/uctale/domain/game/ActionResolverTest.java
@@ -1,0 +1,101 @@
+package com.uctale.uctale.domain.game;
+
+import com.uctale.uctale.domain.action.ActionType;
+import com.uctale.uctale.domain.action.PlayerAction;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ActionResolverTest {
+
+    private final ActionResolver resolver = new ActionResolver();
+
+    @Test
+    @DisplayName("Narrative choice는 provider 없이 GameResult와 다음 canonical turn을 확정한다")
+    void resolveNarrativeChoice_ProducesDeterministicResolution() {
+        GameState state = GameState.initial("세계관", "캐릭터", "오프닝");
+        PlayerAction action = narrativeChoice(1, 7, "문을 잠근다");
+
+        TurnResolution resolution = resolver.resolve(state, action);
+
+        assertThat(resolution.gameResult().resolvedAction()).isEqualTo(action);
+        assertThat(resolution.gameResult().outcome()).isEqualTo(GameResult.Outcome.RESOLVED);
+        assertThat(resolution.gameResult().canonicalFacts()).isEmpty();
+        assertThat(resolution.gameResult().events()).containsExactly(GameResult.GameEvent.ACTION_RESOLVED);
+        assertThat(resolution.gameResult().stateChanges())
+                .containsExactly(new GameResult.TurnAdvanced(1, 2));
+        assertThat(resolution.gameResult().narrativeCues()).containsExactly("문을 잠근다");
+        assertThat(resolution.stateTransition().previousState()).isEqualTo(state);
+        assertThat(resolution.stateTransition().nextState().turnNumber()).isEqualTo(2);
+        assertThat(resolution.stateTransition().nextState().playerCharacter()).isEqualTo(state.playerCharacter());
+        assertThat(resolution.stateTransition().nextState().worldState()).isEqualTo(state.worldState());
+        assertThat(resolution.stateTransition().nextState().storyMemory()).isEqualTo(state.storyMemory());
+    }
+
+    @Test
+    @DisplayName("같은 state와 action은 동일한 TurnResolution을 만든다")
+    void resolveNarrativeChoice_IsDeterministic() {
+        GameState state = GameState.initial("세계관", "캐릭터", "오프닝");
+        PlayerAction action = narrativeChoice(1, 3, "기다린다");
+
+        assertThat(resolver.resolve(state, action)).isEqualTo(resolver.resolve(state, action));
+    }
+
+    @Test
+    @DisplayName("stale source turn은 규칙 실행 전에 거절한다")
+    void resolveNarrativeChoice_RejectsStaleSourceTurn() {
+        GameState state = GameState.initial("세계관", "캐릭터", "오프닝");
+        PlayerAction stale = narrativeChoice(2, 1, "간다");
+
+        assertThatThrownBy(() -> resolver.resolve(state, stale))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("source turn");
+    }
+
+    @Test
+    @DisplayName("choiceId arguments 변조는 resolver에서도 거절한다")
+    void resolveNarrativeChoice_RejectsTamperedArguments() {
+        GameState state = GameState.initial("세계관", "캐릭터", "오프닝");
+        PlayerAction tampered = new PlayerAction(
+                7, "token", ActionType.NARRATIVE_CHOICE, 1, Map.of("choiceId", "8"), "문을 잠근다"
+        );
+
+        assertThatThrownBy(() -> resolver.resolve(state, tampered))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("arguments");
+    }
+
+    @Test
+    @DisplayName("Narrative 부착은 확정된 canonical 상태를 바꾸지 않고 StoryMemory만 완성한다")
+    void attachNarrative_OnlyCompletesNarrativeMemory() {
+        GameState state = GameState.initial("세계관", "캐릭터", "오프닝");
+        TurnResolution resolution = resolver.resolve(state, narrativeChoice(1, 7, "문을 잠근다"));
+        GameState canonicalNextState = resolution.stateTransition().nextState();
+
+        StateTransition committed = resolution.attachNarrative("문은 굳게 잠겼다.");
+
+        assertThat(committed.previousState()).isEqualTo(state);
+        assertThat(committed.nextState().turnNumber()).isEqualTo(canonicalNextState.turnNumber());
+        assertThat(committed.nextState().playerCharacter()).isEqualTo(canonicalNextState.playerCharacter());
+        assertThat(committed.nextState().worldState()).isEqualTo(canonicalNextState.worldState());
+        assertThat(committed.nextState().storyMemory().canonicalFacts())
+                .isEqualTo(canonicalNextState.storyMemory().canonicalFacts());
+        assertThat(committed.nextState().storyMemory().recentTurns().getLast())
+                .isEqualTo(new GameTurn(2, "문을 잠근다", "문은 굳게 잠겼다."));
+    }
+
+    private PlayerAction narrativeChoice(int sourceTurn, int choiceId, String text) {
+        return new PlayerAction(
+                choiceId,
+                "token",
+                ActionType.NARRATIVE_CHOICE,
+                sourceTurn,
+                Map.of("choiceId", Integer.toString(choiceId)),
+                text
+        );
+    }
+}


### PR DESCRIPTION
## 왜 필요한가요?

현재 `/progress`는 서버가 `PlayerAction`을 검증한 뒤에도 Narrative provider 응답을 받은 다음에야 `GameState.advance(...)`로 다음 상태를 만들고 있었습니다. 첫 실제 규칙 행동이 들어오기 전에 action resolution과 canonical state transition을 provider/persistence에서 분리합니다.

- Closes #34

## 무엇이 바뀌나요?

- 게임 규칙·상태: pure domain `ActionResolver`, `TurnResolution`, 최소 `GameResult`, `StateTransition`을 추가했습니다. 현재 유일한 `NARRATIVE_CHOICE`는 provider 호출 전에 `ACTION_RESOLVED`와 `TurnAdvanced`를 확정합니다.
- Backend / API / DB: `GameService`가 `TurnProcessor`로 action을 먼저 resolve하고, `GameTurnCommit`이 raw previous/next state 대신 typed `StateTransition`을 소유하도록 변경했습니다. 기존 API/DB schema는 변경하지 않았습니다.
- AI narrative / prompt: #36 범위를 선행하지 않고 기존 `NarrativeContext` 계약을 유지합니다. provider prose는 확정된 규칙 결과를 재판정하지 않고 기존 `StoryMemory` transcript만 완성합니다.
- Image generation: 변경 없음.
- Frontend / UX: 변경 없음.
- Build / deploy / docs: `docs/architecture/action-resolution.md`를 추가하고 현재 turn pipeline 문서를 구현 상태에 맞게 갱신했습니다.

## 책임 경계

게임 기능이나 AI 변경이 있다면 아래를 명확히 적어 주세요.

- **서버가 결정하는 사실:** resolved action, `GameResult` outcome/events/state changes, canonical next turn/state transition
- **LLM이 서술하는 내용:** 이미 resolve된 행동 이후의 story prose와 다음 narrative choice 후보
- **LLM이 변경하면 안 되는 사실:** resolved action, turn advancement, canonical facts/events, player/world state와 이후 추가될 규칙 결과

## 어떻게 검증했나요?

- [x] PR 작성 전 변경 diff를 비판적으로 검토하고 타당한 지적을 반영했습니다.
- [x] `./gradlew clean test`
- [x] `./gradlew postgresIntegrationTest`
- [x] `./gradlew build`
- [x] `cd frontend && npm ci && npm test && npm run lint && npm run build`
- [x] 정상 흐름을 직접 확인했습니다.
- [x] 잘못된 입력/실패 흐름을 확인했습니다.
- [x] 중복 요청 또는 상태 전이가 관련되면 이를 검증했습니다.

GitHub Actions CI #176에서 backend test, PostgreSQL integration test, backend build와 frontend install/test/lint/build가 모두 성공했습니다. 추가한 자동 테스트는 정상 resolve, deterministic resolution, stale source turn, tampered arguments, narrative attachment의 canonical-state 불변, application `TurnProcessor` 경계를 검증합니다. 기존 `GameServiceTest`와 PostgreSQL M2 turn integrity matrix도 함께 통과해 정상 진행, retry/concurrency/stale-owner canonical commit 회귀가 없음을 확인했습니다.

비판적 자체 리뷰에서는 `GameState.recordNarrativeTurn()`의 신규 non-blank 검증이 legacy `GameState.advance()`/log recovery가 과거 허용하던 데이터 범위를 좁힐 수 있음을 발견했습니다. 새 pipeline의 story 검증을 `StateTransition.attachNarrative()`로 이동하고 legacy compatibility method의 기존 의미를 유지하도록 수정했습니다.

## 게임 상태·AI 안전성

해당하지 않는 항목은 이유를 적어 주세요.

- [x] 게임의 결정적 상태는 서버에서 검증·저장됩니다.
- [x] LLM 출력만으로 HP, 보상, 성공/실패 등 결정적 상태가 임의 변경되지 않습니다.
- [x] AI 요청에 필요한 최소 문맥만 전달합니다.
- [x] AI 응답 파싱 실패와 provider 오류가 게임 상태를 오염시키지 않습니다.
- [x] 기존 저장 데이터 또는 GameState 호환성 영향을 확인했습니다.

현재 `StoryMemory`는 기존 schema 호환을 위해 provider story prose를 snapshot 내부 transcript로 유지합니다. 이 transcript 부착은 turn/player/world/canonical facts/`GameResult`를 변경하지 않으며, `GameResult` 기반 `NarrativeContext` 전환은 #36에서 처리합니다.

## 보안·비용

- [x] API Key, 토큰, 비밀번호가 코드·로그·URL·클라이언트 응답에 노출되지 않습니다.
- [x] 외부 AI/Image 호출 횟수와 실패 시 동작을 검토했습니다.
- [x] 사용자 입력 길이와 외부 API 비용 증가 가능성을 검토했습니다.
- [x] CORS 또는 공개 endpoint 변경이 있다면 의도된 변경입니다.

provider 호출 횟수, reservation, provider-attempt accounting은 변경하지 않았습니다. Action resolution은 provider 호출 전에 수행되는 pure in-memory operation입니다. CORS/public endpoint 변경은 없습니다.

## API·DB·운영 영향

- [x] API 계약 변경 시 Frontend 호출부와 문서를 함께 갱신했습니다.
- [x] DB schema 변경 시 migration 전략을 포함했습니다.
- [x] 환경변수는 이름과 용도만 문서화했고 실제 Secret은 포함하지 않았습니다.
- [x] 배포 후 확인할 smoke test가 있습니다.

API/DB schema/env 변경은 없습니다. 따라서 frontend API 수정, Flyway migration, 신규 환경변수는 필요하지 않습니다. CI #176에서 production smoke script syntax validation도 성공했습니다.

## 화면 / 응답 예시

UI/API wire response 변경은 없습니다.
