### PR TITLE
refactor(ai): GameResult 기반 NarrativeContext 구성

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ UCTale은 사용자가 직접 입력한 세계관과 주인공 설정을 바탕�
 
 UCTale의 핵심 원칙은 **게임의 결정적 사실과 규칙은 서버가 소유하고, LLM은 확정된 결과를 서술한다**는 것입니다.
 
-현재 main은 공유 베타 운영 안전망과 신뢰 가능한 턴 저장 기반의 구현 범위를 갖추었고, M3에서 서버 주도 행동 판정과 Skill Check를 확장하는 단계입니다.
+현재 main은 공유 베타 운영 안전망과 신뢰 가능한 턴 저장 기반에 더해 `ActionResolver` / `GameResult` / provider-safe `NarrativeContext` 경계까지 갖추었고, M3에서 실제 Skill Check turn 통합을 확장하는 단계입니다.
 
-- 서버: 세션 소유권, 현재 턴, idempotency, reservation lease, canonical state, GameLog, provider attempt 상한을 검증합니다.
-- Narrative AI: 서버가 전달한 문맥을 바탕으로 이야기와 다음 선택지 표현을 생성합니다.
+- 서버: 세션 소유권, 현재 턴, idempotency, reservation lease, canonical state, `GameResult`, GameLog, provider attempt 상한을 검증합니다.
+- Narrative AI: 서버가 확정한 결과와 제한된 state/memory projection을 바탕으로 이야기와 다음 선택지 표현을 생성합니다.
 - Image AI: 브라우저의 임의 prompt가 아니라 서버가 발급한 image asset 계약만 실행합니다.
 - Frontend: 서버가 반환한 선택 행동과 상태를 표시하고, 규칙을 재계산하지 않습니다.
 
@@ -48,8 +48,9 @@ UCTale의 핵심 원칙은 **게임의 결정적 사실과 규칙은 서버가 �
 3. 서버가 첫 장면과 서버 발급 선택 행동을 생성합니다.
 4. 플레이어가 현재 턴에 유효한 행동을 선택합니다.
 5. 서버가 소유권, expected turn, idempotency, action payload를 검증합니다.
-6. 필요한 경우 Narrative provider를 호출하고 canonical state와 committed-turn log를 원자적으로 저장합니다.
-7. 시각적으로 표현할 장면이 있으면 서버가 발급한 image asset을 통해 삽화를 제공합니다.
+6. 서버가 action을 `GameResult` / canonical next state로 먼저 resolve하고 provider-safe `NarrativeContext`를 구성한 뒤 Narrative provider를 호출합니다.
+7. 검증된 story는 확정 rule state를 변경하지 않고 transcript를 완성하며 canonical state와 committed-turn log를 원자적으로 저장합니다.
+8. 시각적으로 표현할 장면이 있으면 서버가 발급한 image asset을 통해 삽화를 제공합니다.
 
 ---
 
@@ -64,15 +65,16 @@ UCTale의 핵심 원칙은 **게임의 결정적 사실과 규칙은 서버가 �
 - 운영 CORS origin은 명시적으로 관리하며 기본 production origin은 `https://uctale.vercel.app`입니다.
 - 공유 비밀번호 인증 실패는 별도의 IP 기반 rate limit으로 보호합니다.
 
-### 서버 발급 행동 경계
+### 서버 발급 행동과 Action Resolution 경계
 
-M3의 첫 선행 작업인 #33이 main에 반영되어 `AvailableAction`과 `PlayerAction` 경계가 존재합니다.
+#33의 `AvailableAction` / `PlayerAction`과 #34의 `ActionResolver` / `TurnResolution` / `GameResult` 경계가 main에 반영되어 있습니다.
 
 - 서버는 각 선택지에 action token/type/source turn/arguments를 발급할 수 있습니다.
 - `/progress`는 현재 turn의 서버 발급 action과 요청 payload가 일치하는지 검증합니다.
 - 변조되거나 만료된 action은 provider 호출 전에 거절됩니다.
+- 검증된 action은 provider 호출 전에 pure `ActionResolver`에서 `GameResult`와 canonical next `StateTransition`으로 확정됩니다.
+- `GameService`는 action type별 규칙 세부 구현을 알지 않고 orchestration만 담당합니다.
 - 기존 `choiceId` 기반 요청은 compatibility 경로로 유지합니다.
-- #7에서 typed stats와 pure Skill Check 규칙은 추가되지만, 실제 action/turn pipeline 연결은 #34/#37 후속 범위입니다.
 
 ### 타입 안전한 능력치와 Skill Check
 
@@ -88,11 +90,11 @@ M3의 첫 선행 작업인 #33이 main에 반영되어 `AvailableAction`과 `Pla
 - production random adapter는 `SecureRandom`, 테스트는 fixed/sequence `RandomSource`를 사용합니다.
 - Skill Check는 pure domain operation이며 Narrative provider를 호출하지 않습니다.
 
-아직 이 판정을 실제 `/progress`, `GameResult`, NarrativeContext, DB roll 저장, frontend에 연결하지 않습니다.
+아직 이 판정을 실제 `/progress` action/turn pipeline과 DB roll 저장, frontend에 연결하지 않습니다. 실제 통합은 #37/#38 범위입니다.
 
 ### GameState와 Story Memory
 
-서버는 세션별 canonical `GameState`를 JSON snapshot으로 저장하고 Narrative Engine에는 필요한 문맥만 전달합니다.
+서버는 세션별 canonical `GameState`를 JSON snapshot으로 저장하고 Narrative Engine에는 필요한 projection만 전달합니다.
 
 - `PlayerCharacter`는 typed `CharacterStats`를 소유합니다.
 - `canonicalFacts`: 서버가 유지하는 장기 사실
@@ -100,6 +102,20 @@ M3의 첫 선행 작업인 #33이 main에 반영되어 `AvailableAction`과 `Pla
 - `recentTurns`: 최근 진행 기록
 
 snapshot JSON은 schema/ruleset version을 가지며 legacy production snapshot을 deterministic upgrader로 읽을 수 있습니다. typed stats 도입으로 현재 snapshot schema는 v2이며, v0/v1 stats는 읽을 때 순수 변환합니다. read-time upgrade는 in-memory에서만 수행하고 다음 정상 canonical write에서 최신 형식으로 저장합니다.
+
+### GameResult 기반 NarrativeContext
+
+#36 이후 progress Narrative provider에는 raw `GameState + 사용자 행동 문자열` 조합 대신 서버가 확정한 결과를 provider-safe projection으로 전달합니다.
+
+- `NarrativeContext`는 canonical result ID, resolved action projection, outcome, canonical facts/events/state changes, canonical next-state projection, memory projection, narrative cues를 포함합니다.
+- 서버 발급 `PlayerAction.token`은 provider context에 포함하지 않습니다.
+- prompt는 확정 결과/state, narrative cues, 금지 canonical mutation을 분리합니다.
+- provider는 story prose와 다음 choice 후보를 만들 수 있지만 서버가 확정한 outcome/roll/state change를 재판정할 수 없습니다.
+- provider story는 canonical state를 직접 변경하지 않고 기존 StoryMemory transcript만 완성합니다.
+- `game_log`는 새 progress turn부터 `canonical_result_id`와 `generated_story_id`를 함께 기록합니다. legacy/opening 행은 두 값이 모두 비어 있을 수 있습니다.
+- provider failure 시 canonical turn은 진행하지 않으며 같은 idempotent 요청은 동일 canonical result link를 재구성합니다.
+
+Gemini structured output의 provider-specific schema validation과 bounded repair/retry 강화는 #35의 별도 범위입니다. Story Memory projection/token budget 전면 개선은 #46 범위입니다.
 
 ### 신뢰 가능한 턴 파이프라인
 
@@ -178,6 +194,8 @@ uctale/
 주요 설계 문서:
 
 - [개발 원칙](./CONTRIBUTING.md)
+- [Action Resolution](./docs/architecture/action-resolution.md)
+- [GameResult 기반 NarrativeContext](./docs/architecture/narrative-context.md)
 - [GameState / Story Memory](./docs/architecture/game-state-story-memory.md)
 - [Game mutation idempotency](./docs/architecture/game-mutation-idempotency.md)
 - [Turn reservation lease](./docs/architecture/game-turn-reservation.md)
@@ -305,6 +323,8 @@ GitHub Actions CI도 backend unit test → PostgreSQL integration test → backe
 
 진행 중.
 
-현재 #33 `AvailableAction` / `PlayerAction` 경계와 #7 typed `CharacterStats` / pure Skill Check 규칙 기반이 반영되었습니다. 다음 핵심 작업은 `ActionResolver` / `GameResult` 경계(#34), 확정 결과 기반 NarrativeContext(#36), 실제 Skill Check turn 통합(#37) 순으로 확장하는 것입니다.
+현재 #33 `AvailableAction` / `PlayerAction`, #34 `ActionResolver` / `GameResult`, #36 확정 결과 기반 `NarrativeContext`, #7 typed `CharacterStats` / pure Skill Check 규칙 기반이 반영되었습니다. 다음 핵심 game-rule vertical slice는 #37 실제 Skill Check turn 통합입니다.
+
+Gemini structured output 검증과 bounded recovery는 #35, Skill Check 결과/roll 감사 저장과 frontend 표현은 #37/#38의 완료 조건을 기준으로 진행합니다.
 
 아직 구현되지 않은 전투·인벤토리·퀘스트·NPC 관계 기능은 현재 기능처럼 문서에 표시하지 않습니다.

--- a/docs/architecture/action-resolution.md
+++ b/docs/architecture/action-resolution.md
@@ -4,7 +4,7 @@
 
 UCTale의 결정적 게임 규칙은 Narrative provider가 아니라 서버가 소유한다. `/progress`는 서버가 발급한 `PlayerAction`을 먼저 규칙으로 해석하고, 그 결과와 canonical state transition을 확정한 뒤 Narrative provider를 호출한다.
 
-현재 #34에서는 첫 규칙 경계만 도입한다. 실제 action type은 `NARRATIVE_CHOICE` 하나이므로 resolver registry나 범용 Rule Engine은 만들지 않는다.
+현재 실제 action type은 `NARRATIVE_CHOICE` 하나이므로 resolver registry나 범용 Rule Engine은 만들지 않는다.
 
 ## 책임
 
@@ -46,11 +46,12 @@ application 단계에서 `ActionResolver` 호출과 resolved transition의 narra
 2. 현재 session/turn/canonical state 로드
 3. 서버 발급 action 검증
 4. `TurnProcessor.resolve()`로 `GameResult`와 canonical `StateTransition` 확정
-5. rate limit / provider attempt accounting 확인
-6. Narrative provider 호출
-7. provider 응답 검증
-8. 확정된 transition에 narrative transcript를 부착하고 다음 server-issued actions 구성
-9. `GameTurnCommit`으로 원자적 persistence 호출
+5. `GameResult`와 canonical next state에서 provider-safe `NarrativeContext` 구성
+6. rate limit / provider attempt accounting 확인
+7. Narrative provider 호출
+8. provider 응답 검증
+9. 확정된 transition에 narrative transcript를 부착하고 다음 server-issued actions 구성
+10. `GameTurnCommit`으로 원자적 persistence 호출
 
 `GameService`는 action type별 규칙 공식이나 상태 변경 세부 구현을 알지 않는다.
 
@@ -63,6 +64,7 @@ application 단계에서 `ActionResolver` 호출과 resolved transition의 narra
 - previous/next state version
 - DB의 canonical previous state와 transition의 previous state equality
 - optimistic lock / unique turn constraint
+- canonical result / generated story linkage pair
 
 Persistence는 user choice text나 story prose를 파싱해 규칙 결과를 계산하지 않는다.
 
@@ -76,29 +78,32 @@ Persistence는 user choice text나 story prose를 파싱해 규칙 결과를 계
 - 규칙이 만드는 state changes
 - canonical next turn/state transition
 - narrative cues
+- provider-safe `NarrativeContext`
 
-외부 provider 실패나 다른 prose가 위 값을 다시 판정하지 않는다.
+외부 provider 실패나 다른 prose가 위 값을 다시 판정하지 않는다. `PlayerAction.token`은 provider context에서 제외한다.
 
 ### Provider 호출 뒤 허용되는 것
 
 현재 `StoryMemory.recentTurns`는 기존 장기 narrative 호환을 위해 provider가 만든 story prose를 transcript로 보관한다. 이 단계는 이미 확정된 turn number, player/world state, canonical facts, `GameResult`를 변경하지 않는다.
 
-즉 #34에서는 **규칙 state transition**과 **narrative-memory transcript 완성**을 타입으로 분리했다. `StoryMemory`가 현재 `GameState` snapshot 안에 함께 저장되는 기존 schema는 유지한다. 이를 제거하거나 `NarrativeContext`를 `GameResult` projection으로 전환하는 작업은 #36/#46의 별도 범위다.
+`game_log`에는 새 progress turn부터 `canonical_result_id`와 `generated_story_id`를 함께 기록해 서버 결과와 최종 채택 prose의 연결을 남긴다. legacy/opening 행은 두 값이 모두 비어 있을 수 있다.
+
+Story Memory projection 자체의 전면 재설계와 token budget 개선은 #46 범위다. 세부 NarrativeContext 계약은 [narrative-context.md](./narrative-context.md)를 기준으로 한다.
 
 ## Transaction boundary
 
 Narrative/Image provider 네트워크 호출 동안 DB transaction을 열지 않는다.
 
 - load/reservation 검증: 짧은 DB transaction
-- action resolution: pure in-memory domain operation
+- action resolution/context projection: pure in-memory operation
 - Narrative/Image provider: DB transaction 밖
 - final commit: `GameTurnCommit`을 단일 persistence transaction으로 저장
 
-provider 호출 성공 후 commit 전 crash window에서 외부 provider가 재호출될 수 있다는 기존 bounded at-least-once 정책과 stale-owner fencing은 변경하지 않는다.
+provider 호출 성공 후 commit 전 crash window에서 외부 provider가 재호출될 수 있다는 bounded at-least-once 정책과 stale-owner fencing은 변경하지 않는다. 동일 idempotent mutation retry는 동일 canonical result link를 재구성하고, 완료된 mutation은 provider 없이 committed turn을 replay한다.
 
 ## 호환성
 
 - API wire contract와 기존 `NARRATIVE_CHOICE` 선택 흐름은 변경하지 않는다.
 - `GameState.advance(playerAction, storyText)`는 legacy log recovery와 기존 테스트 호환을 위해 남기되, 내부적으로 `advanceTurn()` + `recordNarrativeTurn()`을 사용한다.
-- snapshot schema/DB migration은 변경하지 않는다.
+- 기존 `game_log` 행은 신규 narrative linkage 컬럼이 `NULL`이어도 읽을 수 있다.
 - Skill Check 실제 turn 연결과 roll 감사 저장은 #37 범위다.

--- a/docs/architecture/game-state-story-memory.md
+++ b/docs/architecture/game-state-story-memory.md
@@ -43,7 +43,7 @@ UCTale의 결정적 게임 상태는 서버가 소유하고, LLM은 그 상태�
 
 랜덤은 `RandomSource` port로 분리합니다. production adapter는 `SecureRandom`을 사용하고 테스트는 fixed/sequence source로 결정적으로 검증합니다. 이 pure domain 판정은 Narrative provider를 호출하지 않습니다.
 
-#7 범위에서는 이 규칙을 실제 `/progress` turn pipeline, `GameResult`, NarrativeContext, DB roll ledger, frontend에 아직 연결하지 않습니다. Skill Check의 실제 통합은 #37/#38에서 수행합니다.
+#7 범위에서는 이 규칙을 실제 `/progress` turn pipeline과 DB roll ledger에 아직 연결하지 않습니다. Skill Check의 실제 통합은 #37/#38에서 수행합니다.
 
 ## Story Memory
 
@@ -61,13 +61,13 @@ Story Memory는 세 계층으로 구분합니다.
    - 가장 최근 6턴
    - 플레이어 행동과 결과 본문 보관
 
-Narrative Engine에는 전체 `game_log` 대신 위 계층과 현재 요청에 필요한 행동 문맥만 전달합니다.
+Narrative Engine에는 전체 `game_log` 대신 read-only memory projection과 현재 요청에 필요한 canonical result/state 문맥만 전달합니다. Story Memory 자체의 canonical projection/token budget 재설계는 #46 범위입니다.
 
 ## 메모리 우선순위
 
 충돌 시 다음 순서를 따릅니다.
 
-`canonicalFacts > rollingSummary > recentTurns > LLM 생성 내용`
+`GameResult / canonical state > canonicalFacts > rollingSummary > recentTurns > LLM 생성 내용`
 
 LLM 응답 자체는 canonical rule state 변경 권한이 없습니다.
 
@@ -82,22 +82,24 @@ LLM 응답 자체는 canonical rule state 변경 권한이 없습니다.
 
 #34 이후 검증된 `PlayerAction`은 `ActionResolver`에서 `TurnResolution(GameResult, StateTransition)`으로 resolve됩니다. 현재 `ActionType`은 `NARRATIVE_CHOICE` 하나이므로 resolver registry는 두지 않습니다.
 
+#36 이후 Narrative provider에는 raw state/action 문자열 조합 대신 확정된 `GameResult`와 canonical next-state에서 만든 provider-safe `NarrativeContext`를 전달합니다. 서버 발급 `PlayerAction.token`은 provider context에 포함하지 않습니다.
+
 ## 현재 턴 처리 흐름
 
 1. idempotency와 `(session_id, expected_turn)` reservation을 확인합니다.
 2. `expectedTurn`으로 현재 세션과 `GameState.turnNumber`를 검증합니다.
 3. 제출된 `PlayerAction`을 현재 서버 발급 `AvailableAction`과 대조합니다.
 4. `ActionResolver`가 `GameResult`와 canonical next `StateTransition`을 pure domain operation으로 확정합니다.
-5. rate limit과 provider budget/attempt 경계를 확인합니다.
-6. 현재 #36 이전 compatibility 경로에서는 기존 state/action 문맥으로 `NarrativeContext`를 구성합니다.
-7. Narrative Engine이 이야기와 다음 choice 후보를 생성합니다.
+5. 확정 결과와 canonical next state에서 provider-safe `NarrativeContext`를 구성합니다.
+6. rate limit과 provider budget/attempt 경계를 확인합니다.
+7. Narrative Engine이 확정 결과를 재판정하지 않고 story와 다음 choice 후보를 생성합니다.
 8. 검증된 story prose는 확정된 rule transition을 변경하지 않고 `StoryMemory` transcript에만 부착합니다.
 9. 서버가 다음 server-issued available actions를 구성합니다.
-10. `GameTurnCommit`이 `StateTransition`을 소유한 채 canonical transaction에서 저장됩니다.
+10. `GameTurnCommit`이 `StateTransition`, `canonicalResultId`, `generatedStoryId`를 소유한 채 canonical transaction에서 저장됩니다.
 
-세부 책임과 provider/transaction 경계는 [action-resolution.md](./action-resolution.md)를 기준으로 합니다.
+세부 책임과 provider/transaction 경계는 [action-resolution.md](./action-resolution.md), prompt 계약과 retry/linkage 정책은 [narrative-context.md](./narrative-context.md)를 기준으로 합니다.
 
-#36에서는 `NarrativeContext`를 확정된 `GameResult`와 state projection 기반으로 전환해 provider가 성공/실패·roll·state change를 더 직접적으로 서술하도록 강화합니다. #37은 그 위에 Skill Check vertical slice를 연결합니다.
+#37은 이 경계 위에 실제 Skill Check vertical slice와 roll 결과를 연결합니다.
 
 ## 기존 세션 호환성
 
@@ -107,4 +109,6 @@ legacy stats가 없으면 기본값 10을 적용하고 canonical legacy stat 값
 
 `GameState.advance(playerAction, storyText)`는 legacy `GameLog` recovery에서 동일한 StoryMemory를 복원해야 하므로 compatibility method로 유지합니다. 새 turn pipeline은 규칙 단계의 `advanceTurn()`과 provider 이후의 `recordNarrativeTurn()`을 분리해 사용합니다.
 
-세부 내용은 [game-state-snapshot-evolution.md](./game-state-snapshot-evolution.md)를 기준으로 합니다.
+#36의 `game_log.canonical_result_id`와 `generated_story_id`는 legacy/opening 행에서 둘 다 `NULL`일 수 있도록 migration했습니다. 새 production progress commit은 두 linkage ID를 함께 기록하며 한쪽만 존재하는 상태는 DB CHECK constraint와 `GameTurnCommit`에서 거부합니다.
+
+세부 snapshot 내용은 [game-state-snapshot-evolution.md](./game-state-snapshot-evolution.md)를 기준으로 합니다.

--- a/docs/architecture/narrative-context.md
+++ b/docs/architecture/narrative-context.md
@@ -1,0 +1,77 @@
+# GameResult 기반 NarrativeContext
+
+## 목적
+
+Narrative provider는 게임 규칙을 판정하지 않는다. 서버가 `ActionResolver`에서 확정한 `GameResult`와 canonical next state를 provider-safe projection으로 전달하고, provider는 그 결과를 story prose와 다음 choice 후보로 표현한다.
+
+## Context 계약
+
+`NarrativeContext.from(canonicalResultId, TurnResolution)`은 provider 호출 전에 다음을 고정한다.
+
+- `canonicalResultId`: 같은 idempotent mutation request에서 재구성해도 동일한 결과 연결 ID
+- resolved action projection: legacy choice ID, action type, source turn, 검증된 arguments, display text
+- `GameResult.outcome`
+- 이번 결과가 만든 canonical facts/events/state changes
+- canonical next-state projection: turn, world premise/flags, player description/stats
+- memory projection: 기존 canonical facts, rolling summary, recent turns
+- narrative cues
+- provider가 수행하면 안 되는 canonical mutation 규칙
+
+`PlayerAction.token`은 서버 발급 capability 정보이므로 Narrative provider projection에 포함하지 않는다.
+
+Story Memory 전면 재설계나 token budget 개선은 #46 범위이며, 이번 경계에서는 기존 memory 구조를 read-only projection으로 유지한다.
+
+## Prompt 책임 분리
+
+Gemini progress prompt는 다음 섹션을 명시적으로 분리한다.
+
+1. 확정 게임 결과 ID
+2. resolved action
+3. 확정 게임 결과
+4. 확정 상태 projection
+5. canonical facts / rolling summary / recent turns
+6. narrative cues
+7. 금지 canonical mutation
+
+provider는 다음을 할 수 있다.
+
+- 확정 결과가 드러나는 story prose 생성
+- 다음 선택지 후보 제안
+- canonical state가 아닌 선택적 visual assets 묘사
+
+provider는 다음을 할 수 없다.
+
+- 서버가 확정한 outcome 재판정
+- 서버가 제공하지 않은 roll/성공/실패 창작
+- state changes에 없는 HP, 능력치, 아이템, 레벨, 위치, 생사 변경 확정
+- state projection/canonical facts 변경
+
+현재 adapter의 provider-specific structured output 강화와 bounded repair/retry는 #35 범위로 남긴다.
+
+## GameLog narrative linkage
+
+`game_log`에는 새 progress turn부터 다음 nullable 컬럼을 함께 기록한다.
+
+- `canonical_result_id`
+- `generated_story_id`
+
+legacy/opening row는 두 값이 모두 `NULL`일 수 있다. DB CHECK constraint와 `GameTurnCommit` 불변식은 두 값 중 하나만 존재하는 부분 linkage를 거부한다.
+
+`canonicalResultId`는 `(session, next turn, mutation request)`로 결정적으로 구성한다. 동일 idempotency key/payload가 provider 실패 후 재시도되면 동일 mutation request ID를 사용하므로 동일 canonical result link를 재구성한다.
+
+`generatedStoryId`는 검증된 provider story마다 새로 발급하며, 최종 canonical commit에 채택된 story ID만 GameLog에 기록한다.
+
+## Provider 실패와 retry 정책
+
+provider 호출 전에 `TurnResolution`과 canonical next state는 이미 결정되어 있지만 DB에는 아직 commit하지 않는다.
+
+- provider 실패: mutation을 failed 처리하고 reservation lease를 만료시키며 GameLog/GameState turn은 진행하지 않는다.
+- 같은 idempotent 요청 재시도: unchanged canonical previous state와 같은 action으로 pure resolution을 다시 계산하고 동일 `canonicalResultId`를 재사용한다.
+- provider 성공 후 commit 실패/stale owner: stale owner는 canonical commit할 수 없다. 이후 재시도에서 provider가 다시 호출될 수 있다는 bounded at-least-once 정책은 유지한다.
+- 완료된 mutation retry: 기존 committed turn을 replay하고 provider를 재호출하지 않는다.
+
+외부 provider strict exactly-once를 보장하지 않는다. canonical DB commit exactly-once, stale-owner fencing, bounded provider attempts 정책을 유지한다.
+
+## Persistence 경계
+
+Persistence는 `GameTurnCommit`이 전달한 typed `StateTransition`과 narrative linkage를 저장할 뿐 user text/story prose를 파싱해 규칙을 계산하지 않는다. Narrative prose는 `StoryMemory` transcript를 완성하지만 이미 확정된 rule state/outcome/state changes를 변경하지 않는다.

--- a/src/main/java/com/uctale/uctale/application/game/GamePersistenceService.java
+++ b/src/main/java/com/uctale/uctale/application/game/GamePersistenceService.java
@@ -120,8 +120,8 @@ public class GamePersistenceService {
                     : persistImageAsset(session, commit.nextStateVersion(), commit.imageAsset());
             gameSessionRepository.save(session);
             gameLogRepository.save(GameLog.committedTurn(session, commit.nextStateVersion(), commit.inputChoiceId(),
-                    commit.inputChoiceText(), commit.previousStateVersion(), commit.nextStateVersion(), commit.storyText(),
-                    commit.choicesJson(), imageUrl));
+                    commit.inputChoiceText(), commit.previousStateVersion(), commit.nextStateVersion(),
+                    commit.canonicalResultId(), commit.generatedStoryId(), commit.storyText(), commit.choicesJson(), imageUrl));
             GameStateSnapshot snapshot = gameStateSnapshotRepository.findById(sessionId)
                     .orElseGet(() -> new GameStateSnapshot(session, gameStateCodec.serialize(commit.previousState())));
             snapshot.updateStateJson(gameStateCodec.serialize(commit.nextState()));

--- a/src/main/java/com/uctale/uctale/application/game/GameTurnCommit.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameTurnCommit.java
@@ -11,8 +11,12 @@ public record GameTurnCommit(
         StateTransition stateTransition,
         String storyText,
         String choicesJson,
+        String canonicalResultId,
+        String generatedStoryId,
         ImageAssetService.AssetReference imageAsset
 ) {
+    private static final int MAX_LINK_ID_LENGTH = 128;
+
     public GameTurnCommit {
         if (expectedTurn < 1) {
             throw new IllegalArgumentException("expectedTurn은 1 이상이어야 합니다.");
@@ -38,6 +42,24 @@ public record GameTurnCommit(
         if (choicesJson == null) {
             throw new IllegalArgumentException("choicesJson은 null일 수 없습니다.");
         }
+        if ((canonicalResultId == null) != (generatedStoryId == null)) {
+            throw new IllegalArgumentException("canonicalResultId와 generatedStoryId는 함께 기록해야 합니다.");
+        }
+        validateLinkId("canonicalResultId", canonicalResultId);
+        validateLinkId("generatedStoryId", generatedStoryId);
+    }
+
+    public GameTurnCommit(
+            int expectedTurn,
+            int inputChoiceId,
+            String inputChoiceText,
+            StateTransition stateTransition,
+            String storyText,
+            String choicesJson,
+            ImageAssetService.AssetReference imageAsset
+    ) {
+        this(expectedTurn, inputChoiceId, inputChoiceText, stateTransition, storyText, choicesJson,
+                null, null, imageAsset);
     }
 
     public GameTurnCommit(
@@ -51,7 +73,7 @@ public record GameTurnCommit(
             ImageAssetService.AssetReference imageAsset
     ) {
         this(expectedTurn, inputChoiceId, inputChoiceText, new StateTransition(previousState, nextState),
-                storyText, choicesJson, imageAsset);
+                storyText, choicesJson, null, null, imageAsset);
     }
 
     public GameState previousState() {
@@ -68,5 +90,16 @@ public record GameTurnCommit(
 
     public int nextStateVersion() {
         return nextState().turnNumber();
+    }
+
+    public boolean hasNarrativeLink() {
+        return canonicalResultId != null;
+    }
+
+    private static void validateLinkId(String name, String value) {
+        if (value == null) return;
+        if (value.isBlank() || value.length() > MAX_LINK_ID_LENGTH) {
+            throw new IllegalArgumentException(name + "가 올바르지 않습니다.");
+        }
     }
 }

--- a/src/main/java/com/uctale/uctale/application/narrative/NarrativeContext.java
+++ b/src/main/java/com/uctale/uctale/application/narrative/NarrativeContext.java
@@ -67,6 +67,10 @@ public record NarrativeContext(
         );
     }
 
+    public String playerAction() {
+        return resolvedAction.displayText();
+    }
+
     public record ResolvedAction(
             int legacyChoiceId,
             ActionType type,

--- a/src/main/java/com/uctale/uctale/application/narrative/NarrativeContext.java
+++ b/src/main/java/com/uctale/uctale/application/narrative/NarrativeContext.java
@@ -1,34 +1,142 @@
 package com.uctale.uctale.application.narrative;
 
+import com.uctale.uctale.domain.action.ActionType;
+import com.uctale.uctale.domain.action.PlayerAction;
 import com.uctale.uctale.domain.game.CanonicalFact;
+import com.uctale.uctale.domain.game.CharacterStats;
+import com.uctale.uctale.domain.game.GameResult;
 import com.uctale.uctale.domain.game.GameState;
 import com.uctale.uctale.domain.game.GameTurn;
+import com.uctale.uctale.domain.game.TurnResolution;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 public record NarrativeContext(
-        String worldPremise,
-        String playerDescription,
-        List<CanonicalFact> canonicalFacts,
-        String rollingSummary,
-        List<GameTurn> recentTurns,
-        String playerAction
+        String canonicalResultId,
+        ResolvedAction resolvedAction,
+        GameResult.Outcome outcome,
+        List<CanonicalFact> resultCanonicalFacts,
+        List<GameResult.GameEvent> events,
+        List<GameResult.StateChange> stateChanges,
+        StateProjection state,
+        MemoryProjection memory,
+        List<String> narrativeCues,
+        List<String> forbiddenCanonicalMutations
 ) {
+    public static final List<String> CANONICAL_MUTATION_GUARDRAILS = List.of(
+            "GameResult.outcome과 서버가 확정한 성공/실패를 변경하거나 다시 판정하지 않는다.",
+            "GameResult.stateChanges에 없는 HP, 능력치, 아이템, 레벨, 위치, 생사 변화를 확정하지 않는다.",
+            "서버가 제공하지 않은 roll이나 판정 결과를 새로 만들지 않는다.",
+            "state projection과 canonical facts를 수정하거나 충돌하는 사실을 확정하지 않는다."
+    );
+
     public NarrativeContext {
-        canonicalFacts = canonicalFacts == null ? List.of() : List.copyOf(canonicalFacts);
-        rollingSummary = rollingSummary == null ? "" : rollingSummary;
-        recentTurns = recentTurns == null ? List.of() : List.copyOf(recentTurns);
-        playerAction = playerAction == null ? "" : playerAction;
+        if (canonicalResultId == null || canonicalResultId.isBlank()) {
+            throw new IllegalArgumentException("canonicalResultId는 필수입니다.");
+        }
+        Objects.requireNonNull(resolvedAction, "resolvedAction은 필수입니다.");
+        Objects.requireNonNull(outcome, "outcome은 필수입니다.");
+        resultCanonicalFacts = resultCanonicalFacts == null ? List.of() : List.copyOf(resultCanonicalFacts);
+        events = events == null ? List.of() : List.copyOf(events);
+        stateChanges = stateChanges == null ? List.of() : List.copyOf(stateChanges);
+        Objects.requireNonNull(state, "state projection은 필수입니다.");
+        Objects.requireNonNull(memory, "memory projection은 필수입니다.");
+        narrativeCues = narrativeCues == null ? List.of() : List.copyOf(narrativeCues);
+        forbiddenCanonicalMutations = forbiddenCanonicalMutations == null
+                ? CANONICAL_MUTATION_GUARDRAILS
+                : List.copyOf(forbiddenCanonicalMutations);
     }
 
-    public static NarrativeContext from(GameState state, String playerAction) {
+    public static NarrativeContext from(String canonicalResultId, TurnResolution resolution) {
+        Objects.requireNonNull(resolution, "TurnResolution은 필수입니다.");
+        GameResult result = resolution.gameResult();
+        GameState canonicalNextState = resolution.stateTransition().nextState();
         return new NarrativeContext(
-                state.worldState().premise(),
-                state.playerCharacter().description(),
-                state.storyMemory().canonicalFacts(),
-                state.storyMemory().rollingSummary(),
-                state.storyMemory().recentTurns(),
-                playerAction
+                canonicalResultId,
+                ResolvedAction.from(result.resolvedAction()),
+                result.outcome(),
+                result.canonicalFacts(),
+                result.events(),
+                result.stateChanges(),
+                StateProjection.from(canonicalNextState),
+                MemoryProjection.from(canonicalNextState),
+                result.narrativeCues(),
+                CANONICAL_MUTATION_GUARDRAILS
         );
+    }
+
+    public record ResolvedAction(
+            int legacyChoiceId,
+            ActionType type,
+            int sourceTurn,
+            Map<String, String> arguments,
+            String displayText
+    ) {
+        public ResolvedAction {
+            if (legacyChoiceId < 1 || sourceTurn < 1) {
+                throw new IllegalArgumentException("resolved action 식별자가 올바르지 않습니다.");
+            }
+            Objects.requireNonNull(type, "action type은 필수입니다.");
+            arguments = arguments == null ? Map.of() : Map.copyOf(arguments);
+            displayText = displayText == null ? "" : displayText;
+        }
+
+        private static ResolvedAction from(PlayerAction action) {
+            return new ResolvedAction(
+                    action.legacyChoiceId(),
+                    action.type(),
+                    action.sourceTurn(),
+                    action.arguments(),
+                    action.displayText()
+            );
+        }
+    }
+
+    public record StateProjection(
+            int turnNumber,
+            String worldPremise,
+            String playerDescription,
+            CharacterStats playerStats,
+            Map<String, String> worldFlags
+    ) {
+        public StateProjection {
+            if (turnNumber < 1) throw new IllegalArgumentException("turnNumber는 1 이상이어야 합니다.");
+            worldPremise = worldPremise == null ? "" : worldPremise;
+            playerDescription = playerDescription == null ? "" : playerDescription;
+            Objects.requireNonNull(playerStats, "playerStats는 필수입니다.");
+            worldFlags = worldFlags == null ? Map.of() : Map.copyOf(worldFlags);
+        }
+
+        private static StateProjection from(GameState state) {
+            return new StateProjection(
+                    state.turnNumber(),
+                    state.worldState().premise(),
+                    state.playerCharacter().description(),
+                    state.playerCharacter().stats(),
+                    state.worldState().flags()
+            );
+        }
+    }
+
+    public record MemoryProjection(
+            List<CanonicalFact> canonicalFacts,
+            String rollingSummary,
+            List<GameTurn> recentTurns
+    ) {
+        public MemoryProjection {
+            canonicalFacts = canonicalFacts == null ? List.of() : List.copyOf(canonicalFacts);
+            rollingSummary = rollingSummary == null ? "" : rollingSummary;
+            recentTurns = recentTurns == null ? List.of() : List.copyOf(recentTurns);
+        }
+
+        private static MemoryProjection from(GameState state) {
+            return new MemoryProjection(
+                    state.storyMemory().canonicalFacts(),
+                    state.storyMemory().rollingSummary(),
+                    state.storyMemory().recentTurns()
+            );
+        }
     }
 }

--- a/src/main/java/com/uctale/uctale/domain/GameLog.java
+++ b/src/main/java/com/uctale/uctale/domain/GameLog.java
@@ -53,6 +53,12 @@ public class GameLog {
     @Column(name = "state_version", nullable = false)
     private int stateVersion;
 
+    @Column(name = "canonical_result_id", length = 128)
+    private String canonicalResultId;
+
+    @Column(name = "generated_story_id", length = 128)
+    private String generatedStoryId;
+
     @Column(columnDefinition = "TEXT")
     private String storyText;
 
@@ -79,6 +85,8 @@ public class GameLog {
                 null,
                 0,
                 1,
+                null,
+                null,
                 storyText,
                 choicesJson,
                 imageUrl
@@ -96,6 +104,25 @@ public class GameLog {
             String choicesJson,
             String imageUrl
     ) {
+        return committedTurn(
+                gameSession, turnNumber, inputChoiceId, inputChoiceText, previousStateVersion, stateVersion,
+                null, null, storyText, choicesJson, imageUrl
+        );
+    }
+
+    public static GameLog committedTurn(
+            GameSession gameSession,
+            int turnNumber,
+            int inputChoiceId,
+            String inputChoiceText,
+            int previousStateVersion,
+            int stateVersion,
+            String canonicalResultId,
+            String generatedStoryId,
+            String storyText,
+            String choicesJson,
+            String imageUrl
+    ) {
         return new GameLog(
                 gameSession,
                 turnNumber,
@@ -103,6 +130,8 @@ public class GameLog {
                 inputChoiceText,
                 previousStateVersion,
                 stateVersion,
+                canonicalResultId,
+                generatedStoryId,
                 storyText,
                 choicesJson,
                 imageUrl
@@ -116,6 +145,8 @@ public class GameLog {
             String inputChoiceText,
             int previousStateVersion,
             int stateVersion,
+            String canonicalResultId,
+            String generatedStoryId,
             String storyText,
             String choicesJson,
             String imageUrl
@@ -126,6 +157,8 @@ public class GameLog {
         this.inputChoiceText = inputChoiceText;
         this.previousStateVersion = previousStateVersion;
         this.stateVersion = stateVersion;
+        this.canonicalResultId = canonicalResultId;
+        this.generatedStoryId = generatedStoryId;
         this.storyText = storyText;
         this.choicesJson = choicesJson;
         this.imageUrl = imageUrl;

--- a/src/main/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapter.java
+++ b/src/main/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapter.java
@@ -23,13 +23,14 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
     private static final String GEMINI_API_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent";
     private static final String SYSTEM_INSTRUCTION = """
             당신은 UCTale의 Narrative Engine입니다.
-            게임의 결정적 상태와 사실은 서버가 소유하며, 당신은 전달받은 상태를 바탕으로 서사를 표현합니다.
+            게임의 결정적 상태와 사실은 서버가 소유하며, 당신은 전달받은 확정 결과를 서사로 표현합니다.
 
             [핵심 원칙]
-            1. **캐논 우선:** [캐논 사실]과 [현재 게임 상태]에 반하는 내용을 진실로 확정하지 마십시오.
-            2. **상태 비소유:** 능력치, 아이템, 생사, 위치 등 결정적 게임 상태를 임의로 변경했다고 확정하지 마십시오.
-            3. **개연성:** 사건은 전달받은 과거 문맥과 사용자 행동에 맞는 인과관계를 가져야 합니다.
-            4. **메모리 우선순위:** 캐논 사실 > 누적 요약 > 최근 턴 순으로 충돌을 해결하십시오.
+            1. **확정 결과 우선:** [확정 게임 결과], [확정 상태 projection], [캐논 사실]에 반하는 내용을 진실로 확정하지 마십시오.
+            2. **상태 비소유:** 능력치, 아이템, 생사, 위치 등 결정적 게임 상태를 임의로 변경하거나 다시 판정하지 마십시오.
+            3. **개연성:** 사건은 전달받은 결과, 과거 문맥, resolved action에 맞는 인과관계를 가져야 합니다.
+            4. **메모리 우선순위:** 확정 게임 결과/상태 > 캐논 사실 > 누적 요약 > 최근 턴 순으로 충돌을 해결하십시오.
+            5. **출력 책임:** story_text와 다음 choices를 제안하고, 선택적으로 visual_assets를 묘사하십시오. canonical state 변경값을 출력 계약으로 만들지 마십시오.
 
             [시각적 요소(visual_assets) 작성 규칙 - 매우 중요]
             1. **이미지 생성 판단:** 직전 턴과 비교하여 **시각적으로 명확한 변화**가 있을 때만 작성하세요.
@@ -89,39 +90,63 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
     @Override
     public NarrativeTurn createNextTurn(NarrativeContext context) {
         try {
-            String prompt = String.format("""
-                    [현재 게임 상태]
-                    세계관: %s
-                    플레이어: %s
-
-                    [캐논 사실]
-                    %s
-
-                    [누적 요약]
-                    %s
-
-                    [최근 턴]
-                    %s
-
-                    [이번 사용자 행동]
-                    %s
-
-                    행동의 결과와 다음 상황을 서술하세요.
-                    서버가 전달하지 않은 결정적 상태 변화는 임의로 확정하지 마세요.
-                    시각적 변화가 없다면 visual_assets를 비워두세요.
-                    """,
-                    context.worldPremise(),
-                    context.playerDescription(),
-                    objectMapper.writeValueAsString(context.canonicalFacts()),
-                    context.rollingSummary().isBlank() ? "(없음)" : context.rollingSummary(),
-                    objectMapper.writeValueAsString(context.recentTurns()),
-                    context.playerAction()
-            );
-            return generate(prompt, "Gemini API Progress Error");
+            return generate(buildProgressPrompt(context), "Gemini API Progress Error");
         } catch (Exception e) {
             log.error("Gemini 다음 턴 생성 실패: {}", e.getClass().getSimpleName());
             throw new RuntimeException("AI 서버 연결 실패 (진행 중): 잠시 후 다시 시도해주세요.", e);
         }
+    }
+
+    String buildProgressPrompt(NarrativeContext context) throws JacksonException {
+        return String.format("""
+                [확정 게임 결과 ID]
+                %s
+
+                [resolved action]
+                %s
+
+                [확정 게임 결과]
+                outcome: %s
+                canonical facts: %s
+                events: %s
+                state changes: %s
+
+                [확정 상태 projection]
+                %s
+
+                [캐논 사실]
+                %s
+
+                [누적 요약]
+                %s
+
+                [최근 턴]
+                %s
+
+                [narrative cues]
+                %s
+
+                [금지 canonical mutation]
+                %s
+
+                위 확정 결과를 변경하거나 재판정하지 말고 그 결과가 드러나는 장면을 서술하세요.
+                서버가 확정하지 않은 roll, 성공/실패, HP/능력치/아이템/레벨/위치/생사 변화를 새 사실로 만들지 마세요.
+                응답은 story 표현, 다음 choices 제안, 선택적 visual_assets만 포함합니다.
+                시각적 변화가 없다면 visual_assets를 비워두세요.
+                """,
+                context.canonicalResultId(),
+                objectMapper.writeValueAsString(context.resolvedAction()),
+                context.outcome(),
+                objectMapper.writeValueAsString(context.resultCanonicalFacts()),
+                objectMapper.writeValueAsString(context.events()),
+                objectMapper.writeValueAsString(context.stateChanges()),
+                objectMapper.writeValueAsString(context.state()),
+                objectMapper.writeValueAsString(context.memory().canonicalFacts()),
+                context.memory().rollingSummary().isBlank() ? "(없음)" : context.memory().rollingSummary(),
+                objectMapper.writeValueAsString(context.memory().recentTurns()),
+                objectMapper.writeValueAsString(context.narrativeCues()),
+                objectMapper.writeValueAsString(context.forbiddenCanonicalMutations())
+        );
     }
 
     private NarrativeTurn generate(String prompt, String errorContext) throws JacksonException {

--- a/src/main/java/com/uctale/uctale/service/GameService.java
+++ b/src/main/java/com/uctale/uctale/service/GameService.java
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Service;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -118,7 +119,9 @@ public class GameService {
             PlayerAction playerAction = choiceCodec.resolve(loadedTurn.choicesJson(), request);
             TurnResolution resolution = turnProcessor.resolve(loadedTurn.gameState(), playerAction);
             String userChoiceText = resolution.gameResult().resolvedAction().displayText();
-            NarrativeContext narrativeContext = NarrativeContext.from(loadedTurn.gameState(), userChoiceText);
+            String canonicalResultId = canonicalResultId(mutation.requestId(), loadedTurn.sessionId(),
+                    resolution.stateTransition().nextState().turnNumber());
+            NarrativeContext narrativeContext = NarrativeContext.from(canonicalResultId, resolution);
             costRateLimiter.check(CostOperation.NARRATIVE, providerContext);
             NarrativeTurn nextTurn = providerCallTelemetry.observe(
                     "gemini", "progress", providerContext, 0,
@@ -128,6 +131,7 @@ public class GameService {
                     () -> narrativeGenerator.createNextTurn(narrativeContext)
             );
             validateNarrativeTurn(nextTurn);
+            String generatedStoryId = "story:" + UUID.randomUUID();
             StateTransition committedTransition = turnProcessor.attachNarrative(resolution, nextTurn.storyText());
             List<GameChoice> choices = choiceCodec.issue(nextTurn.choices(), request.expectedTurn() + 1);
 
@@ -145,7 +149,8 @@ public class GameService {
 
             GameTurnCommit commit = new GameTurnCommit(
                     request.expectedTurn(), resolution.gameResult().resolvedAction().legacyChoiceId(), userChoiceText,
-                    committedTransition, nextTurn.storyText(), choiceCodec.serialize(choices), imageAsset
+                    committedTransition, nextTurn.storyText(), choiceCodec.serialize(choices),
+                    canonicalResultId, generatedStoryId, imageAsset
             );
 
             int savedTurn = gamePersistenceService.saveNextTurn(
@@ -170,6 +175,13 @@ public class GameService {
                 mutation.resultSessionId(), mutation.resultTurn(), mutation.resultTitle(), turn.storyText(),
                 choiceCodec.deserialize(turn.choicesJson()), turn.imageUrl()
         );
+    }
+
+    private String canonicalResultId(Long mutationRequestId, Long sessionId, int nextTurn) {
+        if (mutationRequestId == null || sessionId == null || nextTurn < 2) {
+            throw new IllegalArgumentException("canonical result link를 만들 수 없습니다.");
+        }
+        return "game-result:%d:%d:%d".formatted(sessionId, nextTurn, mutationRequestId);
     }
 
     private void validateNarrativeTurn(NarrativeTurn turn) {

--- a/src/main/resources/db/migration/V11__link_game_result_and_generated_story.sql
+++ b/src/main/resources/db/migration/V11__link_game_result_and_generated_story.sql
@@ -1,0 +1,3 @@
+ALTER TABLE game_log
+    ADD COLUMN canonical_result_id VARCHAR(128),
+    ADD COLUMN generated_story_id VARCHAR(128);

--- a/src/main/resources/db/migration/V11__link_game_result_and_generated_story.sql
+++ b/src/main/resources/db/migration/V11__link_game_result_and_generated_story.sql
@@ -1,3 +1,12 @@
 ALTER TABLE game_log
-    ADD COLUMN canonical_result_id VARCHAR(128),
+    ADD COLUMN canonical_result_id VARCHAR(128);
+
+ALTER TABLE game_log
     ADD COLUMN generated_story_id VARCHAR(128);
+
+ALTER TABLE game_log
+    ADD CONSTRAINT ck_game_log_narrative_link_pair
+    CHECK (
+        (canonical_result_id IS NULL AND generated_story_id IS NULL)
+        OR (canonical_result_id IS NOT NULL AND generated_story_id IS NOT NULL)
+    );

--- a/src/test/java/com/uctale/uctale/application/game/GameNarrativeLinkPersistenceTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/GameNarrativeLinkPersistenceTest.java
@@ -1,0 +1,71 @@
+package com.uctale.uctale.application.game;
+
+import com.uctale.uctale.domain.GameLog;
+import com.uctale.uctale.domain.GameSession;
+import com.uctale.uctale.domain.game.GameState;
+import com.uctale.uctale.domain.game.StateTransition;
+import com.uctale.uctale.repository.GameLogRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class GameNarrativeLinkPersistenceTest {
+
+    private static final String OWNER_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+    @Autowired private GamePersistenceService gamePersistenceService;
+    @Autowired private GameLogRepository gameLogRepository;
+
+    @Test
+    @DisplayName("새 progress GameLog는 canonical result와 생성 story 연결 ID를 함께 기록한다")
+    void saveNextTurn_PersistsCanonicalResultAndGeneratedStoryLink() {
+        GameSession session = gamePersistenceService.saveOpening(
+                OWNER_KEY, "세계관", "캐릭터", "오프닝", "[]", null
+        );
+        GameState previous = gamePersistenceService.loadLatestTurn(OWNER_KEY, session.getId(), 1).gameState();
+        GameState next = previous.advance("문을 잠근다", "문이 잠겼다.");
+        GameTurnCommit commit = new GameTurnCommit(
+                1,
+                7,
+                "문을 잠근다",
+                new StateTransition(previous, next),
+                "문이 잠겼다.",
+                "[]",
+                "game-result:%d:2:100".formatted(session.getId()),
+                "story:11111111-1111-1111-1111-111111111111",
+                null
+        );
+
+        gamePersistenceService.saveNextTurn(OWNER_KEY, session.getId(), commit);
+
+        List<GameLog> logs = gameLogRepository.findByGameSessionOrderByTurnNumberAsc(session);
+        assertThat(logs).hasSize(2);
+        assertThat(logs.getFirst().getCanonicalResultId()).isNull();
+        assertThat(logs.getFirst().getGeneratedStoryId()).isNull();
+        assertThat(logs.getLast().getCanonicalResultId())
+                .isEqualTo("game-result:%d:2:100".formatted(session.getId()));
+        assertThat(logs.getLast().getGeneratedStoryId())
+                .isEqualTo("story:11111111-1111-1111-1111-111111111111");
+    }
+
+    @Test
+    @DisplayName("narrative linkage는 한쪽 ID만 있는 불완전 commit을 거절한다")
+    void gameTurnCommit_RejectsPartialNarrativeLink() {
+        GameState previous = GameState.initial("세계관", "캐릭터", "오프닝");
+        GameState next = previous.advance("간다", "도착했다.");
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> new GameTurnCommit(
+                1, 1, "간다", new StateTransition(previous, next), "도착했다.", "[]",
+                "game-result:42:2:100", null, null
+        )).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("함께 기록");
+    }
+}

--- a/src/test/java/com/uctale/uctale/application/narrative/NarrativeContextTest.java
+++ b/src/test/java/com/uctale/uctale/application/narrative/NarrativeContextTest.java
@@ -1,0 +1,61 @@
+package com.uctale.uctale.application.narrative;
+
+import com.uctale.uctale.domain.action.ActionType;
+import com.uctale.uctale.domain.action.PlayerAction;
+import com.uctale.uctale.domain.game.ActionResolver;
+import com.uctale.uctale.domain.game.GameResult;
+import com.uctale.uctale.domain.game.GameState;
+import com.uctale.uctale.domain.game.TurnResolution;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class NarrativeContextTest {
+
+    @Test
+    @DisplayName("NarrativeContext는 확정 GameResult와 canonical next state를 provider-safe projection으로 만든다")
+    void from_UsesResolvedResultAndCanonicalNextState() {
+        GameState state = GameState.initial("세계관", "캐릭터", "오프닝");
+        PlayerAction action = new PlayerAction(
+                7,
+                "SERVER_ONLY_ACTION_TOKEN",
+                ActionType.NARRATIVE_CHOICE,
+                1,
+                Map.of("choiceId", "7"),
+                "문을 잠근다"
+        );
+        TurnResolution resolution = new ActionResolver().resolve(state, action);
+
+        NarrativeContext context = NarrativeContext.from("game-result:42:2:100", resolution);
+
+        assertThat(context.canonicalResultId()).isEqualTo("game-result:42:2:100");
+        assertThat(context.outcome()).isEqualTo(GameResult.Outcome.RESOLVED);
+        assertThat(context.resolvedAction().legacyChoiceId()).isEqualTo(7);
+        assertThat(context.resolvedAction().displayText()).isEqualTo("문을 잠근다");
+        assertThat(context.playerAction()).isEqualTo("문을 잠근다");
+        assertThat(context.state().turnNumber()).isEqualTo(2);
+        assertThat(context.state().worldPremise()).isEqualTo("세계관");
+        assertThat(context.memory().recentTurns()).hasSize(1);
+        assertThat(context.stateChanges()).containsExactly(new GameResult.TurnAdvanced(1, 2));
+        assertThat(context.narrativeCues()).containsExactly("문을 잠근다");
+        assertThat(context.forbiddenCanonicalMutations()).anyMatch(rule -> rule.contains("HP"));
+    }
+
+    @Test
+    @DisplayName("canonical result link가 없으면 NarrativeContext를 만들 수 없다")
+    void from_RejectsBlankCanonicalResultId() {
+        GameState state = GameState.initial("세계관", "캐릭터", "오프닝");
+        PlayerAction action = new PlayerAction(
+                1, "token", ActionType.NARRATIVE_CHOICE, 1, Map.of("choiceId", "1"), "간다"
+        );
+        TurnResolution resolution = new ActionResolver().resolve(state, action);
+
+        assertThatThrownBy(() -> NarrativeContext.from(" ", resolution))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("canonicalResultId");
+    }
+}

--- a/src/test/java/com/uctale/uctale/provider/gemini/GeminiPromptContractTest.java
+++ b/src/test/java/com/uctale/uctale/provider/gemini/GeminiPromptContractTest.java
@@ -1,0 +1,47 @@
+package com.uctale.uctale.provider.gemini;
+
+import tools.jackson.databind.ObjectMapper;
+import com.uctale.uctale.application.narrative.NarrativeContext;
+import com.uctale.uctale.domain.action.ActionType;
+import com.uctale.uctale.domain.action.PlayerAction;
+import com.uctale.uctale.domain.game.ActionResolver;
+import com.uctale.uctale.domain.game.GameState;
+import com.uctale.uctale.domain.game.TurnResolution;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GeminiPromptContractTest {
+
+    @Test
+    @DisplayName("progress prompt는 확정 결과/상태/금지 mutation/cues를 분리하고 action token을 노출하지 않는다")
+    void buildProgressPrompt_UsesCanonicalContractWithoutActionToken() throws Exception {
+        GeminiNarrativeAdapter adapter = new GeminiNarrativeAdapter(new ObjectMapper(), RestClient.builder());
+        GameState state = GameState.initial("폐허 도시", "정찰자", "오프닝");
+        PlayerAction action = new PlayerAction(
+                7,
+                "SERVER_ONLY_SECRET_TOKEN",
+                ActionType.NARRATIVE_CHOICE,
+                1,
+                Map.of("choiceId", "7"),
+                "문을 잠근다"
+        );
+        TurnResolution resolution = new ActionResolver().resolve(state, action);
+        NarrativeContext context = NarrativeContext.from("game-result:42:2:100", resolution);
+
+        String prompt = adapter.buildProgressPrompt(context);
+
+        assertThat(prompt)
+                .contains("[확정 게임 결과 ID]", "game-result:42:2:100")
+                .contains("[확정 게임 결과]", "outcome: RESOLVED")
+                .contains("state changes", "previousTurn", "nextTurn")
+                .contains("[확정 상태 projection]", "\"turnNumber\":2")
+                .contains("[narrative cues]", "문을 잠근다")
+                .contains("[금지 canonical mutation]", "HP", "roll")
+                .doesNotContain("SERVER_ONLY_SECRET_TOKEN");
+    }
+}


### PR DESCRIPTION
## 왜 필요한가요?

현재 #34에서 action resolution과 canonical state transition은 Narrative provider 호출 전에 확정되지만, provider context는 아직 이전 state/action 문자열 중심이었습니다. 서버가 확정한 결과를 명시적 계약으로 전달하고 provider가 canonical 의미를 재판정하지 못하도록 Narrative 경계를 강화합니다.

- Closes #36

## 무엇이 바뀌나요?

- 게임 규칙·상태: `TurnResolution`의 `GameResult`와 canonical next state에서 provider-safe `NarrativeContext` projection을 구성합니다. rule state 자체는 기존 #34 경계를 유지합니다.
- Backend / API / DB: 새 progress `GameLog`에 `canonical_result_id`와 `generated_story_id`를 함께 기록합니다. V11 migration은 legacy/opening 행의 `(NULL, NULL)`을 허용하면서 한쪽 ID만 존재하는 부분 linkage는 CHECK constraint로 거부합니다. API wire contract는 변경하지 않습니다.
- AI narrative / prompt: 확정 결과, canonical next-state projection, memory projection, narrative cues, 금지 canonical mutation을 prompt에서 분리합니다. `PlayerAction.token`은 provider projection에서 제외합니다.
- Image generation: 기존 optional `visual_assets` 계약을 유지하며 canonical state 권한은 부여하지 않습니다.
- Frontend / UX: 변경 없음.
- Build / deploy / docs: `narrative-context.md`를 추가하고 README와 action/game-state architecture 문서를 현재 구현 상태로 갱신했습니다.

#35는 선행 Issue로 열려 있지만 provider-specific structured output 검증/repair/bounded retry 구현은 이 PR에 포함하지 않습니다. 이번 변경은 이미 존재하는 provider 호출 경계 앞의 context 계약과 canonical result/story linkage만 다룹니다. Story Memory 전면 개편은 #46 범위로 유지합니다.

## 책임 경계

- **서버가 결정하는 사실:** resolved action, `GameResult.outcome`, canonical facts/events/state changes, canonical next state, canonical result ID
- **LLM이 서술하는 내용:** 서버가 확정한 결과가 드러나는 story prose, 다음 choice 후보, 선택적 visual assets
- **LLM이 변경하면 안 되는 사실:** outcome/roll/성공·실패, HP·능력치·아이템·레벨·위치·생사 등 서버가 state change로 제공하지 않은 canonical 변화, state projection/canonical facts

## 어떻게 검증했나요?

- [x] PR 작성 전 변경 diff를 비판적으로 검토하고 타당한 지적을 반영했습니다.
- [x] `./gradlew clean test`
- [x] `./gradlew postgresIntegrationTest`
- [x] `./gradlew build`
- [x] `cd frontend && npm ci && npm test && npm run lint && npm run build`
- [x] 정상 흐름을 직접 확인했습니다.
- [x] 잘못된 입력/실패 흐름을 확인했습니다.
- [x] 중복 요청 또는 상태 전이가 관련되면 이를 검증했습니다.

GitHub Actions CI #178에서 backend test, PostgreSQL integration test, backend build와 frontend install/test/lint/build가 모두 성공했습니다. production smoke script syntax validation도 성공했습니다.

추가한 테스트는 `NarrativeContext`의 canonical next-state projection, prompt의 결과/state/cues/금지 mutation 분리와 action token 비노출, GameLog result/story linkage 및 partial-link 거부를 검증합니다. 기존 `GameServiceTest`와 PostgreSQL turn integrity matrix도 함께 통과해 provider 실패 시 turn 미진행, completed retry replay, stale-owner fencing, canonical single commit 회귀가 없음을 확인했습니다.

provider failure/retry 정책은 기존 idempotency/reservation 경계를 유지합니다. 같은 idempotent 요청은 동일 mutation request ID로 같은 `canonicalResultId`를 재구성하며, provider 실패 시 canonical turn을 commit하지 않습니다. 완료된 mutation은 provider를 재호출하지 않고 committed turn을 replay합니다.

비판적 자체 리뷰에서 다음 두 문제를 발견해 PR 작성 전에 수정했습니다.

1. `GameResult`를 그대로 직렬화하면 `PlayerAction.token`이 외부 provider로 노출될 수 있어 provider-safe resolved action projection으로 분리했습니다.
2. 애플리케이션 불변식만으로는 DB에 `(canonical_result_id 값, generated_story_id NULL)` 같은 부분 linkage가 들어갈 수 있어 V11에 pair CHECK constraint를 추가했습니다.

## 게임 상태·AI 안전성

- [x] 게임의 결정적 상태는 서버에서 검증·저장됩니다.
- [x] LLM 출력만으로 HP, 보상, 성공/실패 등 결정적 상태가 임의 변경되지 않습니다.
- [x] AI 요청에 필요한 최소 문맥만 전달합니다.
- [x] AI 응답 파싱 실패와 provider 오류가 게임 상태를 오염시키지 않습니다.
- [x] 기존 저장 데이터 또는 GameState 호환성 영향을 확인했습니다.

`NarrativeTurn`은 canonical state 변경 필드를 갖지 않고, provider prose는 #34의 확정 transition에 transcript로만 부착됩니다. legacy `game_log`는 신규 linkage 두 컬럼이 모두 NULL인 상태로 호환됩니다.

## 보안·비용

- [x] API Key, 토큰, 비밀번호가 코드·로그·URL·클라이언트 응답에 노출되지 않습니다.
- [x] 외부 AI/Image 호출 횟수와 실패 시 동작을 검토했습니다.
- [x] 사용자 입력 길이와 외부 API 비용 증가 가능성을 검토했습니다.
- [x] CORS 또는 공개 endpoint 변경이 있다면 의도된 변경입니다.

특히 서버 발급 `PlayerAction.token`은 Narrative provider context에서 제거했습니다. provider 호출 횟수와 attempt accounting은 변경하지 않았고 prompt에 추가되는 값은 이미 서버가 보유한 bounded state/memory projection입니다. CORS/public endpoint 변경은 없습니다.

## API·DB·운영 영향

- [x] API 계약 변경 시 Frontend 호출부와 문서를 함께 갱신했습니다.
- [x] DB schema 변경 시 migration 전략을 포함했습니다.
- [x] 환경변수는 이름과 용도만 문서화했고 실제 Secret은 포함하지 않았습니다.
- [x] 배포 후 확인할 smoke test가 있습니다.

API wire contract와 환경변수 변경은 없습니다. V11 migration은 nullable linkage 컬럼 2개와 legacy-compatible pair CHECK constraint만 추가합니다. CI #178에서 PostgreSQL migration/integration 경로와 production smoke script syntax validation이 통과했습니다.

## 화면 / 응답 예시

UI/API wire response 변경은 없습니다.
