### PR TITLE
feat(game): Skill Check를 턴 처리와 감사 로그에 통합

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ UCTale은 사용자가 직접 입력한 세계관과 주인공 설정을 바탕�
 
 UCTale의 핵심 원칙은 **게임의 결정적 사실과 규칙은 서버가 소유하고, LLM은 확정된 결과를 서술한다**는 것입니다.
 
-현재 main은 공유 베타 운영 안전망과 신뢰 가능한 턴 저장 기반에 더해 `ActionResolver` / `GameResult` / provider-safe `NarrativeContext` 경계까지 갖추었고, M3에서 실제 Skill Check turn 통합을 확장하는 단계입니다.
+현재 main은 공유 베타 운영 안전망과 신뢰 가능한 턴 저장 기반에 더해 `ActionResolver` / `GameResult` / provider-safe `NarrativeContext` 경계와 첫 실제 Skill Check turn vertical slice까지 갖추는 단계입니다.
 
-- 서버: 세션 소유권, 현재 턴, idempotency, reservation lease, canonical state, `GameResult`, GameLog, provider attempt 상한을 검증합니다.
+- 서버: 세션 소유권, 현재 턴, idempotency, reservation lease, canonical state, Skill Check 판정, `GameResult`, GameLog, provider attempt 상한을 검증합니다.
 - Narrative AI: 서버가 확정한 결과와 제한된 state/memory projection을 바탕으로 이야기와 다음 선택지 표현을 생성합니다.
 - Image AI: 브라우저의 임의 prompt가 아니라 서버가 발급한 image asset 계약만 실행합니다.
 - Frontend: 서버가 반환한 선택 행동과 상태를 표시하고, 규칙을 재계산하지 않습니다.
@@ -48,9 +48,10 @@ UCTale의 핵심 원칙은 **게임의 결정적 사실과 규칙은 서버가 �
 3. 서버가 첫 장면과 서버 발급 선택 행동을 생성합니다.
 4. 플레이어가 현재 턴에 유효한 행동을 선택합니다.
 5. 서버가 소유권, expected turn, idempotency, action payload를 검증합니다.
-6. 서버가 action을 `GameResult` / canonical next state로 먼저 resolve하고 provider-safe `NarrativeContext`를 구성한 뒤 Narrative provider를 호출합니다.
-7. 검증된 story는 확정 rule state를 변경하지 않고 transcript를 완성하며 canonical state와 committed-turn log를 원자적으로 저장합니다.
-8. 시각적으로 표현할 장면이 있으면 서버가 발급한 image asset을 통해 삽화를 제공합니다.
+6. Skill Check action이면 reservation 소유 요청이 서버 난수와 modifier/DC/outcome을 한 번 확정·보존합니다.
+7. 서버가 action을 `GameResult` / canonical next state로 resolve하고 provider-safe `NarrativeContext`를 구성한 뒤 Narrative provider를 호출합니다.
+8. 검증된 story는 확정 rule state를 변경하지 않고 transcript를 완성하며 canonical state와 committed-turn log를 원자적으로 저장합니다.
+9. 시각적으로 표현할 장면이 있으면 서버가 발급한 image asset을 통해 삽화를 제공합니다.
 
 ---
 
@@ -70,15 +71,16 @@ UCTale의 핵심 원칙은 **게임의 결정적 사실과 규칙은 서버가 �
 #33의 `AvailableAction` / `PlayerAction`과 #34의 `ActionResolver` / `TurnResolution` / `GameResult` 경계가 main에 반영되어 있습니다.
 
 - 서버는 각 선택지에 action token/type/source turn/arguments를 발급할 수 있습니다.
+- 신규 typed 선택은 첫 vertical slice로 `SKILL_CHECK` action을 사용하며 현재 서버 정책은 `WILL`, DC 10, 상황 modifier 0입니다.
 - `/progress`는 현재 turn의 서버 발급 action과 요청 payload가 일치하는지 검증합니다.
 - 변조되거나 만료된 action은 provider 호출 전에 거절됩니다.
-- 검증된 action은 provider 호출 전에 pure `ActionResolver`에서 `GameResult`와 canonical next `StateTransition`으로 확정됩니다.
+- metadata 없는 legacy wire 요청은 기존 `NARRATIVE_CHOICE` compatibility 의미를 유지합니다.
+- 검증된 action은 provider 호출 전에 `ActionResolver`에서 `GameResult`와 canonical next `StateTransition`으로 확정됩니다.
 - `GameService`는 action type별 규칙 세부 구현을 알지 않고 orchestration만 담당합니다.
-- 기존 `choiceId` 기반 요청은 compatibility 경로로 유지합니다.
 
 ### 타입 안전한 능력치와 Skill Check
 
-#7에서 서버 소유 게임 규칙의 첫 순수 도메인 기반을 추가했습니다.
+#7의 순수 규칙 기반에 #37의 실제 turn 통합을 연결합니다.
 
 - `StatType`: `MIGHT`, `AGILITY`, `INTELLECT`, `WILL`, `PRESENCE`
 - 신규·legacy 캐릭터는 기본 능력치 10을 사용합니다.
@@ -86,11 +88,11 @@ UCTale의 핵심 원칙은 **게임의 결정적 사실과 규칙은 서버가 �
 - `Difficulty`, `DiceRoll`, situational modifier가 각 허용 범위를 검증합니다.
 - `SkillCheck`는 `rawRoll + statModifier + situationalModifier >= DC`만으로 성공/실패를 결정합니다.
 - natural 1/20 특수 규칙은 사용하지 않습니다.
-- `SkillCheckResult`는 raw roll, modifier, DC, total, outcome, ruleset version을 보존합니다.
+- `SkillCheckResult`는 raw roll, stat modifier, situational modifier, DC, total, outcome, ruleset version을 보존합니다.
 - production random adapter는 `SecureRandom`, 테스트는 fixed/sequence `RandomSource`를 사용합니다.
-- Skill Check는 pure domain operation이며 Narrative provider를 호출하지 않습니다.
-
-아직 이 판정을 실제 `/progress` action/turn pipeline과 DB roll 저장, frontend에 연결하지 않습니다. 실제 통합은 #37/#38 범위입니다.
+- 같은 idempotency mutation retry는 reservation에 보존된 동일 판정을 재사용하고, 다른 request가 만료 lease를 takeover하면 새 판정을 확정합니다.
+- canonical commit은 Skill Check 결과와 state transition을 같은 transaction에서 `GameLog`에 기록합니다.
+- frontend의 능력치/판정 결과 표시는 #38 범위입니다.
 
 ### GameState와 Story Memory
 
@@ -107,13 +109,14 @@ snapshot JSON은 schema/ruleset version을 가지며 legacy production snapshot�
 
 #36 이후 progress Narrative provider에는 raw `GameState + 사용자 행동 문자열` 조합 대신 서버가 확정한 결과를 provider-safe projection으로 전달합니다.
 
-- `NarrativeContext`는 canonical result ID, resolved action projection, outcome, canonical facts/events/state changes, canonical next-state projection, memory projection, narrative cues를 포함합니다.
+- `NarrativeContext`는 canonical result ID, resolved action projection, outcome, optional Skill Check projection, canonical facts/events/state changes, canonical next-state projection, memory projection, narrative cues를 포함합니다.
+- Skill Check projection은 raw roll, stat/situational modifier, DC, total, success/failure, ruleset version을 포함합니다.
 - 서버 발급 `PlayerAction.token`은 provider context에 포함하지 않습니다.
 - prompt는 확정 결과/state, narrative cues, 금지 canonical mutation을 분리합니다.
 - provider는 story prose와 다음 choice 후보를 만들 수 있지만 서버가 확정한 outcome/roll/state change를 재판정할 수 없습니다.
 - provider story는 canonical state를 직접 변경하지 않고 기존 StoryMemory transcript만 완성합니다.
-- `game_log`는 새 progress turn부터 `canonical_result_id`와 `generated_story_id`를 함께 기록합니다. legacy/opening 행은 두 값이 모두 비어 있을 수 있습니다.
-- provider failure 시 canonical turn은 진행하지 않으며 같은 idempotent 요청은 동일 canonical result link를 재구성합니다.
+- `game_log`는 progress turn의 `canonical_result_id` / `generated_story_id`와 선택적 Skill Check audit 필드를 기록합니다. legacy/opening 행은 Skill Check 필드가 모두 비어 있을 수 있습니다.
+- provider failure 시 canonical turn은 진행하지 않으며 같은 idempotent 요청은 reservation에 저장된 Skill Check 판정과 동일 canonical result link를 재사용합니다.
 
 Gemini structured output의 provider-specific schema validation과 bounded repair/retry 강화는 #35의 별도 범위입니다. Story Memory projection/token budget 전면 개선은 #46 범위입니다.
 
@@ -125,6 +128,7 @@ M2의 턴 무결성·복구 구현 범위와 완료 조건은 main에 반영되�
 - 같은 key + 같은 payload의 완료 요청은 provider를 재호출하지 않고 canonical 결과를 replay합니다.
 - 같은 key를 다른 payload/operation에 재사용하면 provider 호출 전에 conflict로 거절합니다.
 - `(session_id, expected_turn)` reservation lease로 유효 lease 동안 중복 provider 진입을 억제합니다.
+- Skill Check가 필요한 typed action은 provider 호출 전에 현재 reservation owner가 판정을 한 번 저장합니다.
 - provider attempt는 reservation 획득 횟수와 분리된 `provider_attempt_count`로 관리하며 turn당 최대 3회로 제한합니다.
 - validation, rate limit, budget guard 같은 pre-provider 실패는 provider attempt를 소비하지 않습니다.
 - stale lease owner는 takeover 이후 canonical commit을 수행할 수 없습니다.
@@ -195,6 +199,7 @@ uctale/
 
 - [개발 원칙](./CONTRIBUTING.md)
 - [Action Resolution](./docs/architecture/action-resolution.md)
+- [Skill Check turn integration](./docs/architecture/skill-check-turn.md)
 - [GameResult 기반 NarrativeContext](./docs/architecture/narrative-context.md)
 - [GameState / Story Memory](./docs/architecture/game-state-story-memory.md)
 - [Game mutation idempotency](./docs/architecture/game-mutation-idempotency.md)
@@ -323,8 +328,8 @@ GitHub Actions CI도 backend unit test → PostgreSQL integration test → backe
 
 진행 중.
 
-현재 #33 `AvailableAction` / `PlayerAction`, #34 `ActionResolver` / `GameResult`, #36 확정 결과 기반 `NarrativeContext`, #7 typed `CharacterStats` / pure Skill Check 규칙 기반이 반영되었습니다. 다음 핵심 game-rule vertical slice는 #37 실제 Skill Check turn 통합입니다.
+현재 #33 `AvailableAction` / `PlayerAction`, #34 `ActionResolver` / `GameResult`, #36 확정 결과 기반 `NarrativeContext`, #7 typed `CharacterStats` / pure Skill Check 규칙에 더해 #37 Skill Check turn 통합과 감사 저장이 반영됩니다.
 
-Gemini structured output 검증과 bounded recovery는 #35, Skill Check 결과/roll 감사 저장과 frontend 표현은 #37/#38의 완료 조건을 기준으로 진행합니다.
+다음 UI 단계는 #38 능력치·Skill Check 결과 표시입니다. Gemini structured output 검증과 bounded recovery는 #35의 별도 P1 작업입니다.
 
 아직 구현되지 않은 전투·인벤토리·퀘스트·NPC 관계 기능은 현재 기능처럼 문서에 표시하지 않습니다.

--- a/docs/architecture/skill-check-turn.md
+++ b/docs/architecture/skill-check-turn.md
@@ -1,0 +1,110 @@
+# Skill Check turn integration
+
+## 목적
+
+#37은 #7의 pure `SkillCheck` 규칙을 실제 `/progress` turn pipeline에 연결하는 첫 서버 주도 판정 vertical slice다.
+
+핵심 원칙은 다음과 같다.
+
+> roll, modifier, DC, total, success/failure는 서버가 한 번 확정하고, Narrative provider는 그 결과를 서술만 한다.
+
+## 현재 action 정책
+
+신규 typed choice는 서버가 `SKILL_CHECK` `AvailableAction`으로 발급한다.
+
+현재 vertical slice의 최소 정책은 다음과 같다.
+
+- stat: `WILL`
+- DC: `10`
+- situational modifier: `0`
+- `choiceId`는 기존 choice 식별자와 일치해야 한다.
+
+이 값은 provider가 결정하지 않는다. choice text는 Narrative provider가 제안할 수 있지만 action type과 rule arguments는 서버가 발급한다.
+
+이 정책은 첫 end-to-end 판정 경계를 검증하기 위한 최소 규칙이며 최종 balancing이나 행동별 stat/DC 선택 시스템을 의미하지 않는다.
+
+metadata가 없는 legacy wire 요청은 기존 `NARRATIVE_CHOICE` compatibility 의미를 유지한다.
+
+## 판정 수명주기
+
+1. mutation request가 `(session, expectedTurn)` reservation을 획득한다.
+2. `ChoiceCodec`이 서버 발급 action 전체 metadata를 검증한다.
+3. `TurnProcessor`가 `SKILL_CHECK` 여부를 확인한다.
+4. `SkillCheckDecisionService`가 현재 reservation owner와 lease를 `FOR UPDATE`로 검증한다.
+5. 같은 mutation request에 이미 저장된 판정이 있으면 재사용한다.
+6. 없으면 production `SecureRandomSource`로 d20을 한 번 생성하고 판정 전체를 reservation에 저장한다.
+7. `ActionResolver`가 저장된 판정이 action의 stat/DC/situational modifier와 현재 canonical stat modifier에 일치하는지 다시 검증한다.
+8. `GameResult`와 canonical next state를 확정한다.
+9. `NarrativeContext`에는 provider-safe `SkillCheckProjection`만 전달한다.
+10. provider story가 유효하면 state transition과 동일 canonical commit에서 Skill Check audit을 `GameLog`에 기록한다.
+
+## retry와 concurrency
+
+### 같은 idempotency request
+
+provider 실패나 DB 실패 뒤 같은 idempotency request가 재시작돼도 `game_turn_reservation.skill_check_request_id`가 같은 mutation request ID를 가리키면 저장된 판정을 재사용한다.
+
+따라서 같은 사용자 mutation에서 provider retry나 canonical commit retry 때문에 d20이 바뀌지 않는다.
+
+### 다른 request takeover
+
+다른 mutation request가 만료된 lease를 takeover하면 이전 request의 provisional 판정을 canonical 결과로 재사용하지 않는다. 새 reservation owner/request가 새 판정을 확정해 기존 provisional 값을 교체한다.
+
+이는 외부 provider exactly-once를 주장하는 것이 아니다. lease 만료 이후 takeover에서는 provider가 다시 호출될 수 있지만 stale owner는 canonical commit을 수행할 수 없다.
+
+### provider attempt accounting
+
+Skill Check 판정 생성은 provider attempt가 아니다. 기존 정책처럼 `provider_attempt_count`는 실제 Narrative provider 호출 직전에만 증가한다.
+
+validation, rate limit, budget guard처럼 provider 호출 전 종료되는 경로가 provider attempt로 잘못 계산되지 않는 기존 경계를 유지한다.
+
+## 감사 로그
+
+Flyway V12는 `game_log`에 다음 nullable audit 필드를 추가한다.
+
+- `skill_check_stat_type`
+- `skill_check_raw_roll`
+- `skill_check_stat_modifier`
+- `skill_check_situational_modifier`
+- `skill_check_dc`
+- `skill_check_total`
+- `skill_check_outcome`
+- `skill_check_ruleset_version`
+
+Skill Check가 없는 legacy/opening/narrative-only turn은 모두 `NULL`이다.
+
+Skill Check가 있는 turn은 CHECK constraint로 전체 필드가 함께 존재해야 하므로 부분 audit이 조용히 저장되지 않는다.
+
+## Narrative provider 경계
+
+`NarrativeContext.SkillCheckProjection`은 다음 값을 제공한다.
+
+- stat type
+- raw roll
+- stat modifier
+- situational modifier
+- DC
+- total
+- success/failure
+- ruleset version
+
+`PlayerAction.token`은 provider context에 포함하지 않는다.
+
+Gemini prompt는 서버가 확정한 roll/modifier/DC/total/outcome을 변경하거나 재판정하지 않도록 명시한다. provider 응답은 canonical Skill Check 결과의 근거가 아니다.
+
+## 테스트 경계
+
+- `ActionResolverTest`: fixed `RandomSource` 성공/실패 경계, stale/invalid action, 저장 판정 재검증
+- `GameServiceTest`: 같은 Skill Check 결과가 `NarrativeContext`와 canonical commit 후보에 전달되는지 검증
+- `GeminiPromptContractTest`: raw roll부터 outcome까지 prompt projection 및 token 비노출 검증
+- `PostgresSkillCheckDecisionTest`: 같은 mutation retry의 판정 재사용, 다른 takeover request의 새 판정 검증
+- `PostgresSkillCheckAuditTest`: PostgreSQL `GameLog`에서 raw roll부터 outcome까지 조회 가능함을 검증
+- 기존 M2 PostgreSQL matrix는 수정하지 않고 idempotency/concurrency/crash/stale-owner 회귀를 계속 검증한다.
+
+## 범위 밖
+
+- 전체 Combat
+- natural 1/20 특수 규칙
+- advantage/disadvantage
+- 행동별 stat/DC 자동 선택 또는 balancing
+- frontend 판정 상세 UI (#38)

--- a/src/main/java/com/uctale/uctale/application/game/ChoiceCodec.java
+++ b/src/main/java/com/uctale/uctale/application/game/ChoiceCodec.java
@@ -4,6 +4,7 @@ import com.uctale.uctale.application.narrative.NarrativeTurn;
 import com.uctale.uctale.domain.action.ActionType;
 import com.uctale.uctale.domain.action.AvailableAction;
 import com.uctale.uctale.domain.action.PlayerAction;
+import com.uctale.uctale.domain.game.StatType;
 import com.uctale.uctale.dto.GameChoice;
 import com.uctale.uctale.dto.GameProgressRequest;
 import org.springframework.stereotype.Component;
@@ -18,6 +19,10 @@ import java.util.UUID;
 @Component
 public class ChoiceCodec {
 
+    static final StatType DEFAULT_SKILL_STAT = StatType.WILL;
+    static final int DEFAULT_SKILL_DC = 10;
+    static final int DEFAULT_SITUATIONAL_MODIFIER = 0;
+
     private final ObjectMapper objectMapper;
 
     public ChoiceCodec(ObjectMapper objectMapper) {
@@ -29,9 +34,14 @@ public class ChoiceCodec {
                 .map(choice -> new AvailableAction(
                         choice.id(),
                         UUID.randomUUID().toString(),
-                        ActionType.NARRATIVE_CHOICE,
+                        ActionType.SKILL_CHECK,
                         sourceTurn,
-                        Map.of("choiceId", Integer.toString(choice.id())),
+                        Map.of(
+                                "choiceId", Integer.toString(choice.id()),
+                                "statType", DEFAULT_SKILL_STAT.name(),
+                                "dc", Integer.toString(DEFAULT_SKILL_DC),
+                                "situationalModifier", Integer.toString(DEFAULT_SITUATIONAL_MODIFIER)
+                        ),
                         choice.text()
                 ))
                 .map(this::toDto)

--- a/src/main/java/com/uctale/uctale/application/game/ChoiceCodec.java
+++ b/src/main/java/com/uctale/uctale/application/game/ChoiceCodec.java
@@ -85,7 +85,7 @@ public class ChoiceCodec {
             throw invalidAction();
         }
         if (legacyWireRequest) {
-            return playerActionFrom(available);
+            return legacyPlayerAction(storedChoice, request.expectedTurn());
         }
 
         ActionType requestedType;

--- a/src/main/java/com/uctale/uctale/application/game/GamePersistenceService.java
+++ b/src/main/java/com/uctale/uctale/application/game/GamePersistenceService.java
@@ -121,7 +121,8 @@ public class GamePersistenceService {
             gameSessionRepository.save(session);
             gameLogRepository.save(GameLog.committedTurn(session, commit.nextStateVersion(), commit.inputChoiceId(),
                     commit.inputChoiceText(), commit.previousStateVersion(), commit.nextStateVersion(),
-                    commit.canonicalResultId(), commit.generatedStoryId(), commit.storyText(), commit.choicesJson(), imageUrl));
+                    commit.canonicalResultId(), commit.generatedStoryId(), commit.skillCheckResult(),
+                    commit.storyText(), commit.choicesJson(), imageUrl));
             GameStateSnapshot snapshot = gameStateSnapshotRepository.findById(sessionId)
                     .orElseGet(() -> new GameStateSnapshot(session, gameStateCodec.serialize(commit.previousState())));
             snapshot.updateStateJson(gameStateCodec.serialize(commit.nextState()));

--- a/src/main/java/com/uctale/uctale/application/game/GameTurnCommit.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameTurnCommit.java
@@ -20,47 +20,107 @@ public record GameTurnCommit(
     private static final int MAX_LINK_ID_LENGTH = 128;
 
     public GameTurnCommit {
-        if (expectedTurn < 1) throw new IllegalArgumentException("expectedTurn은 1 이상이어야 합니다.");
-        if (inputChoiceId < 1) throw new IllegalArgumentException("inputChoiceId는 1 이상이어야 합니다.");
-        if (inputChoiceText == null || inputChoiceText.isBlank()) throw new IllegalArgumentException("inputChoiceText는 비어 있을 수 없습니다.");
-        if (stateTransition == null) throw new IllegalArgumentException("stateTransition은 null일 수 없습니다.");
-        if (stateTransition.previousState().turnNumber() != expectedTurn) throw new IllegalArgumentException("previousState turn과 expectedTurn이 일치해야 합니다.");
-        if (stateTransition.nextState().turnNumber() != expectedTurn + 1) throw new IllegalArgumentException("nextState는 expectedTurn의 다음 turn이어야 합니다.");
-        if (storyText == null || storyText.isBlank()) throw new IllegalArgumentException("storyText는 비어 있을 수 없습니다.");
-        if (choicesJson == null) throw new IllegalArgumentException("choicesJson은 null일 수 없습니다.");
-        if ((canonicalResultId == null) != (generatedStoryId == null)) throw new IllegalArgumentException("canonicalResultId와 generatedStoryId는 함께 기록해야 합니다.");
+        if (expectedTurn < 1) {
+            throw new IllegalArgumentException("expectedTurn은 1 이상이어야 합니다.");
+        }
+        if (inputChoiceId < 1) {
+            throw new IllegalArgumentException("inputChoiceId는 1 이상이어야 합니다.");
+        }
+        if (inputChoiceText == null || inputChoiceText.isBlank()) {
+            throw new IllegalArgumentException("inputChoiceText는 비어 있을 수 없습니다.");
+        }
+        if (stateTransition == null) {
+            throw new IllegalArgumentException("stateTransition은 null일 수 없습니다.");
+        }
+        if (stateTransition.previousState().turnNumber() != expectedTurn) {
+            throw new IllegalArgumentException("previousState turn과 expectedTurn이 일치해야 합니다.");
+        }
+        if (stateTransition.nextState().turnNumber() != expectedTurn + 1) {
+            throw new IllegalArgumentException("nextState는 expectedTurn의 다음 turn이어야 합니다.");
+        }
+        if (storyText == null || storyText.isBlank()) {
+            throw new IllegalArgumentException("storyText는 비어 있을 수 없습니다.");
+        }
+        if (choicesJson == null) {
+            throw new IllegalArgumentException("choicesJson은 null일 수 없습니다.");
+        }
+        if ((canonicalResultId == null) != (generatedStoryId == null)) {
+            throw new IllegalArgumentException("canonicalResultId와 generatedStoryId는 함께 기록해야 합니다.");
+        }
         validateLinkId("canonicalResultId", canonicalResultId);
         validateLinkId("generatedStoryId", generatedStoryId);
     }
 
-    public GameTurnCommit(int expectedTurn, int inputChoiceId, String inputChoiceText, StateTransition stateTransition,
-            String storyText, String choicesJson, String canonicalResultId, String generatedStoryId,
-            ImageAssetService.AssetReference imageAsset) {
+    public GameTurnCommit(
+            int expectedTurn,
+            int inputChoiceId,
+            String inputChoiceText,
+            StateTransition stateTransition,
+            String storyText,
+            String choicesJson,
+            String canonicalResultId,
+            String generatedStoryId,
+            ImageAssetService.AssetReference imageAsset
+    ) {
         this(expectedTurn, inputChoiceId, inputChoiceText, stateTransition, storyText, choicesJson,
                 canonicalResultId, generatedStoryId, null, imageAsset);
     }
 
-    public GameTurnCommit(int expectedTurn, int inputChoiceId, String inputChoiceText, StateTransition stateTransition,
-            String storyText, String choicesJson, ImageAssetService.AssetReference imageAsset) {
+    public GameTurnCommit(
+            int expectedTurn,
+            int inputChoiceId,
+            String inputChoiceText,
+            StateTransition stateTransition,
+            String storyText,
+            String choicesJson,
+            ImageAssetService.AssetReference imageAsset
+    ) {
         this(expectedTurn, inputChoiceId, inputChoiceText, stateTransition, storyText, choicesJson,
                 null, null, null, imageAsset);
     }
 
-    public GameTurnCommit(int expectedTurn, int inputChoiceId, String inputChoiceText, GameState previousState,
-            GameState nextState, String storyText, String choicesJson, ImageAssetService.AssetReference imageAsset) {
+    public GameTurnCommit(
+            int expectedTurn,
+            int inputChoiceId,
+            String inputChoiceText,
+            GameState previousState,
+            GameState nextState,
+            String storyText,
+            String choicesJson,
+            ImageAssetService.AssetReference imageAsset
+    ) {
         this(expectedTurn, inputChoiceId, inputChoiceText, new StateTransition(previousState, nextState),
                 storyText, choicesJson, null, null, null, imageAsset);
     }
 
-    public GameState previousState() { return stateTransition.previousState(); }
-    public GameState nextState() { return stateTransition.nextState(); }
-    public int previousStateVersion() { return previousState().turnNumber(); }
-    public int nextStateVersion() { return nextState().turnNumber(); }
-    public boolean hasNarrativeLink() { return canonicalResultId != null; }
-    public boolean hasSkillCheck() { return skillCheckResult != null; }
+    public GameState previousState() {
+        return stateTransition.previousState();
+    }
+
+    public GameState nextState() {
+        return stateTransition.nextState();
+    }
+
+    public int previousStateVersion() {
+        return previousState().turnNumber();
+    }
+
+    public int nextStateVersion() {
+        return nextState().turnNumber();
+    }
+
+    public boolean hasNarrativeLink() {
+        return canonicalResultId != null;
+    }
+
+    public boolean hasSkillCheck() {
+        return skillCheckResult != null;
+    }
 
     private static void validateLinkId(String name, String value) {
         if (value == null) return;
-        if (value.isBlank() || value.length() > MAX_LINK_ID_LENGTH) throw new IllegalArgumentException(name + "가 올바르지 않습니다.");
+        if (value.isBlank() || value.length() > MAX_LINK_ID_LENGTH) {
+            throw new IllegalArgumentException(name + "가 올바르지 않습니다.");
+        }
     }
 }

--- a/src/main/java/com/uctale/uctale/application/game/GameTurnCommit.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameTurnCommit.java
@@ -2,6 +2,7 @@ package com.uctale.uctale.application.game;
 
 import com.uctale.uctale.application.image.ImageAssetService;
 import com.uctale.uctale.domain.game.GameState;
+import com.uctale.uctale.domain.game.SkillCheckResult;
 import com.uctale.uctale.domain.game.StateTransition;
 
 public record GameTurnCommit(
@@ -13,93 +14,53 @@ public record GameTurnCommit(
         String choicesJson,
         String canonicalResultId,
         String generatedStoryId,
+        SkillCheckResult skillCheckResult,
         ImageAssetService.AssetReference imageAsset
 ) {
     private static final int MAX_LINK_ID_LENGTH = 128;
 
     public GameTurnCommit {
-        if (expectedTurn < 1) {
-            throw new IllegalArgumentException("expectedTurn은 1 이상이어야 합니다.");
-        }
-        if (inputChoiceId < 1) {
-            throw new IllegalArgumentException("inputChoiceId는 1 이상이어야 합니다.");
-        }
-        if (inputChoiceText == null || inputChoiceText.isBlank()) {
-            throw new IllegalArgumentException("inputChoiceText는 비어 있을 수 없습니다.");
-        }
-        if (stateTransition == null) {
-            throw new IllegalArgumentException("stateTransition은 null일 수 없습니다.");
-        }
-        if (stateTransition.previousState().turnNumber() != expectedTurn) {
-            throw new IllegalArgumentException("previousState turn과 expectedTurn이 일치해야 합니다.");
-        }
-        if (stateTransition.nextState().turnNumber() != expectedTurn + 1) {
-            throw new IllegalArgumentException("nextState는 expectedTurn의 다음 turn이어야 합니다.");
-        }
-        if (storyText == null || storyText.isBlank()) {
-            throw new IllegalArgumentException("storyText는 비어 있을 수 없습니다.");
-        }
-        if (choicesJson == null) {
-            throw new IllegalArgumentException("choicesJson은 null일 수 없습니다.");
-        }
-        if ((canonicalResultId == null) != (generatedStoryId == null)) {
-            throw new IllegalArgumentException("canonicalResultId와 generatedStoryId는 함께 기록해야 합니다.");
-        }
+        if (expectedTurn < 1) throw new IllegalArgumentException("expectedTurn은 1 이상이어야 합니다.");
+        if (inputChoiceId < 1) throw new IllegalArgumentException("inputChoiceId는 1 이상이어야 합니다.");
+        if (inputChoiceText == null || inputChoiceText.isBlank()) throw new IllegalArgumentException("inputChoiceText는 비어 있을 수 없습니다.");
+        if (stateTransition == null) throw new IllegalArgumentException("stateTransition은 null일 수 없습니다.");
+        if (stateTransition.previousState().turnNumber() != expectedTurn) throw new IllegalArgumentException("previousState turn과 expectedTurn이 일치해야 합니다.");
+        if (stateTransition.nextState().turnNumber() != expectedTurn + 1) throw new IllegalArgumentException("nextState는 expectedTurn의 다음 turn이어야 합니다.");
+        if (storyText == null || storyText.isBlank()) throw new IllegalArgumentException("storyText는 비어 있을 수 없습니다.");
+        if (choicesJson == null) throw new IllegalArgumentException("choicesJson은 null일 수 없습니다.");
+        if ((canonicalResultId == null) != (generatedStoryId == null)) throw new IllegalArgumentException("canonicalResultId와 generatedStoryId는 함께 기록해야 합니다.");
         validateLinkId("canonicalResultId", canonicalResultId);
         validateLinkId("generatedStoryId", generatedStoryId);
     }
 
-    public GameTurnCommit(
-            int expectedTurn,
-            int inputChoiceId,
-            String inputChoiceText,
-            StateTransition stateTransition,
-            String storyText,
-            String choicesJson,
-            ImageAssetService.AssetReference imageAsset
-    ) {
+    public GameTurnCommit(int expectedTurn, int inputChoiceId, String inputChoiceText, StateTransition stateTransition,
+            String storyText, String choicesJson, String canonicalResultId, String generatedStoryId,
+            ImageAssetService.AssetReference imageAsset) {
         this(expectedTurn, inputChoiceId, inputChoiceText, stateTransition, storyText, choicesJson,
-                null, null, imageAsset);
+                canonicalResultId, generatedStoryId, null, imageAsset);
     }
 
-    public GameTurnCommit(
-            int expectedTurn,
-            int inputChoiceId,
-            String inputChoiceText,
-            GameState previousState,
-            GameState nextState,
-            String storyText,
-            String choicesJson,
-            ImageAssetService.AssetReference imageAsset
-    ) {
+    public GameTurnCommit(int expectedTurn, int inputChoiceId, String inputChoiceText, StateTransition stateTransition,
+            String storyText, String choicesJson, ImageAssetService.AssetReference imageAsset) {
+        this(expectedTurn, inputChoiceId, inputChoiceText, stateTransition, storyText, choicesJson,
+                null, null, null, imageAsset);
+    }
+
+    public GameTurnCommit(int expectedTurn, int inputChoiceId, String inputChoiceText, GameState previousState,
+            GameState nextState, String storyText, String choicesJson, ImageAssetService.AssetReference imageAsset) {
         this(expectedTurn, inputChoiceId, inputChoiceText, new StateTransition(previousState, nextState),
-                storyText, choicesJson, null, null, imageAsset);
+                storyText, choicesJson, null, null, null, imageAsset);
     }
 
-    public GameState previousState() {
-        return stateTransition.previousState();
-    }
-
-    public GameState nextState() {
-        return stateTransition.nextState();
-    }
-
-    public int previousStateVersion() {
-        return previousState().turnNumber();
-    }
-
-    public int nextStateVersion() {
-        return nextState().turnNumber();
-    }
-
-    public boolean hasNarrativeLink() {
-        return canonicalResultId != null;
-    }
+    public GameState previousState() { return stateTransition.previousState(); }
+    public GameState nextState() { return stateTransition.nextState(); }
+    public int previousStateVersion() { return previousState().turnNumber(); }
+    public int nextStateVersion() { return nextState().turnNumber(); }
+    public boolean hasNarrativeLink() { return canonicalResultId != null; }
+    public boolean hasSkillCheck() { return skillCheckResult != null; }
 
     private static void validateLinkId(String name, String value) {
         if (value == null) return;
-        if (value.isBlank() || value.length() > MAX_LINK_ID_LENGTH) {
-            throw new IllegalArgumentException(name + "가 올바르지 않습니다.");
-        }
+        if (value.isBlank() || value.length() > MAX_LINK_ID_LENGTH) throw new IllegalArgumentException(name + "가 올바르지 않습니다.");
     }
 }

--- a/src/main/java/com/uctale/uctale/application/game/SkillCheckDecisionService.java
+++ b/src/main/java/com/uctale/uctale/application/game/SkillCheckDecisionService.java
@@ -1,0 +1,133 @@
+package com.uctale.uctale.application.game;
+
+import com.uctale.uctale.domain.game.SkillCheckOutcome;
+import com.uctale.uctale.domain.game.SkillCheckResult;
+import com.uctale.uctale.domain.game.StatType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+@Service
+public class SkillCheckDecisionService {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final Clock clock;
+
+    public SkillCheckDecisionService(JdbcTemplate jdbcTemplate, Clock clock) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public SkillCheckResult getOrCreate(
+            Long requestId,
+            String reservationOwner,
+            Supplier<SkillCheckResult> decisionFactory
+    ) {
+        if (requestId == null || reservationOwner == null || reservationOwner.isBlank()) {
+            throw new IllegalArgumentException("Skill Check 판정에는 유효한 reservation 소유권이 필요합니다.");
+        }
+        Objects.requireNonNull(decisionFactory, "decisionFactory는 필수입니다.");
+        LocalDateTime now = LocalDateTime.now(clock);
+        List<StoredDecision> decisions = jdbcTemplate.query(
+                """
+                        SELECT skill_check_stat_type, skill_check_raw_roll, skill_check_stat_modifier,
+                               skill_check_situational_modifier, skill_check_dc, skill_check_total,
+                               skill_check_outcome, skill_check_ruleset_version
+                        FROM game_turn_reservation
+                        WHERE request_id = ? AND lease_owner = ? AND lease_expires_at > ?
+                        FOR UPDATE
+                        """,
+                (rs, rowNum) -> new StoredDecision(
+                        rs.getString("skill_check_stat_type"),
+                        nullableInt(rs, "skill_check_raw_roll"),
+                        nullableInt(rs, "skill_check_stat_modifier"),
+                        nullableInt(rs, "skill_check_situational_modifier"),
+                        nullableInt(rs, "skill_check_dc"),
+                        nullableInt(rs, "skill_check_total"),
+                        rs.getString("skill_check_outcome"),
+                        nullableInt(rs, "skill_check_ruleset_version")
+                ),
+                requestId, reservationOwner, now
+        );
+        if (decisions.isEmpty()) {
+            throw new TurnConflictException("턴 reservation이 만료되었거나 회수되었습니다.");
+        }
+
+        StoredDecision stored = decisions.getFirst();
+        if (stored.isComplete()) {
+            return stored.toDomain();
+        }
+        if (!stored.isEmpty()) {
+            throw new IllegalStateException("저장된 Skill Check 판정이 부분적으로 손상되었습니다.");
+        }
+
+        SkillCheckResult created = Objects.requireNonNull(decisionFactory.get(), "SkillCheckResult는 필수입니다.");
+        int updated = jdbcTemplate.update(
+                """
+                        UPDATE game_turn_reservation
+                        SET skill_check_stat_type = ?, skill_check_raw_roll = ?, skill_check_stat_modifier = ?,
+                            skill_check_situational_modifier = ?, skill_check_dc = ?, skill_check_total = ?,
+                            skill_check_outcome = ?, skill_check_ruleset_version = ?, updated_at = CURRENT_TIMESTAMP
+                        WHERE request_id = ? AND lease_owner = ? AND lease_expires_at > ?
+                          AND skill_check_stat_type IS NULL
+                        """,
+                created.statType().name(), created.rawRoll(), created.statModifier(),
+                created.situationalModifier(), created.dc(), created.total(), created.outcome().name(),
+                created.rulesetVersion(), requestId, reservationOwner, now
+        );
+        if (updated != 1) {
+            throw new TurnConflictException("Skill Check 판정을 reservation에 확정할 수 없습니다.");
+        }
+        return created;
+    }
+
+    private static Integer nullableInt(java.sql.ResultSet rs, String column) throws java.sql.SQLException {
+        int value = rs.getInt(column);
+        return rs.wasNull() ? null : value;
+    }
+
+    private record StoredDecision(
+            String statType,
+            Integer rawRoll,
+            Integer statModifier,
+            Integer situationalModifier,
+            Integer dc,
+            Integer total,
+            String outcome,
+            Integer rulesetVersion
+    ) {
+        private boolean isEmpty() {
+            return statType == null && rawRoll == null && statModifier == null && situationalModifier == null
+                    && dc == null && total == null && outcome == null && rulesetVersion == null;
+        }
+
+        private boolean isComplete() {
+            return statType != null && rawRoll != null && statModifier != null && situationalModifier != null
+                    && dc != null && total != null && outcome != null && rulesetVersion != null;
+        }
+
+        private SkillCheckResult toDomain() {
+            try {
+                return new SkillCheckResult(
+                        StatType.valueOf(statType),
+                        rawRoll,
+                        statModifier,
+                        situationalModifier,
+                        dc,
+                        total,
+                        SkillCheckOutcome.valueOf(outcome),
+                        rulesetVersion
+                );
+            } catch (RuntimeException exception) {
+                throw new IllegalStateException("저장된 Skill Check 판정이 현재 규칙과 일치하지 않습니다.", exception);
+            }
+        }
+    }
+}

--- a/src/main/java/com/uctale/uctale/application/game/SkillCheckDecisionService.java
+++ b/src/main/java/com/uctale/uctale/application/game/SkillCheckDecisionService.java
@@ -37,14 +37,15 @@ public class SkillCheckDecisionService {
         LocalDateTime now = LocalDateTime.now(clock);
         List<StoredDecision> decisions = jdbcTemplate.query(
                 """
-                        SELECT skill_check_stat_type, skill_check_raw_roll, skill_check_stat_modifier,
-                               skill_check_situational_modifier, skill_check_dc, skill_check_total,
-                               skill_check_outcome, skill_check_ruleset_version
+                        SELECT skill_check_request_id, skill_check_stat_type, skill_check_raw_roll,
+                               skill_check_stat_modifier, skill_check_situational_modifier, skill_check_dc,
+                               skill_check_total, skill_check_outcome, skill_check_ruleset_version
                         FROM game_turn_reservation
                         WHERE request_id = ? AND lease_owner = ? AND lease_expires_at > ?
                         FOR UPDATE
                         """,
                 (rs, rowNum) -> new StoredDecision(
+                        nullableLong(rs, "skill_check_request_id"),
                         rs.getString("skill_check_stat_type"),
                         nullableInt(rs, "skill_check_raw_roll"),
                         nullableInt(rs, "skill_check_stat_modifier"),
@@ -61,10 +62,10 @@ public class SkillCheckDecisionService {
         }
 
         StoredDecision stored = decisions.getFirst();
-        if (stored.isComplete()) {
+        if (stored.isComplete() && requestId.equals(stored.requestId())) {
             return stored.toDomain();
         }
-        if (!stored.isEmpty()) {
+        if (!stored.isEmpty() && !stored.isComplete()) {
             throw new IllegalStateException("저장된 Skill Check 판정이 부분적으로 손상되었습니다.");
         }
 
@@ -72,13 +73,13 @@ public class SkillCheckDecisionService {
         int updated = jdbcTemplate.update(
                 """
                         UPDATE game_turn_reservation
-                        SET skill_check_stat_type = ?, skill_check_raw_roll = ?, skill_check_stat_modifier = ?,
-                            skill_check_situational_modifier = ?, skill_check_dc = ?, skill_check_total = ?,
-                            skill_check_outcome = ?, skill_check_ruleset_version = ?, updated_at = CURRENT_TIMESTAMP
+                        SET skill_check_request_id = ?, skill_check_stat_type = ?, skill_check_raw_roll = ?,
+                            skill_check_stat_modifier = ?, skill_check_situational_modifier = ?, skill_check_dc = ?,
+                            skill_check_total = ?, skill_check_outcome = ?, skill_check_ruleset_version = ?,
+                            updated_at = CURRENT_TIMESTAMP
                         WHERE request_id = ? AND lease_owner = ? AND lease_expires_at > ?
-                          AND skill_check_stat_type IS NULL
                         """,
-                created.statType().name(), created.rawRoll(), created.statModifier(),
+                requestId, created.statType().name(), created.rawRoll(), created.statModifier(),
                 created.situationalModifier(), created.dc(), created.total(), created.outcome().name(),
                 created.rulesetVersion(), requestId, reservationOwner, now
         );
@@ -93,7 +94,13 @@ public class SkillCheckDecisionService {
         return rs.wasNull() ? null : value;
     }
 
+    private static Long nullableLong(java.sql.ResultSet rs, String column) throws java.sql.SQLException {
+        long value = rs.getLong(column);
+        return rs.wasNull() ? null : value;
+    }
+
     private record StoredDecision(
+            Long requestId,
             String statType,
             Integer rawRoll,
             Integer statModifier,
@@ -104,26 +111,22 @@ public class SkillCheckDecisionService {
             Integer rulesetVersion
     ) {
         private boolean isEmpty() {
-            return statType == null && rawRoll == null && statModifier == null && situationalModifier == null
-                    && dc == null && total == null && outcome == null && rulesetVersion == null;
+            return requestId == null && statType == null && rawRoll == null && statModifier == null
+                    && situationalModifier == null && dc == null && total == null && outcome == null
+                    && rulesetVersion == null;
         }
 
         private boolean isComplete() {
-            return statType != null && rawRoll != null && statModifier != null && situationalModifier != null
-                    && dc != null && total != null && outcome != null && rulesetVersion != null;
+            return requestId != null && statType != null && rawRoll != null && statModifier != null
+                    && situationalModifier != null && dc != null && total != null && outcome != null
+                    && rulesetVersion != null;
         }
 
         private SkillCheckResult toDomain() {
             try {
                 return new SkillCheckResult(
-                        StatType.valueOf(statType),
-                        rawRoll,
-                        statModifier,
-                        situationalModifier,
-                        dc,
-                        total,
-                        SkillCheckOutcome.valueOf(outcome),
-                        rulesetVersion
+                        StatType.valueOf(statType), rawRoll, statModifier, situationalModifier, dc, total,
+                        SkillCheckOutcome.valueOf(outcome), rulesetVersion
                 );
             } catch (RuntimeException exception) {
                 throw new IllegalStateException("저장된 Skill Check 판정이 현재 규칙과 일치하지 않습니다.", exception);

--- a/src/main/java/com/uctale/uctale/application/game/TurnProcessor.java
+++ b/src/main/java/com/uctale/uctale/application/game/TurnProcessor.java
@@ -3,15 +3,55 @@ package com.uctale.uctale.application.game;
 import com.uctale.uctale.domain.action.PlayerAction;
 import com.uctale.uctale.domain.game.ActionResolver;
 import com.uctale.uctale.domain.game.GameState;
+import com.uctale.uctale.domain.game.RandomSource;
+import com.uctale.uctale.domain.game.SkillCheckResult;
 import com.uctale.uctale.domain.game.StateTransition;
 import com.uctale.uctale.domain.game.TurnResolution;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
+@Component
 public final class TurnProcessor {
 
-    private final ActionResolver actionResolver = new ActionResolver();
+    private final ActionResolver actionResolver;
+    private final SkillCheckDecisionService skillCheckDecisionService;
+    private final RandomSource randomSource;
+
+    public TurnProcessor() {
+        this.actionResolver = new ActionResolver();
+        this.skillCheckDecisionService = null;
+        this.randomSource = null;
+    }
+
+    @Autowired
+    public TurnProcessor(SkillCheckDecisionService skillCheckDecisionService, RandomSource randomSource) {
+        this.actionResolver = new ActionResolver();
+        this.skillCheckDecisionService = skillCheckDecisionService;
+        this.randomSource = randomSource;
+    }
 
     public TurnResolution resolve(GameState state, PlayerAction action) {
         return actionResolver.resolve(state, action);
+    }
+
+    public TurnResolution resolve(
+            GameState state,
+            PlayerAction action,
+            Long requestId,
+            String reservationOwner
+    ) {
+        if (!actionResolver.requiresSkillCheck(action)) {
+            return actionResolver.resolve(state, action);
+        }
+        if (skillCheckDecisionService == null || randomSource == null) {
+            throw new IllegalStateException("Skill Check turn processor가 persistence/random source와 연결되지 않았습니다.");
+        }
+        SkillCheckResult result = skillCheckDecisionService.getOrCreate(
+                requestId,
+                reservationOwner,
+                () -> actionResolver.rollSkillCheck(state, action, randomSource)
+        );
+        return actionResolver.resolve(state, action, result);
     }
 
     public StateTransition attachNarrative(TurnResolution resolution, String storyText) {

--- a/src/main/java/com/uctale/uctale/application/narrative/NarrativeContext.java
+++ b/src/main/java/com/uctale/uctale/application/narrative/NarrativeContext.java
@@ -37,7 +37,9 @@ public record NarrativeContext(
     );
 
     public NarrativeContext {
-        if (canonicalResultId == null || canonicalResultId.isBlank()) throw new IllegalArgumentException("canonicalResultId는 필수입니다.");
+        if (canonicalResultId == null || canonicalResultId.isBlank()) {
+            throw new IllegalArgumentException("canonicalResultId는 필수입니다.");
+        }
         Objects.requireNonNull(resolvedAction, "resolvedAction은 필수입니다.");
         Objects.requireNonNull(outcome, "outcome은 필수입니다.");
         resultCanonicalFacts = resultCanonicalFacts == null ? List.of() : List.copyOf(resultCanonicalFacts);
@@ -46,7 +48,9 @@ public record NarrativeContext(
         Objects.requireNonNull(state, "state projection은 필수입니다.");
         Objects.requireNonNull(memory, "memory projection은 필수입니다.");
         narrativeCues = narrativeCues == null ? List.of() : List.copyOf(narrativeCues);
-        forbiddenCanonicalMutations = forbiddenCanonicalMutations == null ? CANONICAL_MUTATION_GUARDRAILS : List.copyOf(forbiddenCanonicalMutations);
+        forbiddenCanonicalMutations = forbiddenCanonicalMutations == null
+                ? CANONICAL_MUTATION_GUARDRAILS
+                : List.copyOf(forbiddenCanonicalMutations);
     }
 
     public static NarrativeContext from(String canonicalResultId, TurnResolution resolution) {
@@ -68,31 +72,69 @@ public record NarrativeContext(
         );
     }
 
-    public String playerAction() { return resolvedAction.displayText(); }
+    public String playerAction() {
+        return resolvedAction.displayText();
+    }
 
-    public record ResolvedAction(int legacyChoiceId, ActionType type, int sourceTurn, Map<String, String> arguments, String displayText) {
+    public record ResolvedAction(
+            int legacyChoiceId,
+            ActionType type,
+            int sourceTurn,
+            Map<String, String> arguments,
+            String displayText
+    ) {
         public ResolvedAction {
-            if (legacyChoiceId < 1 || sourceTurn < 1) throw new IllegalArgumentException("resolved action 식별자가 올바르지 않습니다.");
+            if (legacyChoiceId < 1 || sourceTurn < 1) {
+                throw new IllegalArgumentException("resolved action 식별자가 올바르지 않습니다.");
+            }
             Objects.requireNonNull(type, "action type은 필수입니다.");
             arguments = arguments == null ? Map.of() : Map.copyOf(arguments);
             displayText = displayText == null ? "" : displayText;
         }
+
         private static ResolvedAction from(PlayerAction action) {
-            return new ResolvedAction(action.legacyChoiceId(), action.type(), action.sourceTurn(), action.arguments(), action.displayText());
+            return new ResolvedAction(
+                    action.legacyChoiceId(),
+                    action.type(),
+                    action.sourceTurn(),
+                    action.arguments(),
+                    action.displayText()
+            );
         }
     }
 
-    public record SkillCheckProjection(StatType statType, int rawRoll, int statModifier, int situationalModifier,
-            int dc, int total, SkillCheckOutcome outcome, int rulesetVersion) {
+    public record SkillCheckProjection(
+            StatType statType,
+            int rawRoll,
+            int statModifier,
+            int situationalModifier,
+            int dc,
+            int total,
+            SkillCheckOutcome outcome,
+            int rulesetVersion
+    ) {
         private static SkillCheckProjection from(SkillCheckResult result) {
             if (result == null) return null;
-            return new SkillCheckProjection(result.statType(), result.rawRoll(), result.statModifier(),
-                    result.situationalModifier(), result.dc(), result.total(), result.outcome(), result.rulesetVersion());
+            return new SkillCheckProjection(
+                    result.statType(),
+                    result.rawRoll(),
+                    result.statModifier(),
+                    result.situationalModifier(),
+                    result.dc(),
+                    result.total(),
+                    result.outcome(),
+                    result.rulesetVersion()
+            );
         }
     }
 
-    public record StateProjection(int turnNumber, String worldPremise, String playerDescription,
-            CharacterStats playerStats, Map<String, String> worldFlags) {
+    public record StateProjection(
+            int turnNumber,
+            String worldPremise,
+            String playerDescription,
+            CharacterStats playerStats,
+            Map<String, String> worldFlags
+    ) {
         public StateProjection {
             if (turnNumber < 1) throw new IllegalArgumentException("turnNumber는 1 이상이어야 합니다.");
             worldPremise = worldPremise == null ? "" : worldPremise;
@@ -100,20 +142,35 @@ public record NarrativeContext(
             Objects.requireNonNull(playerStats, "playerStats는 필수입니다.");
             worldFlags = worldFlags == null ? Map.of() : Map.copyOf(worldFlags);
         }
+
         private static StateProjection from(GameState state) {
-            return new StateProjection(state.turnNumber(), state.worldState().premise(),
-                    state.playerCharacter().description(), state.playerCharacter().stats(), state.worldState().flags());
+            return new StateProjection(
+                    state.turnNumber(),
+                    state.worldState().premise(),
+                    state.playerCharacter().description(),
+                    state.playerCharacter().stats(),
+                    state.worldState().flags()
+            );
         }
     }
 
-    public record MemoryProjection(List<CanonicalFact> canonicalFacts, String rollingSummary, List<GameTurn> recentTurns) {
+    public record MemoryProjection(
+            List<CanonicalFact> canonicalFacts,
+            String rollingSummary,
+            List<GameTurn> recentTurns
+    ) {
         public MemoryProjection {
             canonicalFacts = canonicalFacts == null ? List.of() : List.copyOf(canonicalFacts);
             rollingSummary = rollingSummary == null ? "" : rollingSummary;
             recentTurns = recentTurns == null ? List.of() : List.copyOf(recentTurns);
         }
+
         private static MemoryProjection from(GameState state) {
-            return new MemoryProjection(state.storyMemory().canonicalFacts(), state.storyMemory().rollingSummary(), state.storyMemory().recentTurns());
+            return new MemoryProjection(
+                    state.storyMemory().canonicalFacts(),
+                    state.storyMemory().rollingSummary(),
+                    state.storyMemory().recentTurns()
+            );
         }
     }
 }

--- a/src/main/java/com/uctale/uctale/application/narrative/NarrativeContext.java
+++ b/src/main/java/com/uctale/uctale/application/narrative/NarrativeContext.java
@@ -7,6 +7,9 @@ import com.uctale.uctale.domain.game.CharacterStats;
 import com.uctale.uctale.domain.game.GameResult;
 import com.uctale.uctale.domain.game.GameState;
 import com.uctale.uctale.domain.game.GameTurn;
+import com.uctale.uctale.domain.game.SkillCheckOutcome;
+import com.uctale.uctale.domain.game.SkillCheckResult;
+import com.uctale.uctale.domain.game.StatType;
 import com.uctale.uctale.domain.game.TurnResolution;
 
 import java.util.List;
@@ -17,6 +20,7 @@ public record NarrativeContext(
         String canonicalResultId,
         ResolvedAction resolvedAction,
         GameResult.Outcome outcome,
+        SkillCheckProjection skillCheck,
         List<CanonicalFact> resultCanonicalFacts,
         List<GameResult.GameEvent> events,
         List<GameResult.StateChange> stateChanges,
@@ -33,9 +37,7 @@ public record NarrativeContext(
     );
 
     public NarrativeContext {
-        if (canonicalResultId == null || canonicalResultId.isBlank()) {
-            throw new IllegalArgumentException("canonicalResultId는 필수입니다.");
-        }
+        if (canonicalResultId == null || canonicalResultId.isBlank()) throw new IllegalArgumentException("canonicalResultId는 필수입니다.");
         Objects.requireNonNull(resolvedAction, "resolvedAction은 필수입니다.");
         Objects.requireNonNull(outcome, "outcome은 필수입니다.");
         resultCanonicalFacts = resultCanonicalFacts == null ? List.of() : List.copyOf(resultCanonicalFacts);
@@ -44,9 +46,7 @@ public record NarrativeContext(
         Objects.requireNonNull(state, "state projection은 필수입니다.");
         Objects.requireNonNull(memory, "memory projection은 필수입니다.");
         narrativeCues = narrativeCues == null ? List.of() : List.copyOf(narrativeCues);
-        forbiddenCanonicalMutations = forbiddenCanonicalMutations == null
-                ? CANONICAL_MUTATION_GUARDRAILS
-                : List.copyOf(forbiddenCanonicalMutations);
+        forbiddenCanonicalMutations = forbiddenCanonicalMutations == null ? CANONICAL_MUTATION_GUARDRAILS : List.copyOf(forbiddenCanonicalMutations);
     }
 
     public static NarrativeContext from(String canonicalResultId, TurnResolution resolution) {
@@ -57,6 +57,7 @@ public record NarrativeContext(
                 canonicalResultId,
                 ResolvedAction.from(result.resolvedAction()),
                 result.outcome(),
+                SkillCheckProjection.from(result.skillCheckResult()),
                 result.canonicalFacts(),
                 result.events(),
                 result.stateChanges(),
@@ -67,44 +68,31 @@ public record NarrativeContext(
         );
     }
 
-    public String playerAction() {
-        return resolvedAction.displayText();
-    }
+    public String playerAction() { return resolvedAction.displayText(); }
 
-    public record ResolvedAction(
-            int legacyChoiceId,
-            ActionType type,
-            int sourceTurn,
-            Map<String, String> arguments,
-            String displayText
-    ) {
+    public record ResolvedAction(int legacyChoiceId, ActionType type, int sourceTurn, Map<String, String> arguments, String displayText) {
         public ResolvedAction {
-            if (legacyChoiceId < 1 || sourceTurn < 1) {
-                throw new IllegalArgumentException("resolved action 식별자가 올바르지 않습니다.");
-            }
+            if (legacyChoiceId < 1 || sourceTurn < 1) throw new IllegalArgumentException("resolved action 식별자가 올바르지 않습니다.");
             Objects.requireNonNull(type, "action type은 필수입니다.");
             arguments = arguments == null ? Map.of() : Map.copyOf(arguments);
             displayText = displayText == null ? "" : displayText;
         }
-
         private static ResolvedAction from(PlayerAction action) {
-            return new ResolvedAction(
-                    action.legacyChoiceId(),
-                    action.type(),
-                    action.sourceTurn(),
-                    action.arguments(),
-                    action.displayText()
-            );
+            return new ResolvedAction(action.legacyChoiceId(), action.type(), action.sourceTurn(), action.arguments(), action.displayText());
         }
     }
 
-    public record StateProjection(
-            int turnNumber,
-            String worldPremise,
-            String playerDescription,
-            CharacterStats playerStats,
-            Map<String, String> worldFlags
-    ) {
+    public record SkillCheckProjection(StatType statType, int rawRoll, int statModifier, int situationalModifier,
+            int dc, int total, SkillCheckOutcome outcome, int rulesetVersion) {
+        private static SkillCheckProjection from(SkillCheckResult result) {
+            if (result == null) return null;
+            return new SkillCheckProjection(result.statType(), result.rawRoll(), result.statModifier(),
+                    result.situationalModifier(), result.dc(), result.total(), result.outcome(), result.rulesetVersion());
+        }
+    }
+
+    public record StateProjection(int turnNumber, String worldPremise, String playerDescription,
+            CharacterStats playerStats, Map<String, String> worldFlags) {
         public StateProjection {
             if (turnNumber < 1) throw new IllegalArgumentException("turnNumber는 1 이상이어야 합니다.");
             worldPremise = worldPremise == null ? "" : worldPremise;
@@ -112,35 +100,20 @@ public record NarrativeContext(
             Objects.requireNonNull(playerStats, "playerStats는 필수입니다.");
             worldFlags = worldFlags == null ? Map.of() : Map.copyOf(worldFlags);
         }
-
         private static StateProjection from(GameState state) {
-            return new StateProjection(
-                    state.turnNumber(),
-                    state.worldState().premise(),
-                    state.playerCharacter().description(),
-                    state.playerCharacter().stats(),
-                    state.worldState().flags()
-            );
+            return new StateProjection(state.turnNumber(), state.worldState().premise(),
+                    state.playerCharacter().description(), state.playerCharacter().stats(), state.worldState().flags());
         }
     }
 
-    public record MemoryProjection(
-            List<CanonicalFact> canonicalFacts,
-            String rollingSummary,
-            List<GameTurn> recentTurns
-    ) {
+    public record MemoryProjection(List<CanonicalFact> canonicalFacts, String rollingSummary, List<GameTurn> recentTurns) {
         public MemoryProjection {
             canonicalFacts = canonicalFacts == null ? List.of() : List.copyOf(canonicalFacts);
             rollingSummary = rollingSummary == null ? "" : rollingSummary;
             recentTurns = recentTurns == null ? List.of() : List.copyOf(recentTurns);
         }
-
         private static MemoryProjection from(GameState state) {
-            return new MemoryProjection(
-                    state.storyMemory().canonicalFacts(),
-                    state.storyMemory().rollingSummary(),
-                    state.storyMemory().recentTurns()
-            );
+            return new MemoryProjection(state.storyMemory().canonicalFacts(), state.storyMemory().rollingSummary(), state.storyMemory().recentTurns());
         }
     }
 }

--- a/src/main/java/com/uctale/uctale/domain/GameLog.java
+++ b/src/main/java/com/uctale/uctale/domain/GameLog.java
@@ -1,5 +1,6 @@
 package com.uctale.uctale.domain;
 
+import com.uctale.uctale.domain.game.SkillCheckResult;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -59,6 +60,30 @@ public class GameLog {
     @Column(name = "generated_story_id", length = 128)
     private String generatedStoryId;
 
+    @Column(name = "skill_check_stat_type", length = 32)
+    private String skillCheckStatType;
+
+    @Column(name = "skill_check_raw_roll")
+    private Integer skillCheckRawRoll;
+
+    @Column(name = "skill_check_stat_modifier")
+    private Integer skillCheckStatModifier;
+
+    @Column(name = "skill_check_situational_modifier")
+    private Integer skillCheckSituationalModifier;
+
+    @Column(name = "skill_check_dc")
+    private Integer skillCheckDc;
+
+    @Column(name = "skill_check_total")
+    private Integer skillCheckTotal;
+
+    @Column(name = "skill_check_outcome", length = 16)
+    private String skillCheckOutcome;
+
+    @Column(name = "skill_check_ruleset_version")
+    private Integer skillCheckRulesetVersion;
+
     @Column(columnDefinition = "TEXT")
     private String storyText;
 
@@ -72,85 +97,35 @@ public class GameLog {
     @Column(name = "created_at")
     private LocalDateTime committedAt;
 
-    public static GameLog opening(
-            GameSession gameSession,
-            String storyText,
-            String choicesJson,
-            String imageUrl
-    ) {
-        return new GameLog(
-                gameSession,
-                1,
-                null,
-                null,
-                0,
-                1,
-                null,
-                null,
-                storyText,
-                choicesJson,
-                imageUrl
-        );
+    public static GameLog opening(GameSession gameSession, String storyText, String choicesJson, String imageUrl) {
+        return new GameLog(gameSession, 1, null, null, 0, 1, null, null, null, storyText, choicesJson, imageUrl);
     }
 
-    public static GameLog committedTurn(
-            GameSession gameSession,
-            int turnNumber,
-            int inputChoiceId,
-            String inputChoiceText,
-            int previousStateVersion,
-            int stateVersion,
-            String storyText,
-            String choicesJson,
-            String imageUrl
-    ) {
-        return committedTurn(
-                gameSession, turnNumber, inputChoiceId, inputChoiceText, previousStateVersion, stateVersion,
-                null, null, storyText, choicesJson, imageUrl
-        );
+    public static GameLog committedTurn(GameSession gameSession, int turnNumber, int inputChoiceId,
+            String inputChoiceText, int previousStateVersion, int stateVersion, String storyText,
+            String choicesJson, String imageUrl) {
+        return committedTurn(gameSession, turnNumber, inputChoiceId, inputChoiceText, previousStateVersion,
+                stateVersion, null, null, null, storyText, choicesJson, imageUrl);
     }
 
-    public static GameLog committedTurn(
-            GameSession gameSession,
-            int turnNumber,
-            int inputChoiceId,
-            String inputChoiceText,
-            int previousStateVersion,
-            int stateVersion,
-            String canonicalResultId,
-            String generatedStoryId,
-            String storyText,
-            String choicesJson,
-            String imageUrl
-    ) {
-        return new GameLog(
-                gameSession,
-                turnNumber,
-                inputChoiceId,
-                inputChoiceText,
-                previousStateVersion,
-                stateVersion,
-                canonicalResultId,
-                generatedStoryId,
-                storyText,
-                choicesJson,
-                imageUrl
-        );
+    public static GameLog committedTurn(GameSession gameSession, int turnNumber, int inputChoiceId,
+            String inputChoiceText, int previousStateVersion, int stateVersion, String canonicalResultId,
+            String generatedStoryId, String storyText, String choicesJson, String imageUrl) {
+        return committedTurn(gameSession, turnNumber, inputChoiceId, inputChoiceText, previousStateVersion,
+                stateVersion, canonicalResultId, generatedStoryId, null, storyText, choicesJson, imageUrl);
     }
 
-    private GameLog(
-            GameSession gameSession,
-            int turnNumber,
-            Integer inputChoiceId,
-            String inputChoiceText,
-            int previousStateVersion,
-            int stateVersion,
-            String canonicalResultId,
-            String generatedStoryId,
-            String storyText,
-            String choicesJson,
-            String imageUrl
-    ) {
+    public static GameLog committedTurn(GameSession gameSession, int turnNumber, int inputChoiceId,
+            String inputChoiceText, int previousStateVersion, int stateVersion, String canonicalResultId,
+            String generatedStoryId, SkillCheckResult skillCheckResult, String storyText, String choicesJson,
+            String imageUrl) {
+        return new GameLog(gameSession, turnNumber, inputChoiceId, inputChoiceText, previousStateVersion,
+                stateVersion, canonicalResultId, generatedStoryId, skillCheckResult, storyText, choicesJson, imageUrl);
+    }
+
+    private GameLog(GameSession gameSession, int turnNumber, Integer inputChoiceId, String inputChoiceText,
+            int previousStateVersion, int stateVersion, String canonicalResultId, String generatedStoryId,
+            SkillCheckResult skillCheckResult, String storyText, String choicesJson, String imageUrl) {
         this.gameSession = gameSession;
         this.turnNumber = turnNumber;
         this.inputChoiceId = inputChoiceId;
@@ -159,6 +134,16 @@ public class GameLog {
         this.stateVersion = stateVersion;
         this.canonicalResultId = canonicalResultId;
         this.generatedStoryId = generatedStoryId;
+        if (skillCheckResult != null) {
+            this.skillCheckStatType = skillCheckResult.statType().name();
+            this.skillCheckRawRoll = skillCheckResult.rawRoll();
+            this.skillCheckStatModifier = skillCheckResult.statModifier();
+            this.skillCheckSituationalModifier = skillCheckResult.situationalModifier();
+            this.skillCheckDc = skillCheckResult.dc();
+            this.skillCheckTotal = skillCheckResult.total();
+            this.skillCheckOutcome = skillCheckResult.outcome().name();
+            this.skillCheckRulesetVersion = skillCheckResult.rulesetVersion();
+        }
         this.storyText = storyText;
         this.choicesJson = choicesJson;
         this.imageUrl = imageUrl;

--- a/src/main/java/com/uctale/uctale/domain/GameLog.java
+++ b/src/main/java/com/uctale/uctale/domain/GameLog.java
@@ -97,35 +97,108 @@ public class GameLog {
     @Column(name = "created_at")
     private LocalDateTime committedAt;
 
-    public static GameLog opening(GameSession gameSession, String storyText, String choicesJson, String imageUrl) {
-        return new GameLog(gameSession, 1, null, null, 0, 1, null, null, null, storyText, choicesJson, imageUrl);
+    public static GameLog opening(
+            GameSession gameSession,
+            String storyText,
+            String choicesJson,
+            String imageUrl
+    ) {
+        return new GameLog(
+                gameSession,
+                1,
+                null,
+                null,
+                0,
+                1,
+                null,
+                null,
+                null,
+                storyText,
+                choicesJson,
+                imageUrl
+        );
     }
 
-    public static GameLog committedTurn(GameSession gameSession, int turnNumber, int inputChoiceId,
-            String inputChoiceText, int previousStateVersion, int stateVersion, String storyText,
-            String choicesJson, String imageUrl) {
-        return committedTurn(gameSession, turnNumber, inputChoiceId, inputChoiceText, previousStateVersion,
-                stateVersion, null, null, null, storyText, choicesJson, imageUrl);
+    public static GameLog committedTurn(
+            GameSession gameSession,
+            int turnNumber,
+            int inputChoiceId,
+            String inputChoiceText,
+            int previousStateVersion,
+            int stateVersion,
+            String storyText,
+            String choicesJson,
+            String imageUrl
+    ) {
+        return committedTurn(
+                gameSession, turnNumber, inputChoiceId, inputChoiceText, previousStateVersion, stateVersion,
+                null, null, null, storyText, choicesJson, imageUrl
+        );
     }
 
-    public static GameLog committedTurn(GameSession gameSession, int turnNumber, int inputChoiceId,
-            String inputChoiceText, int previousStateVersion, int stateVersion, String canonicalResultId,
-            String generatedStoryId, String storyText, String choicesJson, String imageUrl) {
-        return committedTurn(gameSession, turnNumber, inputChoiceId, inputChoiceText, previousStateVersion,
-                stateVersion, canonicalResultId, generatedStoryId, null, storyText, choicesJson, imageUrl);
+    public static GameLog committedTurn(
+            GameSession gameSession,
+            int turnNumber,
+            int inputChoiceId,
+            String inputChoiceText,
+            int previousStateVersion,
+            int stateVersion,
+            String canonicalResultId,
+            String generatedStoryId,
+            String storyText,
+            String choicesJson,
+            String imageUrl
+    ) {
+        return committedTurn(
+                gameSession, turnNumber, inputChoiceId, inputChoiceText, previousStateVersion, stateVersion,
+                canonicalResultId, generatedStoryId, null, storyText, choicesJson, imageUrl
+        );
     }
 
-    public static GameLog committedTurn(GameSession gameSession, int turnNumber, int inputChoiceId,
-            String inputChoiceText, int previousStateVersion, int stateVersion, String canonicalResultId,
-            String generatedStoryId, SkillCheckResult skillCheckResult, String storyText, String choicesJson,
-            String imageUrl) {
-        return new GameLog(gameSession, turnNumber, inputChoiceId, inputChoiceText, previousStateVersion,
-                stateVersion, canonicalResultId, generatedStoryId, skillCheckResult, storyText, choicesJson, imageUrl);
+    public static GameLog committedTurn(
+            GameSession gameSession,
+            int turnNumber,
+            int inputChoiceId,
+            String inputChoiceText,
+            int previousStateVersion,
+            int stateVersion,
+            String canonicalResultId,
+            String generatedStoryId,
+            SkillCheckResult skillCheckResult,
+            String storyText,
+            String choicesJson,
+            String imageUrl
+    ) {
+        return new GameLog(
+                gameSession,
+                turnNumber,
+                inputChoiceId,
+                inputChoiceText,
+                previousStateVersion,
+                stateVersion,
+                canonicalResultId,
+                generatedStoryId,
+                skillCheckResult,
+                storyText,
+                choicesJson,
+                imageUrl
+        );
     }
 
-    private GameLog(GameSession gameSession, int turnNumber, Integer inputChoiceId, String inputChoiceText,
-            int previousStateVersion, int stateVersion, String canonicalResultId, String generatedStoryId,
-            SkillCheckResult skillCheckResult, String storyText, String choicesJson, String imageUrl) {
+    private GameLog(
+            GameSession gameSession,
+            int turnNumber,
+            Integer inputChoiceId,
+            String inputChoiceText,
+            int previousStateVersion,
+            int stateVersion,
+            String canonicalResultId,
+            String generatedStoryId,
+            SkillCheckResult skillCheckResult,
+            String storyText,
+            String choicesJson,
+            String imageUrl
+    ) {
         this.gameSession = gameSession;
         this.turnNumber = turnNumber;
         this.inputChoiceId = inputChoiceId;

--- a/src/main/java/com/uctale/uctale/domain/action/ActionType.java
+++ b/src/main/java/com/uctale/uctale/domain/action/ActionType.java
@@ -1,5 +1,6 @@
 package com.uctale.uctale.domain.action;
 
 public enum ActionType {
-    NARRATIVE_CHOICE
+    NARRATIVE_CHOICE,
+    SKILL_CHECK
 }

--- a/src/main/java/com/uctale/uctale/domain/game/ActionResolver.java
+++ b/src/main/java/com/uctale/uctale/domain/game/ActionResolver.java
@@ -3,33 +3,79 @@ package com.uctale.uctale.domain.game;
 import com.uctale.uctale.domain.action.ActionType;
 import com.uctale.uctale.domain.action.PlayerAction;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 public final class ActionResolver {
 
+    public boolean requiresSkillCheck(PlayerAction action) {
+        Objects.requireNonNull(action, "PlayerAction은 필수입니다.");
+        return action.type() == ActionType.SKILL_CHECK;
+    }
+
+    public SkillCheckResult rollSkillCheck(GameState state, PlayerAction action, RandomSource randomSource) {
+        validateBase(state, action);
+        if (action.type() != ActionType.SKILL_CHECK) {
+            throw new IllegalArgumentException("Skill Check가 필요하지 않은 action입니다.");
+        }
+        SkillCheck skillCheck = parseSkillCheck(action);
+        return skillCheck.resolve(state.playerCharacter().stats(), randomSource);
+    }
+
     public TurnResolution resolve(GameState state, PlayerAction action) {
+        validateBase(state, action);
+        if (action.type() == ActionType.SKILL_CHECK) {
+            throw new IllegalArgumentException("SKILL_CHECK action에는 서버가 확정한 SkillCheckResult가 필요합니다.");
+        }
+        validateNarrativeChoice(action);
+        return resolved(state, action, null);
+    }
+
+    public TurnResolution resolve(GameState state, PlayerAction action, SkillCheckResult skillCheckResult) {
+        validateBase(state, action);
+        if (action.type() != ActionType.SKILL_CHECK) {
+            if (skillCheckResult != null) {
+                throw new IllegalArgumentException("Skill Check가 아닌 action에 판정 결과를 연결할 수 없습니다.");
+            }
+            validateNarrativeChoice(action);
+            return resolved(state, action, null);
+        }
+        Objects.requireNonNull(skillCheckResult, "SkillCheckResult는 필수입니다.");
+        SkillCheck skillCheck = parseSkillCheck(action);
+        validateSkillCheckResult(state, skillCheck, skillCheckResult);
+        return resolved(state, action, skillCheckResult);
+    }
+
+    private TurnResolution resolved(GameState state, PlayerAction action, SkillCheckResult skillCheckResult) {
+        GameState nextState = state.advanceTurn();
+        List<GameResult.GameEvent> events = new ArrayList<>();
+        events.add(GameResult.GameEvent.ACTION_RESOLVED);
+        if (skillCheckResult != null) {
+            events.add(GameResult.GameEvent.SKILL_CHECK_RESOLVED);
+        }
+        GameResult result = new GameResult(
+                action,
+                GameResult.Outcome.RESOLVED,
+                skillCheckResult,
+                List.of(),
+                events,
+                List.of(new GameResult.TurnAdvanced(state.turnNumber(), nextState.turnNumber())),
+                List.of(action.displayText())
+        );
+        return new TurnResolution(result, new StateTransition(state, nextState));
+    }
+
+    private void validateBase(GameState state, PlayerAction action) {
         Objects.requireNonNull(state, "GameState는 필수입니다.");
         Objects.requireNonNull(action, "PlayerAction은 필수입니다.");
         if (action.sourceTurn() != state.turnNumber()) {
             throw new IllegalArgumentException("PlayerAction source turn이 현재 GameState와 일치하지 않습니다.");
         }
-        if (action.type() != ActionType.NARRATIVE_CHOICE) {
+        if (action.type() != ActionType.NARRATIVE_CHOICE && action.type() != ActionType.SKILL_CHECK) {
             throw new IllegalArgumentException("지원하지 않는 action type입니다: " + action.type());
         }
-        validateNarrativeChoice(action);
-
-        GameState nextState = state.advanceTurn();
-        GameResult result = new GameResult(
-                action,
-                GameResult.Outcome.RESOLVED,
-                List.of(),
-                List.of(GameResult.GameEvent.ACTION_RESOLVED),
-                List.of(new GameResult.TurnAdvanced(state.turnNumber(), nextState.turnNumber())),
-                List.of(action.displayText())
-        );
-        return new TurnResolution(result, new StateTransition(state, nextState));
     }
 
     private void validateNarrativeChoice(PlayerAction action) {
@@ -37,6 +83,38 @@ public final class ActionResolver {
         String choiceId = arguments.get("choiceId");
         if (arguments.size() != 1 || !Integer.toString(action.legacyChoiceId()).equals(choiceId)) {
             throw new IllegalArgumentException("NARRATIVE_CHOICE arguments가 action과 일치하지 않습니다.");
+        }
+    }
+
+    private SkillCheck parseSkillCheck(PlayerAction action) {
+        Map<String, String> arguments = action.arguments();
+        if (arguments.size() != 4
+                || !Integer.toString(action.legacyChoiceId()).equals(arguments.get("choiceId"))) {
+            throw new IllegalArgumentException("SKILL_CHECK arguments가 action과 일치하지 않습니다.");
+        }
+        try {
+            StatType statType = StatType.valueOf(arguments.get("statType"));
+            int dc = Integer.parseInt(arguments.get("dc"));
+            int situationalModifier = Integer.parseInt(arguments.get("situationalModifier"));
+            return new SkillCheck(statType, new Difficulty(dc), situationalModifier);
+        } catch (RuntimeException exception) {
+            throw new IllegalArgumentException("SKILL_CHECK arguments가 올바르지 않습니다.", exception);
+        }
+    }
+
+    private void validateSkillCheckResult(
+            GameState state,
+            SkillCheck skillCheck,
+            SkillCheckResult result
+    ) {
+        if (result.statType() != skillCheck.statType()
+                || result.dc() != skillCheck.difficulty().dc()
+                || result.situationalModifier() != skillCheck.situationalModifier()) {
+            throw new IllegalArgumentException("저장된 Skill Check 결과가 action 규칙과 일치하지 않습니다.");
+        }
+        int expectedStatModifier = state.playerCharacter().stats().modifier(skillCheck.statType());
+        if (result.statModifier() != expectedStatModifier) {
+            throw new IllegalArgumentException("저장된 Skill Check 결과가 현재 canonical 능력치와 일치하지 않습니다.");
         }
     }
 }

--- a/src/main/java/com/uctale/uctale/domain/game/GameResult.java
+++ b/src/main/java/com/uctale/uctale/domain/game/GameResult.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 public record GameResult(
         PlayerAction resolvedAction,
         Outcome outcome,
+        SkillCheckResult skillCheckResult,
         List<CanonicalFact> canonicalFacts,
         List<GameEvent> events,
         List<StateChange> stateChanges,
@@ -22,12 +23,24 @@ public record GameResult(
         narrativeCues = narrativeCues == null ? List.of() : List.copyOf(narrativeCues);
     }
 
+    public GameResult(
+            PlayerAction resolvedAction,
+            Outcome outcome,
+            List<CanonicalFact> canonicalFacts,
+            List<GameEvent> events,
+            List<StateChange> stateChanges,
+            List<String> narrativeCues
+    ) {
+        this(resolvedAction, outcome, null, canonicalFacts, events, stateChanges, narrativeCues);
+    }
+
     public enum Outcome {
         RESOLVED
     }
 
     public enum GameEvent {
-        ACTION_RESOLVED
+        ACTION_RESOLVED,
+        SKILL_CHECK_RESOLVED
     }
 
     public sealed interface StateChange permits TurnAdvanced {}

--- a/src/main/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapter.java
+++ b/src/main/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapter.java
@@ -107,6 +107,7 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
 
                 [확정 게임 결과]
                 outcome: %s
+                skill check: %s
                 canonical facts: %s
                 events: %s
                 state changes: %s
@@ -130,6 +131,7 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
                 %s
 
                 위 확정 결과를 변경하거나 재판정하지 말고 그 결과가 드러나는 장면을 서술하세요.
+                Skill Check가 있으면 raw roll, modifier, DC, total, success/failure를 서버가 확정한 그대로 따르세요.
                 서버가 확정하지 않은 roll, 성공/실패, HP/능력치/아이템/레벨/위치/생사 변화를 새 사실로 만들지 마세요.
                 응답은 story 표현, 다음 choices 제안, 선택적 visual_assets만 포함합니다.
                 시각적 변화가 없다면 visual_assets를 비워두세요.
@@ -137,6 +139,7 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
                 context.canonicalResultId(),
                 objectMapper.writeValueAsString(context.resolvedAction()),
                 context.outcome(),
+                context.skillCheck() == null ? "(없음)" : objectMapper.writeValueAsString(context.skillCheck()),
                 objectMapper.writeValueAsString(context.resultCanonicalFacts()),
                 objectMapper.writeValueAsString(context.events()),
                 objectMapper.writeValueAsString(context.stateChanges()),
@@ -157,9 +160,7 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
                 .body(requestBody)
                 .retrieve()
                 .body(String.class);
-        if (response == null || response.isBlank()) {
-            throw new IllegalStateException(errorContext + ": empty response");
-        }
+        if (response == null || response.isBlank()) throw new IllegalStateException(errorContext + ": empty response");
         return parseResponse(response);
     }
 
@@ -173,13 +174,10 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
 
     private NarrativeTurn parseResponse(String rawResponse) throws JacksonException {
         GeminiApiResponse apiResponse = objectMapper.readValue(rawResponse, GeminiApiResponse.class);
-        if (apiResponse.candidates() == null || apiResponse.candidates().isEmpty()) {
-            throw new IllegalStateException("AI 응답이 비어있습니다.");
-        }
+        if (apiResponse.candidates() == null || apiResponse.candidates().isEmpty()) throw new IllegalStateException("AI 응답이 비어있습니다.");
 
         String jsonText = apiResponse.candidates().get(0).content().parts().get(0).text();
         JsonNode rootNode = objectMapper.readTree(jsonText);
-
         List<NarrativeTurn.Choice> choices = new ArrayList<>();
         JsonNode choicesNode = rootNode.path("choices");
         if (choicesNode.isArray()) {
@@ -213,9 +211,7 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
         if (node.isArray()) {
             for (JsonNode item : node) {
                 String value = item.asString();
-                if (value != null && !value.isBlank()) {
-                    values.add(value);
-                }
+                if (value != null && !value.isBlank()) values.add(value);
             }
         }
         return values;

--- a/src/main/java/com/uctale/uctale/service/GameService.java
+++ b/src/main/java/com/uctale/uctale/service/GameService.java
@@ -47,7 +47,7 @@ public class GameService {
     private final ImageAssetService imageAssetService;
     private final GamePersistenceService gamePersistenceService;
     private final ChoiceCodec choiceCodec;
-    private final TurnProcessor turnProcessor = new TurnProcessor();
+    private final TurnProcessor turnProcessor;
     private final ImagePromptComposer imagePromptComposer;
     private final CostRateLimiter costRateLimiter;
     private final ProviderCallTelemetry providerCallTelemetry;
@@ -63,9 +63,7 @@ public class GameService {
                 costContext.ownerKey(), GameMutationRequestService.INIT, costContext.idempotencyKey(), null, null,
                 mutationFingerprint.init(request)
         );
-        if (mutation.replay()) {
-            return replay(costContext.ownerKey(), mutation);
-        }
+        if (mutation.replay()) return replay(costContext.ownerKey(), mutation);
 
         try {
             costRateLimiter.check(CostOperation.NARRATIVE, costContext);
@@ -77,9 +75,7 @@ public class GameService {
             List<GameChoice> choices = choiceCodec.issue(opening.choices(), 1);
 
             String imagePrompt = imagePromptComposer.compose(opening.visualAssets());
-            if (imagePrompt == null || imagePrompt.isBlank()) {
-                imagePrompt = imagePromptComposer.composeFallback(request.worldSetting());
-            }
+            if (imagePrompt == null || imagePrompt.isBlank()) imagePrompt = imagePromptComposer.composeFallback(request.worldSetting());
             validateImagePrompt(imagePrompt);
             ImageAssetService.AssetReference imageAsset = imageAssetService.issue(imagePrompt, "16:9");
 
@@ -103,9 +99,7 @@ public class GameService {
                 costContext.ownerKey(), GameMutationRequestService.PROGRESS, costContext.idempotencyKey(),
                 request.sessionId(), request.expectedTurn(), mutationFingerprint.progress(request)
         );
-        if (mutation.replay()) {
-            return replay(costContext.ownerKey(), mutation);
-        }
+        if (mutation.replay()) return replay(costContext.ownerKey(), mutation);
 
         try {
             GamePersistenceService.LoadedTurn loadedTurn = gamePersistenceService.loadLatestTurn(
@@ -117,7 +111,9 @@ public class GameService {
             );
 
             PlayerAction playerAction = choiceCodec.resolve(loadedTurn.choicesJson(), request);
-            TurnResolution resolution = turnProcessor.resolve(loadedTurn.gameState(), playerAction);
+            TurnResolution resolution = turnProcessor.resolve(
+                    loadedTurn.gameState(), playerAction, mutation.requestId(), mutation.reservationOwner()
+            );
             String userChoiceText = resolution.gameResult().resolvedAction().displayText();
             String canonicalResultId = canonicalResultId(mutation.requestId(), loadedTurn.sessionId(),
                     resolution.stateTransition().nextState().turnNumber());
@@ -125,9 +121,7 @@ public class GameService {
             costRateLimiter.check(CostOperation.NARRATIVE, providerContext);
             NarrativeTurn nextTurn = providerCallTelemetry.observe(
                     "gemini", "progress", providerContext, 0,
-                    () -> mutationRequestService.markProviderAttemptStarted(
-                            mutation.requestId(), mutation.reservationOwner()
-                    ),
+                    () -> mutationRequestService.markProviderAttemptStarted(mutation.requestId(), mutation.reservationOwner()),
                     () -> narrativeGenerator.createNextTurn(narrativeContext)
             );
             validateNarrativeTurn(nextTurn);
@@ -150,7 +144,7 @@ public class GameService {
             GameTurnCommit commit = new GameTurnCommit(
                     request.expectedTurn(), resolution.gameResult().resolvedAction().legacyChoiceId(), userChoiceText,
                     committedTransition, nextTurn.storyText(), choiceCodec.serialize(choices),
-                    canonicalResultId, generatedStoryId, imageAsset
+                    canonicalResultId, generatedStoryId, resolution.gameResult().skillCheckResult(), imageAsset
             );
 
             int savedTurn = gamePersistenceService.saveNextTurn(
@@ -171,45 +165,29 @@ public class GameService {
         GamePersistenceService.CommittedTurn turn = gamePersistenceService.loadCommittedTurn(
                 ownerKey, mutation.resultSessionId(), mutation.resultTurn()
         );
-        return new GameResponse(
-                mutation.resultSessionId(), mutation.resultTurn(), mutation.resultTitle(), turn.storyText(),
-                choiceCodec.deserialize(turn.choicesJson()), turn.imageUrl()
-        );
+        return new GameResponse(mutation.resultSessionId(), mutation.resultTurn(), mutation.resultTitle(),
+                turn.storyText(), choiceCodec.deserialize(turn.choicesJson()), turn.imageUrl());
     }
 
     private String canonicalResultId(Long mutationRequestId, Long sessionId, int nextTurn) {
-        if (mutationRequestId == null || sessionId == null || nextTurn < 2) {
-            throw new IllegalArgumentException("canonical result link를 만들 수 없습니다.");
-        }
+        if (mutationRequestId == null || sessionId == null || nextTurn < 2) throw new IllegalArgumentException("canonical result link를 만들 수 없습니다.");
         return "game-result:%d:%d:%d".formatted(sessionId, nextTurn, mutationRequestId);
     }
 
     private void validateNarrativeTurn(NarrativeTurn turn) {
         if (turn == null) throw new InvalidNarrativeResponseException("Narrative 응답이 없습니다.");
-        if (turn.title() == null || turn.title().isBlank() || turn.title().length() > MAX_TITLE_LENGTH) {
-            throw new InvalidNarrativeResponseException("Narrative 제목이 올바르지 않습니다.");
-        }
-        if (turn.storyText() == null || turn.storyText().isBlank() || turn.storyText().length() > MAX_STORY_LENGTH) {
-            throw new InvalidNarrativeResponseException("Narrative 본문이 올바르지 않습니다.");
-        }
-        if (turn.choices() == null || turn.choices().isEmpty() || turn.choices().size() > MAX_CHOICES) {
-            throw new InvalidNarrativeResponseException("Narrative 선택지 수가 올바르지 않습니다.");
-        }
+        if (turn.title() == null || turn.title().isBlank() || turn.title().length() > MAX_TITLE_LENGTH) throw new InvalidNarrativeResponseException("Narrative 제목이 올바르지 않습니다.");
+        if (turn.storyText() == null || turn.storyText().isBlank() || turn.storyText().length() > MAX_STORY_LENGTH) throw new InvalidNarrativeResponseException("Narrative 본문이 올바르지 않습니다.");
+        if (turn.choices() == null || turn.choices().isEmpty() || turn.choices().size() > MAX_CHOICES) throw new InvalidNarrativeResponseException("Narrative 선택지 수가 올바르지 않습니다.");
         Set<Integer> choiceIds = new HashSet<>();
         for (NarrativeTurn.Choice choice : turn.choices()) {
-            if (choice == null || choice.id() <= 0 || !choiceIds.add(choice.id())) {
-                throw new InvalidNarrativeResponseException("Narrative 선택지 ID가 올바르지 않습니다.");
-            }
-            if (choice.text() == null || choice.text().isBlank() || choice.text().length() > MAX_CHOICE_TEXT_LENGTH) {
-                throw new InvalidNarrativeResponseException("Narrative 선택지 문구가 올바르지 않습니다.");
-            }
+            if (choice == null || choice.id() <= 0 || !choiceIds.add(choice.id())) throw new InvalidNarrativeResponseException("Narrative 선택지 ID가 올바르지 않습니다.");
+            if (choice.text() == null || choice.text().isBlank() || choice.text().length() > MAX_CHOICE_TEXT_LENGTH) throw new InvalidNarrativeResponseException("Narrative 선택지 문구가 올바르지 않습니다.");
         }
     }
 
     private void validateImagePrompt(String imagePrompt) {
-        if (imagePrompt != null && imagePrompt.length() > MAX_IMAGE_PROMPT_LENGTH) {
-            throw new InvalidNarrativeResponseException("이미지 prompt가 너무 깁니다.");
-        }
+        if (imagePrompt != null && imagePrompt.length() > MAX_IMAGE_PROMPT_LENGTH) throw new InvalidNarrativeResponseException("이미지 prompt가 너무 깁니다.");
     }
 
     private GameResponse toResponse(Long sessionId, int turnNumber, NarrativeTurn turn, List<GameChoice> choices, String imageUrl) {

--- a/src/main/java/com/uctale/uctale/service/GameService.java
+++ b/src/main/java/com/uctale/uctale/service/GameService.java
@@ -54,6 +54,31 @@ public class GameService {
     private final GameMutationFingerprint mutationFingerprint;
     private final GameMutationRequestService mutationRequestService;
 
+    public GameService(
+            NarrativeGenerator narrativeGenerator,
+            ImageAssetService imageAssetService,
+            GamePersistenceService gamePersistenceService,
+            ChoiceCodec choiceCodec,
+            ImagePromptComposer imagePromptComposer,
+            CostRateLimiter costRateLimiter,
+            ProviderCallTelemetry providerCallTelemetry,
+            GameMutationFingerprint mutationFingerprint,
+            GameMutationRequestService mutationRequestService
+    ) {
+        this(
+                narrativeGenerator,
+                imageAssetService,
+                gamePersistenceService,
+                choiceCodec,
+                new TurnProcessor(),
+                imagePromptComposer,
+                costRateLimiter,
+                providerCallTelemetry,
+                mutationFingerprint,
+                mutationRequestService
+        );
+    }
+
     public GameResponse initGame(String ownerKey, GameInitRequest request) {
         return initGame(CostRequestContext.internal(ownerKey, null, 1), request);
     }

--- a/src/main/java/com/uctale/uctale/service/GameService.java
+++ b/src/main/java/com/uctale/uctale/service/GameService.java
@@ -23,8 +23,8 @@ import com.uctale.uctale.dto.GameChoice;
 import com.uctale.uctale.dto.GameInitRequest;
 import com.uctale.uctale.dto.GameProgressRequest;
 import com.uctale.uctale.dto.GameResponse;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.HashSet;
@@ -34,7 +34,6 @@ import java.util.UUID;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class GameService {
 
     private static final int MAX_TITLE_LENGTH = 200;
@@ -53,6 +52,31 @@ public class GameService {
     private final ProviderCallTelemetry providerCallTelemetry;
     private final GameMutationFingerprint mutationFingerprint;
     private final GameMutationRequestService mutationRequestService;
+
+    @Autowired
+    public GameService(
+            NarrativeGenerator narrativeGenerator,
+            ImageAssetService imageAssetService,
+            GamePersistenceService gamePersistenceService,
+            ChoiceCodec choiceCodec,
+            TurnProcessor turnProcessor,
+            ImagePromptComposer imagePromptComposer,
+            CostRateLimiter costRateLimiter,
+            ProviderCallTelemetry providerCallTelemetry,
+            GameMutationFingerprint mutationFingerprint,
+            GameMutationRequestService mutationRequestService
+    ) {
+        this.narrativeGenerator = narrativeGenerator;
+        this.imageAssetService = imageAssetService;
+        this.gamePersistenceService = gamePersistenceService;
+        this.choiceCodec = choiceCodec;
+        this.turnProcessor = turnProcessor;
+        this.imagePromptComposer = imagePromptComposer;
+        this.costRateLimiter = costRateLimiter;
+        this.providerCallTelemetry = providerCallTelemetry;
+        this.mutationFingerprint = mutationFingerprint;
+        this.mutationRequestService = mutationRequestService;
+    }
 
     public GameService(
             NarrativeGenerator narrativeGenerator,

--- a/src/main/java/com/uctale/uctale/service/GameService.java
+++ b/src/main/java/com/uctale/uctale/service/GameService.java
@@ -63,7 +63,9 @@ public class GameService {
                 costContext.ownerKey(), GameMutationRequestService.INIT, costContext.idempotencyKey(), null, null,
                 mutationFingerprint.init(request)
         );
-        if (mutation.replay()) return replay(costContext.ownerKey(), mutation);
+        if (mutation.replay()) {
+            return replay(costContext.ownerKey(), mutation);
+        }
 
         try {
             costRateLimiter.check(CostOperation.NARRATIVE, costContext);
@@ -75,7 +77,9 @@ public class GameService {
             List<GameChoice> choices = choiceCodec.issue(opening.choices(), 1);
 
             String imagePrompt = imagePromptComposer.compose(opening.visualAssets());
-            if (imagePrompt == null || imagePrompt.isBlank()) imagePrompt = imagePromptComposer.composeFallback(request.worldSetting());
+            if (imagePrompt == null || imagePrompt.isBlank()) {
+                imagePrompt = imagePromptComposer.composeFallback(request.worldSetting());
+            }
             validateImagePrompt(imagePrompt);
             ImageAssetService.AssetReference imageAsset = imageAssetService.issue(imagePrompt, "16:9");
 
@@ -99,7 +103,9 @@ public class GameService {
                 costContext.ownerKey(), GameMutationRequestService.PROGRESS, costContext.idempotencyKey(),
                 request.sessionId(), request.expectedTurn(), mutationFingerprint.progress(request)
         );
-        if (mutation.replay()) return replay(costContext.ownerKey(), mutation);
+        if (mutation.replay()) {
+            return replay(costContext.ownerKey(), mutation);
+        }
 
         try {
             GamePersistenceService.LoadedTurn loadedTurn = gamePersistenceService.loadLatestTurn(
@@ -121,7 +127,9 @@ public class GameService {
             costRateLimiter.check(CostOperation.NARRATIVE, providerContext);
             NarrativeTurn nextTurn = providerCallTelemetry.observe(
                     "gemini", "progress", providerContext, 0,
-                    () -> mutationRequestService.markProviderAttemptStarted(mutation.requestId(), mutation.reservationOwner()),
+                    () -> mutationRequestService.markProviderAttemptStarted(
+                            mutation.requestId(), mutation.reservationOwner()
+                    ),
                     () -> narrativeGenerator.createNextTurn(narrativeContext)
             );
             validateNarrativeTurn(nextTurn);
@@ -165,29 +173,45 @@ public class GameService {
         GamePersistenceService.CommittedTurn turn = gamePersistenceService.loadCommittedTurn(
                 ownerKey, mutation.resultSessionId(), mutation.resultTurn()
         );
-        return new GameResponse(mutation.resultSessionId(), mutation.resultTurn(), mutation.resultTitle(),
-                turn.storyText(), choiceCodec.deserialize(turn.choicesJson()), turn.imageUrl());
+        return new GameResponse(
+                mutation.resultSessionId(), mutation.resultTurn(), mutation.resultTitle(), turn.storyText(),
+                choiceCodec.deserialize(turn.choicesJson()), turn.imageUrl()
+        );
     }
 
     private String canonicalResultId(Long mutationRequestId, Long sessionId, int nextTurn) {
-        if (mutationRequestId == null || sessionId == null || nextTurn < 2) throw new IllegalArgumentException("canonical result link를 만들 수 없습니다.");
+        if (mutationRequestId == null || sessionId == null || nextTurn < 2) {
+            throw new IllegalArgumentException("canonical result link를 만들 수 없습니다.");
+        }
         return "game-result:%d:%d:%d".formatted(sessionId, nextTurn, mutationRequestId);
     }
 
     private void validateNarrativeTurn(NarrativeTurn turn) {
         if (turn == null) throw new InvalidNarrativeResponseException("Narrative 응답이 없습니다.");
-        if (turn.title() == null || turn.title().isBlank() || turn.title().length() > MAX_TITLE_LENGTH) throw new InvalidNarrativeResponseException("Narrative 제목이 올바르지 않습니다.");
-        if (turn.storyText() == null || turn.storyText().isBlank() || turn.storyText().length() > MAX_STORY_LENGTH) throw new InvalidNarrativeResponseException("Narrative 본문이 올바르지 않습니다.");
-        if (turn.choices() == null || turn.choices().isEmpty() || turn.choices().size() > MAX_CHOICES) throw new InvalidNarrativeResponseException("Narrative 선택지 수가 올바르지 않습니다.");
+        if (turn.title() == null || turn.title().isBlank() || turn.title().length() > MAX_TITLE_LENGTH) {
+            throw new InvalidNarrativeResponseException("Narrative 제목이 올바르지 않습니다.");
+        }
+        if (turn.storyText() == null || turn.storyText().isBlank() || turn.storyText().length() > MAX_STORY_LENGTH) {
+            throw new InvalidNarrativeResponseException("Narrative 본문이 올바르지 않습니다.");
+        }
+        if (turn.choices() == null || turn.choices().isEmpty() || turn.choices().size() > MAX_CHOICES) {
+            throw new InvalidNarrativeResponseException("Narrative 선택지 수가 올바르지 않습니다.");
+        }
         Set<Integer> choiceIds = new HashSet<>();
         for (NarrativeTurn.Choice choice : turn.choices()) {
-            if (choice == null || choice.id() <= 0 || !choiceIds.add(choice.id())) throw new InvalidNarrativeResponseException("Narrative 선택지 ID가 올바르지 않습니다.");
-            if (choice.text() == null || choice.text().isBlank() || choice.text().length() > MAX_CHOICE_TEXT_LENGTH) throw new InvalidNarrativeResponseException("Narrative 선택지 문구가 올바르지 않습니다.");
+            if (choice == null || choice.id() <= 0 || !choiceIds.add(choice.id())) {
+                throw new InvalidNarrativeResponseException("Narrative 선택지 ID가 올바르지 않습니다.");
+            }
+            if (choice.text() == null || choice.text().isBlank() || choice.text().length() > MAX_CHOICE_TEXT_LENGTH) {
+                throw new InvalidNarrativeResponseException("Narrative 선택지 문구가 올바르지 않습니다.");
+            }
         }
     }
 
     private void validateImagePrompt(String imagePrompt) {
-        if (imagePrompt != null && imagePrompt.length() > MAX_IMAGE_PROMPT_LENGTH) throw new InvalidNarrativeResponseException("이미지 prompt가 너무 깁니다.");
+        if (imagePrompt != null && imagePrompt.length() > MAX_IMAGE_PROMPT_LENGTH) {
+            throw new InvalidNarrativeResponseException("이미지 prompt가 너무 깁니다.");
+        }
     }
 
     private GameResponse toResponse(Long sessionId, int turnNumber, NarrativeTurn turn, List<GameChoice> choices, String imageUrl) {

--- a/src/main/resources/db/migration/V12__persist_skill_check_decision_and_audit.sql
+++ b/src/main/resources/db/migration/V12__persist_skill_check_decision_and_audit.sql
@@ -1,4 +1,5 @@
 alter table game_turn_reservation
+    add column skill_check_request_id bigint,
     add column skill_check_stat_type varchar(32),
     add column skill_check_raw_roll integer,
     add column skill_check_stat_modifier integer,
@@ -10,7 +11,8 @@ alter table game_turn_reservation
 
 alter table game_turn_reservation
     add constraint ck_game_turn_reservation_skill_check_complete check (
-        (skill_check_stat_type is null
+        (skill_check_request_id is null
+            and skill_check_stat_type is null
             and skill_check_raw_roll is null
             and skill_check_stat_modifier is null
             and skill_check_situational_modifier is null
@@ -19,7 +21,8 @@ alter table game_turn_reservation
             and skill_check_outcome is null
             and skill_check_ruleset_version is null)
         or
-        (skill_check_stat_type is not null
+        (skill_check_request_id is not null
+            and skill_check_stat_type is not null
             and skill_check_raw_roll is not null
             and skill_check_stat_modifier is not null
             and skill_check_situational_modifier is not null

--- a/src/main/resources/db/migration/V12__persist_skill_check_decision_and_audit.sql
+++ b/src/main/resources/db/migration/V12__persist_skill_check_decision_and_audit.sql
@@ -1,17 +1,35 @@
 alter table game_turn_reservation
-    add column skill_check_request_id bigint,
-    add column skill_check_stat_type varchar(32),
-    add column skill_check_raw_roll integer,
-    add column skill_check_stat_modifier integer,
-    add column skill_check_situational_modifier integer,
-    add column skill_check_dc integer,
-    add column skill_check_total integer,
-    add column skill_check_outcome varchar(16),
+    add column skill_check_request_id bigint;
+
+alter table game_turn_reservation
+    add column skill_check_stat_type varchar(32);
+
+alter table game_turn_reservation
+    add column skill_check_raw_roll integer;
+
+alter table game_turn_reservation
+    add column skill_check_stat_modifier integer;
+
+alter table game_turn_reservation
+    add column skill_check_situational_modifier integer;
+
+alter table game_turn_reservation
+    add column skill_check_dc integer;
+
+alter table game_turn_reservation
+    add column skill_check_total integer;
+
+alter table game_turn_reservation
+    add column skill_check_outcome varchar(16);
+
+alter table game_turn_reservation
     add column skill_check_ruleset_version integer;
 
 alter table game_turn_reservation
     add constraint fk_game_turn_reservation_skill_check_request
-        foreign key (skill_check_request_id) references game_mutation_request(id),
+        foreign key (skill_check_request_id) references game_mutation_request(id);
+
+alter table game_turn_reservation
     add constraint ck_game_turn_reservation_skill_check_complete check (
         (skill_check_request_id is null
             and skill_check_stat_type is null
@@ -35,13 +53,27 @@ alter table game_turn_reservation
     );
 
 alter table game_log
-    add column skill_check_stat_type varchar(32),
-    add column skill_check_raw_roll integer,
-    add column skill_check_stat_modifier integer,
-    add column skill_check_situational_modifier integer,
-    add column skill_check_dc integer,
-    add column skill_check_total integer,
-    add column skill_check_outcome varchar(16),
+    add column skill_check_stat_type varchar(32);
+
+alter table game_log
+    add column skill_check_raw_roll integer;
+
+alter table game_log
+    add column skill_check_stat_modifier integer;
+
+alter table game_log
+    add column skill_check_situational_modifier integer;
+
+alter table game_log
+    add column skill_check_dc integer;
+
+alter table game_log
+    add column skill_check_total integer;
+
+alter table game_log
+    add column skill_check_outcome varchar(16);
+
+alter table game_log
     add column skill_check_ruleset_version integer;
 
 alter table game_log

--- a/src/main/resources/db/migration/V12__persist_skill_check_decision_and_audit.sql
+++ b/src/main/resources/db/migration/V12__persist_skill_check_decision_and_audit.sql
@@ -10,6 +10,8 @@ alter table game_turn_reservation
     add column skill_check_ruleset_version integer;
 
 alter table game_turn_reservation
+    add constraint fk_game_turn_reservation_skill_check_request
+        foreign key (skill_check_request_id) references game_mutation_request(id),
     add constraint ck_game_turn_reservation_skill_check_complete check (
         (skill_check_request_id is null
             and skill_check_stat_type is null

--- a/src/main/resources/db/migration/V12__persist_skill_check_decision_and_audit.sql
+++ b/src/main/resources/db/migration/V12__persist_skill_check_decision_and_audit.sql
@@ -1,0 +1,61 @@
+alter table game_turn_reservation
+    add column skill_check_stat_type varchar(32),
+    add column skill_check_raw_roll integer,
+    add column skill_check_stat_modifier integer,
+    add column skill_check_situational_modifier integer,
+    add column skill_check_dc integer,
+    add column skill_check_total integer,
+    add column skill_check_outcome varchar(16),
+    add column skill_check_ruleset_version integer;
+
+alter table game_turn_reservation
+    add constraint ck_game_turn_reservation_skill_check_complete check (
+        (skill_check_stat_type is null
+            and skill_check_raw_roll is null
+            and skill_check_stat_modifier is null
+            and skill_check_situational_modifier is null
+            and skill_check_dc is null
+            and skill_check_total is null
+            and skill_check_outcome is null
+            and skill_check_ruleset_version is null)
+        or
+        (skill_check_stat_type is not null
+            and skill_check_raw_roll is not null
+            and skill_check_stat_modifier is not null
+            and skill_check_situational_modifier is not null
+            and skill_check_dc is not null
+            and skill_check_total is not null
+            and skill_check_outcome is not null
+            and skill_check_ruleset_version is not null)
+    );
+
+alter table game_log
+    add column skill_check_stat_type varchar(32),
+    add column skill_check_raw_roll integer,
+    add column skill_check_stat_modifier integer,
+    add column skill_check_situational_modifier integer,
+    add column skill_check_dc integer,
+    add column skill_check_total integer,
+    add column skill_check_outcome varchar(16),
+    add column skill_check_ruleset_version integer;
+
+alter table game_log
+    add constraint ck_game_log_skill_check_complete check (
+        (skill_check_stat_type is null
+            and skill_check_raw_roll is null
+            and skill_check_stat_modifier is null
+            and skill_check_situational_modifier is null
+            and skill_check_dc is null
+            and skill_check_total is null
+            and skill_check_outcome is null
+            and skill_check_ruleset_version is null)
+        or
+        (skill_check_stat_type is not null
+            and skill_check_raw_roll is not null
+            and skill_check_stat_modifier is not null
+            and skill_check_situational_modifier is not null
+            and skill_check_dc is not null
+            and skill_check_total is not null
+            and skill_check_outcome is not null
+            and skill_check_ruleset_version is not null)
+    );

--- a/src/test/java/com/uctale/uctale/application/game/ChoiceCodecTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/ChoiceCodecTest.java
@@ -17,25 +17,36 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ChoiceCodecTest {
+
     private ChoiceCodec codec;
 
     @BeforeEach
-    void setUp() { codec = new ChoiceCodec(new ObjectMapper()); }
+    void setUp() {
+        codec = new ChoiceCodec(new ObjectMapper());
+    }
 
     @Test
-    @DisplayName("신규 선택지는 서버 소유 stat DC modifier를 포함한 SKILL_CHECK action으로 발급된다")
-    void issuedActionContainsServerOwnedSkillCheckContract() {
+    @DisplayName("서버가 발급한 Skill Check action은 token type sourceTurn arguments가 모두 일치할 때만 PlayerAction으로 변환된다")
+    void issuedActionResolvesOnlyWithExactContract() {
         GameChoice issued = codec.issue(List.of(new NarrativeTurn.Choice(7, "문을 잠근다")), 3).getFirst();
         String stored = codec.serialize(List.of(issued));
-        GameProgressRequest request = new GameProgressRequest(42L, issued.id(), 3, issued.actionToken(),
-                issued.actionType(), issued.sourceTurn(), issued.arguments());
+        GameProgressRequest request = new GameProgressRequest(
+                42L,
+                issued.id(),
+                3,
+                issued.actionToken(),
+                issued.actionType(),
+                issued.sourceTurn(),
+                issued.arguments()
+        );
 
         PlayerAction action = codec.resolve(stored, request);
 
         assertThat(action.type()).isEqualTo(ActionType.SKILL_CHECK);
         assertThat(action.sourceTurn()).isEqualTo(3);
         assertThat(action.displayText()).isEqualTo("문을 잠근다");
-        assertThat(action.arguments()).containsEntry("choiceId", "7")
+        assertThat(action.arguments())
+                .containsEntry("choiceId", "7")
                 .containsEntry("statType", "WILL")
                 .containsEntry("dc", "10")
                 .containsEntry("situationalModifier", "0");
@@ -46,16 +57,19 @@ class ChoiceCodecTest {
     void tamperedActionIsRejected() {
         GameChoice issued = codec.issue(List.of(new NarrativeTurn.Choice(7, "문을 잠근다")), 3).getFirst();
         String stored = codec.serialize(List.of(issued));
+
         assertThatThrownBy(() -> codec.resolve(stored, new GameProgressRequest(
-                42L, 7, 3, "tampered", issued.actionType(), issued.sourceTurn(), issued.arguments())))
-                .isInstanceOf(InvalidChoiceException.class);
+                42L, 7, 3, "tampered", issued.actionType(), issued.sourceTurn(), issued.arguments()
+        ))).isInstanceOf(InvalidChoiceException.class);
+
         assertThatThrownBy(() -> codec.resolve(stored, new GameProgressRequest(
-                42L, 7, 3, issued.actionToken(), "USE_ITEM", issued.sourceTurn(), issued.arguments())))
-                .isInstanceOf(InvalidChoiceException.class);
+                42L, 7, 3, issued.actionToken(), "USE_ITEM", issued.sourceTurn(), issued.arguments()
+        ))).isInstanceOf(InvalidChoiceException.class);
+
         assertThatThrownBy(() -> codec.resolve(stored, new GameProgressRequest(
                 42L, 7, 3, issued.actionToken(), issued.actionType(), issued.sourceTurn(),
-                Map.of("choiceId", "7", "statType", "WILL", "dc", "40", "situationalModifier", "0"))))
-                .isInstanceOf(InvalidChoiceException.class);
+                Map.of("choiceId", "7", "statType", "WILL", "dc", "40", "situationalModifier", "0")
+        ))).isInstanceOf(InvalidChoiceException.class);
     }
 
     @Test
@@ -63,20 +77,38 @@ class ChoiceCodecTest {
     void expiredActionIsRejected() {
         GameChoice issued = codec.issue(List.of(new NarrativeTurn.Choice(7, "문을 잠근다")), 2).getFirst();
         String stored = codec.serialize(List.of(issued));
+
         assertThatThrownBy(() -> codec.resolve(stored, new GameProgressRequest(
-                42L, 7, 3, issued.actionToken(), issued.actionType(), issued.sourceTurn(), issued.arguments())))
-                .isInstanceOf(InvalidChoiceException.class);
+                42L, 7, 3, issued.actionToken(), issued.actionType(), issued.sourceTurn(), issued.arguments()
+        ))).isInstanceOf(InvalidChoiceException.class);
     }
 
     @Test
-    @DisplayName("action metadata가 없는 기존 저장 선택지는 legacy narrative compatibility adapter로만 수락한다")
-    void legacyChoiceUsesCompatibilityAdapter() {
-        String stored = codec.serialize(List.of(new GameChoice(7, "문을 잠근다")));
+    @DisplayName("metadata 없는 legacy wire 요청은 신규 저장 action에도 기존 narrative 의미를 유지한다")
+    void legacyWireRequestKeepsNarrativeCompatibility() {
+        GameChoice issued = codec.issue(List.of(new NarrativeTurn.Choice(7, "문을 잠근다")), 3).getFirst();
+        String stored = codec.serialize(List.of(issued));
+
         PlayerAction action = codec.resolve(stored, new GameProgressRequest(42L, 7, 3));
+
         assertThat(action.type()).isEqualTo(ActionType.NARRATIVE_CHOICE);
         assertThat(action.sourceTurn()).isEqualTo(3);
+        assertThat(action.arguments()).containsExactly(Map.entry("choiceId", "7"));
+    }
+
+    @Test
+    @DisplayName("action metadata가 없는 기존 저장 선택지는 legacy compatibility adapter로만 수락한다")
+    void legacyChoiceUsesCompatibilityAdapter() {
+        String stored = codec.serialize(List.of(new GameChoice(7, "문을 잠근다")));
+
+        PlayerAction action = codec.resolve(stored, new GameProgressRequest(42L, 7, 3));
+
+        assertThat(action.type()).isEqualTo(ActionType.NARRATIVE_CHOICE);
+        assertThat(action.sourceTurn()).isEqualTo(3);
+        assertThat(action.displayText()).isEqualTo("문을 잠근다");
+
         assertThatThrownBy(() -> codec.resolve(stored, new GameProgressRequest(
-                42L, 7, 3, "invented", ActionType.NARRATIVE_CHOICE.name(), 3, Map.of("choiceId", "7"))))
-                .isInstanceOf(InvalidChoiceException.class);
+                42L, 7, 3, "invented", ActionType.NARRATIVE_CHOICE.name(), 3, Map.of("choiceId", "7")
+        ))).isInstanceOf(InvalidChoiceException.class);
     }
 }

--- a/src/test/java/com/uctale/uctale/application/game/ChoiceCodecTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/ChoiceCodecTest.java
@@ -17,35 +17,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ChoiceCodecTest {
-
     private ChoiceCodec codec;
 
     @BeforeEach
-    void setUp() {
-        codec = new ChoiceCodec(new ObjectMapper());
-    }
+    void setUp() { codec = new ChoiceCodec(new ObjectMapper()); }
 
     @Test
-    @DisplayName("서버가 발급한 action은 token type sourceTurn arguments가 모두 일치할 때만 PlayerAction으로 변환된다")
-    void issuedActionResolvesOnlyWithExactContract() {
+    @DisplayName("신규 선택지는 서버 소유 stat DC modifier를 포함한 SKILL_CHECK action으로 발급된다")
+    void issuedActionContainsServerOwnedSkillCheckContract() {
         GameChoice issued = codec.issue(List.of(new NarrativeTurn.Choice(7, "문을 잠근다")), 3).getFirst();
         String stored = codec.serialize(List.of(issued));
-        GameProgressRequest request = new GameProgressRequest(
-                42L,
-                issued.id(),
-                3,
-                issued.actionToken(),
-                issued.actionType(),
-                issued.sourceTurn(),
-                issued.arguments()
-        );
+        GameProgressRequest request = new GameProgressRequest(42L, issued.id(), 3, issued.actionToken(),
+                issued.actionType(), issued.sourceTurn(), issued.arguments());
 
         PlayerAction action = codec.resolve(stored, request);
 
-        assertThat(action.type()).isEqualTo(ActionType.NARRATIVE_CHOICE);
+        assertThat(action.type()).isEqualTo(ActionType.SKILL_CHECK);
         assertThat(action.sourceTurn()).isEqualTo(3);
         assertThat(action.displayText()).isEqualTo("문을 잠근다");
-        assertThat(action.arguments()).containsEntry("choiceId", "7");
+        assertThat(action.arguments()).containsEntry("choiceId", "7")
+                .containsEntry("statType", "WILL")
+                .containsEntry("dc", "10")
+                .containsEntry("situationalModifier", "0");
     }
 
     @Test
@@ -53,18 +46,16 @@ class ChoiceCodecTest {
     void tamperedActionIsRejected() {
         GameChoice issued = codec.issue(List.of(new NarrativeTurn.Choice(7, "문을 잠근다")), 3).getFirst();
         String stored = codec.serialize(List.of(issued));
-
         assertThatThrownBy(() -> codec.resolve(stored, new GameProgressRequest(
-                42L, 7, 3, "tampered", issued.actionType(), issued.sourceTurn(), issued.arguments()
-        ))).isInstanceOf(InvalidChoiceException.class);
-
+                42L, 7, 3, "tampered", issued.actionType(), issued.sourceTurn(), issued.arguments())))
+                .isInstanceOf(InvalidChoiceException.class);
         assertThatThrownBy(() -> codec.resolve(stored, new GameProgressRequest(
-                42L, 7, 3, issued.actionToken(), "USE_ITEM", issued.sourceTurn(), issued.arguments()
-        ))).isInstanceOf(InvalidChoiceException.class);
-
+                42L, 7, 3, issued.actionToken(), "USE_ITEM", issued.sourceTurn(), issued.arguments())))
+                .isInstanceOf(InvalidChoiceException.class);
         assertThatThrownBy(() -> codec.resolve(stored, new GameProgressRequest(
-                42L, 7, 3, issued.actionToken(), issued.actionType(), issued.sourceTurn(), Map.of("choiceId", "8")
-        ))).isInstanceOf(InvalidChoiceException.class);
+                42L, 7, 3, issued.actionToken(), issued.actionType(), issued.sourceTurn(),
+                Map.of("choiceId", "7", "statType", "WILL", "dc", "40", "situationalModifier", "0"))))
+                .isInstanceOf(InvalidChoiceException.class);
     }
 
     @Test
@@ -72,25 +63,20 @@ class ChoiceCodecTest {
     void expiredActionIsRejected() {
         GameChoice issued = codec.issue(List.of(new NarrativeTurn.Choice(7, "문을 잠근다")), 2).getFirst();
         String stored = codec.serialize(List.of(issued));
-
         assertThatThrownBy(() -> codec.resolve(stored, new GameProgressRequest(
-                42L, 7, 3, issued.actionToken(), issued.actionType(), issued.sourceTurn(), issued.arguments()
-        ))).isInstanceOf(InvalidChoiceException.class);
+                42L, 7, 3, issued.actionToken(), issued.actionType(), issued.sourceTurn(), issued.arguments())))
+                .isInstanceOf(InvalidChoiceException.class);
     }
 
     @Test
-    @DisplayName("action metadata가 없는 기존 저장 선택지는 legacy compatibility adapter로만 수락한다")
+    @DisplayName("action metadata가 없는 기존 저장 선택지는 legacy narrative compatibility adapter로만 수락한다")
     void legacyChoiceUsesCompatibilityAdapter() {
         String stored = codec.serialize(List.of(new GameChoice(7, "문을 잠근다")));
-
         PlayerAction action = codec.resolve(stored, new GameProgressRequest(42L, 7, 3));
-
         assertThat(action.type()).isEqualTo(ActionType.NARRATIVE_CHOICE);
         assertThat(action.sourceTurn()).isEqualTo(3);
-        assertThat(action.displayText()).isEqualTo("문을 잠근다");
-
         assertThatThrownBy(() -> codec.resolve(stored, new GameProgressRequest(
-                42L, 7, 3, "invented", ActionType.NARRATIVE_CHOICE.name(), 3, Map.of("choiceId", "7")
-        ))).isInstanceOf(InvalidChoiceException.class);
+                42L, 7, 3, "invented", ActionType.NARRATIVE_CHOICE.name(), 3, Map.of("choiceId", "7"))))
+                .isInstanceOf(InvalidChoiceException.class);
     }
 }

--- a/src/test/java/com/uctale/uctale/domain/game/ActionResolverTest.java
+++ b/src/test/java/com/uctale/uctale/domain/game/ActionResolverTest.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ActionResolverTest {
-
     private final ActionResolver resolver = new ActionResolver();
 
     @Test
@@ -19,83 +18,88 @@ class ActionResolverTest {
     void resolveNarrativeChoice_ProducesDeterministicResolution() {
         GameState state = GameState.initial("세계관", "캐릭터", "오프닝");
         PlayerAction action = narrativeChoice(1, 7, "문을 잠근다");
-
         TurnResolution resolution = resolver.resolve(state, action);
-
         assertThat(resolution.gameResult().resolvedAction()).isEqualTo(action);
-        assertThat(resolution.gameResult().outcome()).isEqualTo(GameResult.Outcome.RESOLVED);
-        assertThat(resolution.gameResult().canonicalFacts()).isEmpty();
+        assertThat(resolution.gameResult().skillCheckResult()).isNull();
         assertThat(resolution.gameResult().events()).containsExactly(GameResult.GameEvent.ACTION_RESOLVED);
-        assertThat(resolution.gameResult().stateChanges())
-                .containsExactly(new GameResult.TurnAdvanced(1, 2));
-        assertThat(resolution.gameResult().narrativeCues()).containsExactly("문을 잠근다");
-        assertThat(resolution.stateTransition().previousState()).isEqualTo(state);
+        assertThat(resolution.gameResult().stateChanges()).containsExactly(new GameResult.TurnAdvanced(1, 2));
         assertThat(resolution.stateTransition().nextState().turnNumber()).isEqualTo(2);
-        assertThat(resolution.stateTransition().nextState().playerCharacter()).isEqualTo(state.playerCharacter());
-        assertThat(resolution.stateTransition().nextState().worldState()).isEqualTo(state.worldState());
-        assertThat(resolution.stateTransition().nextState().storyMemory()).isEqualTo(state.storyMemory());
     }
 
     @Test
-    @DisplayName("같은 state와 action은 동일한 TurnResolution을 만든다")
-    void resolveNarrativeChoice_IsDeterministic() {
+    @DisplayName("SKILL_CHECK는 fixed RandomSource로 성공 판정을 만들고 저장 결과를 그대로 GameResult에 사용한다")
+    void resolveSkillCheck_Success() {
         GameState state = GameState.initial("세계관", "캐릭터", "오프닝");
-        PlayerAction action = narrativeChoice(1, 3, "기다린다");
-
-        assertThat(resolver.resolve(state, action)).isEqualTo(resolver.resolve(state, action));
+        PlayerAction action = skillCheck(1, 7, 10, 0);
+        SkillCheckResult rolled = resolver.rollSkillCheck(state, action, (min, max) -> 10);
+        TurnResolution resolution = resolver.resolve(state, action, rolled);
+        assertThat(rolled.rawRoll()).isEqualTo(10);
+        assertThat(rolled.total()).isEqualTo(10);
+        assertThat(rolled.outcome()).isEqualTo(SkillCheckOutcome.SUCCESS);
+        assertThat(resolution.gameResult().skillCheckResult()).isEqualTo(rolled);
+        assertThat(resolution.gameResult().events()).containsExactly(
+                GameResult.GameEvent.ACTION_RESOLVED, GameResult.GameEvent.SKILL_CHECK_RESOLVED);
     }
 
     @Test
-    @DisplayName("stale source turn은 규칙 실행 전에 거절한다")
-    void resolveNarrativeChoice_RejectsStaleSourceTurn() {
+    @DisplayName("SKILL_CHECK는 total이 DC보다 하나 작으면 실패한다")
+    void resolveSkillCheck_FailureBoundary() {
         GameState state = GameState.initial("세계관", "캐릭터", "오프닝");
-        PlayerAction stale = narrativeChoice(2, 1, "간다");
+        PlayerAction action = skillCheck(1, 7, 10, 0);
+        SkillCheckResult rolled = resolver.rollSkillCheck(state, action, (min, max) -> 9);
+        assertThat(rolled.total()).isEqualTo(9);
+        assertThat(rolled.outcome()).isEqualTo(SkillCheckOutcome.FAILURE);
+        assertThat(resolver.resolve(state, action, rolled).gameResult().skillCheckResult()).isEqualTo(rolled);
+    }
 
-        assertThatThrownBy(() -> resolver.resolve(state, stale))
+    @Test
+    @DisplayName("저장된 Skill Check의 stat modifier가 canonical 능력치와 다르면 거절한다")
+    void resolveSkillCheck_RejectsStoredResultFromDifferentStats() {
+        GameState state = GameState.initial("세계관", "캐릭터", "오프닝");
+        PlayerAction action = skillCheck(1, 7, 10, 0);
+        SkillCheckResult tampered = new SkillCheckResult(
+                StatType.WILL, 10, 1, 0, 10, 11, SkillCheckOutcome.SUCCESS, SkillCheck.RULESET_VERSION);
+        assertThatThrownBy(() -> resolver.resolve(state, action, tampered))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("source turn");
+                .hasMessageContaining("canonical 능력치");
     }
 
     @Test
-    @DisplayName("choiceId arguments 변조는 resolver에서도 거절한다")
-    void resolveNarrativeChoice_RejectsTamperedArguments() {
+    @DisplayName("stale source turn과 잘못된 SKILL_CHECK arguments는 난수 생성 전에 거절한다")
+    void resolveSkillCheck_RejectsBeforeRoll() {
         GameState state = GameState.initial("세계관", "캐릭터", "오프닝");
-        PlayerAction tampered = new PlayerAction(
-                7, "token", ActionType.NARRATIVE_CHOICE, 1, Map.of("choiceId", "8"), "문을 잠근다"
-        );
-
-        assertThatThrownBy(() -> resolver.resolve(state, tampered))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("arguments");
+        PlayerAction stale = skillCheck(2, 7, 10, 0);
+        assertThatThrownBy(() -> resolver.rollSkillCheck(state, stale, (min, max) -> 10))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("source turn");
+        PlayerAction invalid = new PlayerAction(7, "token", ActionType.SKILL_CHECK, 1,
+                Map.of("choiceId", "7", "statType", "WILL", "dc", "41", "situationalModifier", "0"), "시도한다");
+        assertThatThrownBy(() -> resolver.rollSkillCheck(state, invalid, (min, max) -> 10))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("arguments");
     }
 
     @Test
-    @DisplayName("Narrative 부착은 확정된 canonical 상태를 바꾸지 않고 StoryMemory만 완성한다")
+    @DisplayName("Narrative 부착은 확정된 Skill Check와 canonical 상태를 바꾸지 않는다")
     void attachNarrative_OnlyCompletesNarrativeMemory() {
         GameState state = GameState.initial("세계관", "캐릭터", "오프닝");
-        TurnResolution resolution = resolver.resolve(state, narrativeChoice(1, 7, "문을 잠근다"));
-        GameState canonicalNextState = resolution.stateTransition().nextState();
-
-        StateTransition committed = resolution.attachNarrative("문은 굳게 잠겼다.");
-
-        assertThat(committed.previousState()).isEqualTo(state);
-        assertThat(committed.nextState().turnNumber()).isEqualTo(canonicalNextState.turnNumber());
-        assertThat(committed.nextState().playerCharacter()).isEqualTo(canonicalNextState.playerCharacter());
-        assertThat(committed.nextState().worldState()).isEqualTo(canonicalNextState.worldState());
-        assertThat(committed.nextState().storyMemory().canonicalFacts())
-                .isEqualTo(canonicalNextState.storyMemory().canonicalFacts());
+        PlayerAction action = skillCheck(1, 7, 10, 0);
+        SkillCheckResult result = resolver.rollSkillCheck(state, action, (min, max) -> 10);
+        TurnResolution resolution = resolver.resolve(state, action, result);
+        StateTransition committed = resolution.attachNarrative("문이 열렸다.");
+        assertThat(resolution.gameResult().skillCheckResult()).isEqualTo(result);
+        assertThat(committed.nextState().turnNumber()).isEqualTo(2);
         assertThat(committed.nextState().storyMemory().recentTurns().getLast())
-                .isEqualTo(new GameTurn(2, "문을 잠근다", "문은 굳게 잠겼다."));
+                .isEqualTo(new GameTurn(2, "시도한다", "문이 열렸다."));
     }
 
     private PlayerAction narrativeChoice(int sourceTurn, int choiceId, String text) {
-        return new PlayerAction(
-                choiceId,
-                "token",
-                ActionType.NARRATIVE_CHOICE,
-                sourceTurn,
-                Map.of("choiceId", Integer.toString(choiceId)),
-                text
-        );
+        return new PlayerAction(choiceId, "token", ActionType.NARRATIVE_CHOICE, sourceTurn,
+                Map.of("choiceId", Integer.toString(choiceId)), text);
+    }
+
+    private PlayerAction skillCheck(int sourceTurn, int choiceId, int dc, int situationalModifier) {
+        return new PlayerAction(choiceId, "token", ActionType.SKILL_CHECK, sourceTurn,
+                Map.of("choiceId", Integer.toString(choiceId), "statType", "WILL",
+                        "dc", Integer.toString(dc), "situationalModifier", Integer.toString(situationalModifier)),
+                "시도한다");
     }
 }

--- a/src/test/java/com/uctale/uctale/domain/game/ActionResolverTest.java
+++ b/src/test/java/com/uctale/uctale/domain/game/ActionResolverTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ActionResolverTest {
+
     private final ActionResolver resolver = new ActionResolver();
 
     @Test
@@ -18,35 +19,84 @@ class ActionResolverTest {
     void resolveNarrativeChoice_ProducesDeterministicResolution() {
         GameState state = GameState.initial("세계관", "캐릭터", "오프닝");
         PlayerAction action = narrativeChoice(1, 7, "문을 잠근다");
+
         TurnResolution resolution = resolver.resolve(state, action);
+
         assertThat(resolution.gameResult().resolvedAction()).isEqualTo(action);
+        assertThat(resolution.gameResult().outcome()).isEqualTo(GameResult.Outcome.RESOLVED);
         assertThat(resolution.gameResult().skillCheckResult()).isNull();
+        assertThat(resolution.gameResult().canonicalFacts()).isEmpty();
         assertThat(resolution.gameResult().events()).containsExactly(GameResult.GameEvent.ACTION_RESOLVED);
-        assertThat(resolution.gameResult().stateChanges()).containsExactly(new GameResult.TurnAdvanced(1, 2));
+        assertThat(resolution.gameResult().stateChanges())
+                .containsExactly(new GameResult.TurnAdvanced(1, 2));
+        assertThat(resolution.gameResult().narrativeCues()).containsExactly("문을 잠근다");
+        assertThat(resolution.stateTransition().previousState()).isEqualTo(state);
         assertThat(resolution.stateTransition().nextState().turnNumber()).isEqualTo(2);
+        assertThat(resolution.stateTransition().nextState().playerCharacter()).isEqualTo(state.playerCharacter());
+        assertThat(resolution.stateTransition().nextState().worldState()).isEqualTo(state.worldState());
+        assertThat(resolution.stateTransition().nextState().storyMemory()).isEqualTo(state.storyMemory());
     }
 
     @Test
-    @DisplayName("SKILL_CHECK는 fixed RandomSource로 성공 판정을 만들고 저장 결과를 그대로 GameResult에 사용한다")
+    @DisplayName("같은 state와 action은 동일한 TurnResolution을 만든다")
+    void resolveNarrativeChoice_IsDeterministic() {
+        GameState state = GameState.initial("세계관", "캐릭터", "오프닝");
+        PlayerAction action = narrativeChoice(1, 3, "기다린다");
+
+        assertThat(resolver.resolve(state, action)).isEqualTo(resolver.resolve(state, action));
+    }
+
+    @Test
+    @DisplayName("stale source turn은 규칙 실행 전에 거절한다")
+    void resolveNarrativeChoice_RejectsStaleSourceTurn() {
+        GameState state = GameState.initial("세계관", "캐릭터", "오프닝");
+        PlayerAction stale = narrativeChoice(2, 1, "간다");
+
+        assertThatThrownBy(() -> resolver.resolve(state, stale))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("source turn");
+    }
+
+    @Test
+    @DisplayName("choiceId arguments 변조는 resolver에서도 거절한다")
+    void resolveNarrativeChoice_RejectsTamperedArguments() {
+        GameState state = GameState.initial("세계관", "캐릭터", "오프닝");
+        PlayerAction tampered = new PlayerAction(
+                7, "token", ActionType.NARRATIVE_CHOICE, 1, Map.of("choiceId", "8"), "문을 잠근다"
+        );
+
+        assertThatThrownBy(() -> resolver.resolve(state, tampered))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("arguments");
+    }
+
+    @Test
+    @DisplayName("Skill Check는 fixed RandomSource로 성공 판정을 만들고 저장 결과를 그대로 GameResult에 사용한다")
     void resolveSkillCheck_Success() {
         GameState state = GameState.initial("세계관", "캐릭터", "오프닝");
         PlayerAction action = skillCheck(1, 7, 10, 0);
+
         SkillCheckResult rolled = resolver.rollSkillCheck(state, action, (min, max) -> 10);
         TurnResolution resolution = resolver.resolve(state, action, rolled);
+
         assertThat(rolled.rawRoll()).isEqualTo(10);
         assertThat(rolled.total()).isEqualTo(10);
         assertThat(rolled.outcome()).isEqualTo(SkillCheckOutcome.SUCCESS);
         assertThat(resolution.gameResult().skillCheckResult()).isEqualTo(rolled);
         assertThat(resolution.gameResult().events()).containsExactly(
-                GameResult.GameEvent.ACTION_RESOLVED, GameResult.GameEvent.SKILL_CHECK_RESOLVED);
+                GameResult.GameEvent.ACTION_RESOLVED,
+                GameResult.GameEvent.SKILL_CHECK_RESOLVED
+        );
     }
 
     @Test
-    @DisplayName("SKILL_CHECK는 total이 DC보다 하나 작으면 실패한다")
+    @DisplayName("Skill Check는 total이 DC보다 하나 작으면 실패한다")
     void resolveSkillCheck_FailureBoundary() {
         GameState state = GameState.initial("세계관", "캐릭터", "오프닝");
         PlayerAction action = skillCheck(1, 7, 10, 0);
+
         SkillCheckResult rolled = resolver.rollSkillCheck(state, action, (min, max) -> 9);
+
         assertThat(rolled.total()).isEqualTo(9);
         assertThat(rolled.outcome()).isEqualTo(SkillCheckOutcome.FAILURE);
         assertThat(resolver.resolve(state, action, rolled).gameResult().skillCheckResult()).isEqualTo(rolled);
@@ -58,48 +108,80 @@ class ActionResolverTest {
         GameState state = GameState.initial("세계관", "캐릭터", "오프닝");
         PlayerAction action = skillCheck(1, 7, 10, 0);
         SkillCheckResult tampered = new SkillCheckResult(
-                StatType.WILL, 10, 1, 0, 10, 11, SkillCheckOutcome.SUCCESS, SkillCheck.RULESET_VERSION);
+                StatType.WILL, 10, 1, 0, 10, 11, SkillCheckOutcome.SUCCESS, SkillCheck.RULESET_VERSION
+        );
+
         assertThatThrownBy(() -> resolver.resolve(state, action, tampered))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("canonical 능력치");
     }
 
     @Test
-    @DisplayName("stale source turn과 잘못된 SKILL_CHECK arguments는 난수 생성 전에 거절한다")
+    @DisplayName("stale source turn과 잘못된 Skill Check arguments는 난수 생성 전에 거절한다")
     void resolveSkillCheck_RejectsBeforeRoll() {
         GameState state = GameState.initial("세계관", "캐릭터", "오프닝");
         PlayerAction stale = skillCheck(2, 7, 10, 0);
+
         assertThatThrownBy(() -> resolver.rollSkillCheck(state, stale, (min, max) -> 10))
-                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("source turn");
-        PlayerAction invalid = new PlayerAction(7, "token", ActionType.SKILL_CHECK, 1,
-                Map.of("choiceId", "7", "statType", "WILL", "dc", "41", "situationalModifier", "0"), "시도한다");
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("source turn");
+
+        PlayerAction invalid = new PlayerAction(
+                7,
+                "token",
+                ActionType.SKILL_CHECK,
+                1,
+                Map.of("choiceId", "7", "statType", "WILL", "dc", "41", "situationalModifier", "0"),
+                "시도한다"
+        );
         assertThatThrownBy(() -> resolver.rollSkillCheck(state, invalid, (min, max) -> 10))
-                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("arguments");
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("arguments");
     }
 
     @Test
-    @DisplayName("Narrative 부착은 확정된 Skill Check와 canonical 상태를 바꾸지 않는다")
+    @DisplayName("Narrative 부착은 확정된 canonical 상태를 바꾸지 않고 StoryMemory만 완성한다")
     void attachNarrative_OnlyCompletesNarrativeMemory() {
         GameState state = GameState.initial("세계관", "캐릭터", "오프닝");
-        PlayerAction action = skillCheck(1, 7, 10, 0);
-        SkillCheckResult result = resolver.rollSkillCheck(state, action, (min, max) -> 10);
-        TurnResolution resolution = resolver.resolve(state, action, result);
-        StateTransition committed = resolution.attachNarrative("문이 열렸다.");
-        assertThat(resolution.gameResult().skillCheckResult()).isEqualTo(result);
-        assertThat(committed.nextState().turnNumber()).isEqualTo(2);
+        TurnResolution resolution = resolver.resolve(state, narrativeChoice(1, 7, "문을 잠근다"));
+        GameState canonicalNextState = resolution.stateTransition().nextState();
+
+        StateTransition committed = resolution.attachNarrative("문은 굳게 잠겼다.");
+
+        assertThat(committed.previousState()).isEqualTo(state);
+        assertThat(committed.nextState().turnNumber()).isEqualTo(canonicalNextState.turnNumber());
+        assertThat(committed.nextState().playerCharacter()).isEqualTo(canonicalNextState.playerCharacter());
+        assertThat(committed.nextState().worldState()).isEqualTo(canonicalNextState.worldState());
+        assertThat(committed.nextState().storyMemory().canonicalFacts())
+                .isEqualTo(canonicalNextState.storyMemory().canonicalFacts());
         assertThat(committed.nextState().storyMemory().recentTurns().getLast())
-                .isEqualTo(new GameTurn(2, "시도한다", "문이 열렸다."));
+                .isEqualTo(new GameTurn(2, "문을 잠근다", "문은 굳게 잠겼다."));
     }
 
     private PlayerAction narrativeChoice(int sourceTurn, int choiceId, String text) {
-        return new PlayerAction(choiceId, "token", ActionType.NARRATIVE_CHOICE, sourceTurn,
-                Map.of("choiceId", Integer.toString(choiceId)), text);
+        return new PlayerAction(
+                choiceId,
+                "token",
+                ActionType.NARRATIVE_CHOICE,
+                sourceTurn,
+                Map.of("choiceId", Integer.toString(choiceId)),
+                text
+        );
     }
 
     private PlayerAction skillCheck(int sourceTurn, int choiceId, int dc, int situationalModifier) {
-        return new PlayerAction(choiceId, "token", ActionType.SKILL_CHECK, sourceTurn,
-                Map.of("choiceId", Integer.toString(choiceId), "statType", "WILL",
-                        "dc", Integer.toString(dc), "situationalModifier", Integer.toString(situationalModifier)),
-                "시도한다");
+        return new PlayerAction(
+                choiceId,
+                "token",
+                ActionType.SKILL_CHECK,
+                sourceTurn,
+                Map.of(
+                        "choiceId", Integer.toString(choiceId),
+                        "statType", "WILL",
+                        "dc", Integer.toString(dc),
+                        "situationalModifier", Integer.toString(situationalModifier)
+                ),
+                "시도한다"
+        );
     }
 }

--- a/src/test/java/com/uctale/uctale/persistence/PostgresM2TurnIntegrityMatrixTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/PostgresM2TurnIntegrityMatrixTest.java
@@ -11,9 +11,7 @@ import com.uctale.uctale.application.game.GameTurnCommit;
 import com.uctale.uctale.application.game.IdempotencyConflictException;
 import com.uctale.uctale.application.game.ImagePromptComposer;
 import com.uctale.uctale.application.game.MutationInProgressException;
-import com.uctale.uctale.application.game.SkillCheckDecisionService;
 import com.uctale.uctale.application.game.TurnConflictException;
-import com.uctale.uctale.application.game.TurnProcessor;
 import com.uctale.uctale.application.image.ImageAssetService;
 import com.uctale.uctale.application.narrative.NarrativeContext;
 import com.uctale.uctale.application.narrative.NarrativeGenerator;
@@ -83,7 +81,12 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
                 """);
         clock = new MutableClock(Instant.parse("2026-08-31T04:00:00Z"));
         mutationService = new TransactionalMutationService(
-                mutationRequestRepository, jdbcTemplate, clock, LEASE_SECONDS, transactionManager);
+                mutationRequestRepository,
+                jdbcTemplate,
+                clock,
+                LEASE_SECONDS,
+                transactionManager
+        );
         narrativeGenerator = new FakeNarrativeGenerator();
         gameService = newGameService(persistenceService);
     }
@@ -93,17 +96,25 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
     void completedInitRetry_ReusesCanonicalOpeningExactlyOnce() {
         String key = "matrix-init-key-001";
         GameInitRequest request = new GameInitRequest("matrix-world", "matrix-character");
+
         GameResponse first = gameService.initGame(initContext(key), request);
         GameResponse retry = gameService.initGame(initContext(key), request);
+
         assertThat(retry.sessionId()).isEqualTo(first.sessionId());
         assertThat(retry.turnNumber()).isEqualTo(1);
         assertThat(retry.storyText()).isEqualTo(first.storyText());
-        assertThat(narrativeGenerator.openingCalls()).isEqualTo(1);
-        assertThat(jdbcTemplate.queryForObject("select count(*) from game_session", Integer.class)).isEqualTo(1);
-        assertThatThrownBy(() -> gameService.initGame(initContext(key),
-                new GameInitRequest("different-world", "matrix-character")))
+        assertThat(narrativeGenerator.openingCalls()).as("NarrativeGenerator opening calls").isEqualTo(1);
+        assertThat(jdbcTemplate.queryForObject("select count(*) from game_session", Integer.class))
+                .as("canonical session count after init retry")
+                .isEqualTo(1);
+
+        assertThatThrownBy(() -> gameService.initGame(
+                initContext(key),
+                new GameInitRequest("different-world", "matrix-character")
+        )).as("phase=init-fingerprint-conflict request=%s", key)
                 .isInstanceOf(IdempotencyConflictException.class);
-        assertThat(narrativeGenerator.openingCalls()).isEqualTo(1);
+        assertThat(narrativeGenerator.openingCalls()).as("provider calls after init fingerprint conflict").isEqualTo(1);
+
         assertCanonicalTurn(first.sessionId(), key, 1, 1);
     }
 
@@ -113,16 +124,22 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
         GameResponse opening = createOpening("matrix-opening-progress");
         String key = "matrix-progress-key-001";
         GameProgressRequest request = new GameProgressRequest(opening.sessionId(), 1, 1);
+
         GameResponse first = gameService.progressGame(progressContext(key, opening.sessionId()), request);
         GameResponse retry = gameService.progressGame(progressContext(key, opening.sessionId()), request);
+
         assertThat(retry.sessionId()).isEqualTo(first.sessionId());
         assertThat(retry.turnNumber()).isEqualTo(2);
         assertThat(retry.storyText()).isEqualTo(first.storyText());
-        assertThat(narrativeGenerator.progressCalls()).isEqualTo(1);
-        assertThatThrownBy(() -> gameService.progressGame(progressContext(key, opening.sessionId()),
-                new GameProgressRequest(opening.sessionId(), 2, 1)))
+        assertThat(narrativeGenerator.progressCalls()).as("NarrativeGenerator progress calls").isEqualTo(1);
+
+        assertThatThrownBy(() -> gameService.progressGame(
+                progressContext(key, opening.sessionId()),
+                new GameProgressRequest(opening.sessionId(), 2, 1)
+        )).as(context("progress-fingerprint-conflict", key, opening.sessionId(), 1))
                 .isInstanceOf(IdempotencyConflictException.class);
-        assertThat(narrativeGenerator.progressCalls()).isEqualTo(1);
+        assertThat(narrativeGenerator.progressCalls()).as("provider calls after progress fingerprint conflict").isEqualTo(1);
+
         assertCanonicalTurn(opening.sessionId(), key, 2, 2);
     }
 
@@ -132,29 +149,43 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
         GameResponse opening = createOpening("matrix-opening-concurrency");
         GameProgressRequest request = new GameProgressRequest(opening.sessionId(), 1, 1);
         narrativeGenerator.blockNextProgress();
+
         CountDownLatch ready = new CountDownLatch(2);
         CountDownLatch start = new CountDownLatch(1);
         CountDownLatch rejected = new CountDownLatch(1);
         ExecutorService executor = Executors.newFixedThreadPool(2);
+
         try {
-            Future<ProgressAttempt> first = executor.submit(concurrentProgressAttempt(ready, start, rejected, "matrix-concurrent-key-a", request));
-            Future<ProgressAttempt> second = executor.submit(concurrentProgressAttempt(ready, start, rejected, "matrix-concurrent-key-b", request));
+            Future<ProgressAttempt> first = executor.submit(concurrentProgressAttempt(
+                    ready, start, rejected, "matrix-concurrent-key-a", request
+            ));
+            Future<ProgressAttempt> second = executor.submit(concurrentProgressAttempt(
+                    ready, start, rejected, "matrix-concurrent-key-b", request
+            ));
+
             awaitLatch(ready, "동시 요청 준비");
             start.countDown();
             narrativeGenerator.awaitProgressEntry();
             awaitLatch(rejected, "reservation 경쟁 요청 거부");
-            assertThat(narrativeGenerator.progressCalls()).isEqualTo(1);
-            assertThat(reservationCount(opening.sessionId(), 1)).isEqualTo(1);
+
+            assertThat(narrativeGenerator.progressCalls()).as("provider calls while lease is active").isEqualTo(1);
+            assertThat(reservationCount(opening.sessionId(), 1)).as("active reservation rows").isEqualTo(1);
+
             narrativeGenerator.releaseProgress();
-            List<ProgressAttempt> attempts = List.of(first.get(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS),
-                    second.get(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+            List<ProgressAttempt> attempts = List.of(
+                    first.get(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    second.get(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            );
             List<ProgressAttempt> winners = attempts.stream().filter(ProgressAttempt::succeeded).toList();
             List<ProgressAttempt> losers = attempts.stream().filter(attempt -> !attempt.succeeded()).toList();
-            assertThat(winners).hasSize(1);
-            assertThat(losers).hasSize(1);
+
+            assertThat(winners).as("canonical winner session=%d turn=1", opening.sessionId()).hasSize(1);
+            assertThat(losers).as("reservation loser session=%d turn=1", opening.sessionId()).hasSize(1);
             assertThat(losers.getFirst().error()).isInstanceOf(MutationInProgressException.class);
             assertThat(narrativeGenerator.progressCalls()).isEqualTo(1);
-            assertCanonicalTurn(opening.sessionId(), winners.getFirst().key(), 2, 2);
+
+            String winnerKey = winners.getFirst().key();
+            assertCanonicalTurn(opening.sessionId(), winnerKey, 2, 2);
             assertThat(reservationCount(opening.sessionId(), 1)).isZero();
         } finally {
             narrativeGenerator.releaseProgress();
@@ -168,36 +199,59 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
         GameResponse opening = createOpening("matrix-opening-crash");
         GameProgressRequest request = new GameProgressRequest(opening.sessionId(), 1, 1);
         String crashedKey = "matrix-crash-key-a";
+
         GameService crashingService = newGameService(new CrashBeforeCommitPersistence(persistenceService));
-        assertThatThrownBy(() -> crashingService.progressGame(progressContext(crashedKey, opening.sessionId()), request))
+
+        assertThatThrownBy(() -> crashingService.progressGame(
+                progressContext(crashedKey, opening.sessionId()), request
+        )).as(context("provider-success-before-crash", crashedKey, opening.sessionId(), 1))
                 .isInstanceOf(SimulatedCrash.class);
+
         Long crashedRequestId = requestId(crashedKey);
         String staleOwner = reservationOwner(opening.sessionId(), 1);
-        assertThat(narrativeGenerator.progressCalls()).isEqualTo(1);
-        assertThat(requestStatus(crashedKey)).isEqualTo("PROCESSING");
-        assertThat(reservationCount(opening.sessionId(), 1)).isEqualTo(1);
+        assertThat(narrativeGenerator.progressCalls()).as("provider calls before simulated crash").isEqualTo(1);
+        assertThat(requestStatus(crashedKey)).as("crashed request remains in-flight").isEqualTo("PROCESSING");
+        assertThat(reservationCount(opening.sessionId(), 1)).as("crashed active reservation").isEqualTo(1);
+
         clock.advance(Duration.ofSeconds(LEASE_SECONDS + 1));
         narrativeGenerator.blockNextProgress();
+
         String takeoverKey = "matrix-crash-key-b";
         ExecutorService executor = Executors.newSingleThreadExecutor();
         try {
             Future<GameResponse> takeover = executor.submit(() -> gameService.progressGame(
-                    progressContext(takeoverKey, opening.sessionId()), request));
+                    progressContext(takeoverKey, opening.sessionId()), request
+            ));
             narrativeGenerator.awaitProgressEntry();
-            assertThat(narrativeGenerator.progressCalls()).isEqualTo(2);
-            assertThat(reservationOwner(opening.sessionId(), 1)).isNotEqualTo(staleOwner);
+
+            assertThat(narrativeGenerator.progressCalls())
+                    .as("provider retry after deterministic lease expiry")
+                    .isEqualTo(2);
+            assertThat(reservationOwner(opening.sessionId(), 1))
+                    .as("reservation owner after takeover")
+                    .isNotEqualTo(staleOwner);
             assertThat(jdbcTemplate.queryForObject(
                     "select attempt_count from game_turn_reservation where session_id = ? and expected_turn = ?",
-                    Integer.class, opening.sessionId(), 1)).isEqualTo(2);
+                    Integer.class, opening.sessionId(), 1
+            )).as("legacy lease attempt_count session=%d turn=1", opening.sessionId()).isEqualTo(2);
             assertThat(jdbcTemplate.queryForObject(
                     "select provider_attempt_count from game_turn_reservation where session_id = ? and expected_turn = ?",
-                    Integer.class, opening.sessionId(), 1)).isEqualTo(2);
-            assertThatThrownBy(() -> commitWithReservation(opening.sessionId(), crashedRequestId, staleOwner, "stale-owner-story"))
-                    .isInstanceOf(TurnConflictException.class).hasMessageContaining("reservation");
+                    Integer.class, opening.sessionId(), 1
+            )).as("provider attempt count session=%d turn=1", opening.sessionId()).isEqualTo(2);
+
+            assertThatThrownBy(() -> commitWithReservation(
+                    opening.sessionId(), crashedRequestId, staleOwner, "stale-owner-story"
+            )).as(context("stale-owner-commit", crashedKey, opening.sessionId(), 1))
+                    .isInstanceOf(TurnConflictException.class)
+                    .hasMessageContaining("reservation");
+
             narrativeGenerator.releaseProgress();
             GameResponse recovered = takeover.get(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
             assertThat(recovered.turnNumber()).isEqualTo(2);
-            assertThat(narrativeGenerator.progressCalls()).isEqualTo(2);
+            assertThat(narrativeGenerator.progressCalls())
+                    .as("external provider strict exactly-once is intentionally not guaranteed after lease expiry")
+                    .isEqualTo(2);
             assertCanonicalTurn(opening.sessionId(), takeoverKey, 2, 2);
             assertThat(reservationCount(opening.sessionId(), 1)).isZero();
         } finally {
@@ -206,35 +260,57 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
         }
     }
 
-    private Callable<ProgressAttempt> concurrentProgressAttempt(CountDownLatch ready, CountDownLatch start,
-            CountDownLatch rejected, String key, GameProgressRequest request) {
+    private Callable<ProgressAttempt> concurrentProgressAttempt(
+            CountDownLatch ready,
+            CountDownLatch start,
+            CountDownLatch rejected,
+            String key,
+            GameProgressRequest request
+    ) {
         return () -> {
             ready.countDown();
             if (!start.await(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
                 return ProgressAttempt.failure(key, new IllegalStateException("동시 요청 시작 신호를 받지 못했습니다."));
             }
             try {
-                return ProgressAttempt.success(key, gameService.progressGame(progressContext(key, request.sessionId()), request));
+                GameResponse response = gameService.progressGame(
+                        progressContext(key, request.sessionId()), request
+                );
+                return ProgressAttempt.success(key, response);
             } catch (RuntimeException exception) {
-                if (exception instanceof MutationInProgressException) rejected.countDown();
+                if (exception instanceof MutationInProgressException) {
+                    rejected.countDown();
+                }
                 return ProgressAttempt.failure(key, exception);
             }
         };
     }
 
     private void awaitLatch(CountDownLatch latch, String phase) throws InterruptedException {
-        assertThat(latch.await(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS)).as(phase).isTrue();
+        assertThat(latch.await(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                .as("%s latch가 제한 시간 안에 완료되어야 한다", phase)
+                .isTrue();
     }
 
     private GameResponse createOpening(String key) {
-        return gameService.initGame(initContext(key), new GameInitRequest("matrix-world", "matrix-character"));
+        return gameService.initGame(
+                initContext(key),
+                new GameInitRequest("matrix-world", "matrix-character")
+        );
     }
 
     private GameService newGameService(GamePersistenceService persistence) {
-        SkillCheckDecisionService skillDecisions = new SkillCheckDecisionService(jdbcTemplate, clock);
-        TurnProcessor turnProcessor = new TurnProcessor(skillDecisions, (min, max) -> 10);
-        return new GameService(narrativeGenerator, imageAssetService, persistence, choiceCodec, turnProcessor,
-                imagePromptComposer, costRateLimiter, providerCallTelemetry, mutationFingerprint, mutationService);
+        return new GameService(
+                narrativeGenerator,
+                imageAssetService,
+                persistence,
+                choiceCodec,
+                imagePromptComposer,
+                costRateLimiter,
+                providerCallTelemetry,
+                mutationFingerprint,
+                mutationService
+        );
     }
 
     private CostRequestContext initContext(String key) {
@@ -248,53 +324,97 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
     private void commitWithReservation(Long sessionId, Long requestId, String reservationOwner, String story) {
         GamePersistenceService.LoadedTurn loaded = persistenceService.loadLatestTurn(OWNER_KEY, sessionId, 1);
         var nextState = loaded.gameState().advance("문을 연다", story);
-        GameTurnCommit commit = new GameTurnCommit(1, 1, "문을 연다", loaded.gameState(), nextState,
-                story, loaded.choicesJson(), null);
-        persistenceService.saveNextTurn(OWNER_KEY, sessionId, commit, requestId, "stale-owner-title", reservationOwner);
+        GameTurnCommit commit = new GameTurnCommit(
+                1,
+                1,
+                "문을 연다",
+                loaded.gameState(),
+                nextState,
+                story,
+                loaded.choicesJson(),
+                null
+        );
+        persistenceService.saveNextTurn(
+                OWNER_KEY,
+                sessionId,
+                commit,
+                requestId,
+                "stale-owner-title",
+                reservationOwner
+        );
     }
 
     private void assertCanonicalTurn(Long sessionId, String completedKey, int expectedTurn, int expectedLogCount) {
-        Integer sessionTurn = jdbcTemplate.queryForObject("select current_turn from game_session where id = ?", Integer.class, sessionId);
-        Integer logCount = jdbcTemplate.queryForObject("select count(*) from game_log where session_id = ?", Integer.class, sessionId);
-        Integer latestStateVersion = jdbcTemplate.queryForObject("select max(state_version) from game_log where session_id = ?", Integer.class, sessionId);
-        Integer snapshotTurn = persistenceService.loadLatestTurn(OWNER_KEY, sessionId, expectedTurn).gameState().turnNumber();
+        Integer sessionTurn = jdbcTemplate.queryForObject(
+                "select current_turn from game_session where id = ?", Integer.class, sessionId
+        );
+        Integer logCount = jdbcTemplate.queryForObject(
+                "select count(*) from game_log where session_id = ?", Integer.class, sessionId
+        );
+        Integer latestStateVersion = jdbcTemplate.queryForObject(
+                "select max(state_version) from game_log where session_id = ?", Integer.class, sessionId
+        );
+        Integer snapshotTurn = persistenceService.loadLatestTurn(OWNER_KEY, sessionId, expectedTurn)
+                .gameState()
+                .turnNumber();
         Integer requestResultTurn = jdbcTemplate.queryForObject(
                 "select result_turn from game_mutation_request where owner_key = ? and idempotency_key = ?",
-                Integer.class, OWNER_KEY, completedKey);
-        assertThat(sessionTurn).isEqualTo(expectedTurn);
-        assertThat(logCount).isEqualTo(expectedLogCount);
-        assertThat(latestStateVersion).isEqualTo(expectedTurn);
-        assertThat(snapshotTurn).isEqualTo(expectedTurn);
-        assertThat(requestStatus(completedKey)).isEqualTo("COMPLETED");
-        assertThat(requestResultTurn).isEqualTo(expectedTurn);
+                Integer.class, OWNER_KEY, completedKey
+        );
+
+        assertThat(sessionTurn).as("session=%d current_turn", sessionId).isEqualTo(expectedTurn);
+        assertThat(logCount).as("session=%d committed GameLog rows", sessionId).isEqualTo(expectedLogCount);
+        assertThat(latestStateVersion).as("session=%d latest GameLog state_version", sessionId).isEqualTo(expectedTurn);
+        assertThat(snapshotTurn).as("session=%d snapshot/currentTurn", sessionId).isEqualTo(expectedTurn);
+        assertThat(requestStatus(completedKey)).as("request=%s status", completedKey).isEqualTo("COMPLETED");
+        assertThat(requestResultTurn).as("request=%s result_turn", completedKey).isEqualTo(expectedTurn);
     }
 
     private Long requestId(String key) {
-        return jdbcTemplate.queryForObject("select id from game_mutation_request where owner_key = ? and idempotency_key = ?",
-                Long.class, OWNER_KEY, key);
+        return jdbcTemplate.queryForObject(
+                "select id from game_mutation_request where owner_key = ? and idempotency_key = ?",
+                Long.class, OWNER_KEY, key
+        );
     }
 
     private String requestStatus(String key) {
-        return jdbcTemplate.queryForObject("select status from game_mutation_request where owner_key = ? and idempotency_key = ?",
-                String.class, OWNER_KEY, key);
+        return jdbcTemplate.queryForObject(
+                "select status from game_mutation_request where owner_key = ? and idempotency_key = ?",
+                String.class, OWNER_KEY, key
+        );
     }
 
     private String reservationOwner(Long sessionId, int expectedTurn) {
-        return jdbcTemplate.queryForObject("select lease_owner from game_turn_reservation where session_id = ? and expected_turn = ?",
-                String.class, sessionId, expectedTurn);
+        return jdbcTemplate.queryForObject(
+                "select lease_owner from game_turn_reservation where session_id = ? and expected_turn = ?",
+                String.class, sessionId, expectedTurn
+        );
     }
 
     private int reservationCount(Long sessionId, int expectedTurn) {
         Integer count = jdbcTemplate.queryForObject(
                 "select count(*) from game_turn_reservation where session_id = ? and expected_turn = ?",
-                Integer.class, sessionId, expectedTurn);
+                Integer.class, sessionId, expectedTurn
+        );
         return count == null ? 0 : count;
     }
 
+    private String context(String phase, String key, Long sessionId, int turn) {
+        return "phase=%s request=%s session=%d turn=%d".formatted(phase, key, sessionId, turn);
+    }
+
     private record ProgressAttempt(String key, GameResponse response, RuntimeException error) {
-        static ProgressAttempt success(String key, GameResponse response) { return new ProgressAttempt(key, response, null); }
-        static ProgressAttempt failure(String key, RuntimeException error) { return new ProgressAttempt(key, null, error); }
-        boolean succeeded() { return response != null; }
+        static ProgressAttempt success(String key, GameResponse response) {
+            return new ProgressAttempt(key, response, null);
+        }
+
+        static ProgressAttempt failure(String key, RuntimeException error) {
+            return new ProgressAttempt(key, null, error);
+        }
+
+        boolean succeeded() {
+            return response != null;
+        }
     }
 
     private static final class FakeNarrativeGenerator implements NarrativeGenerator {
@@ -302,103 +422,205 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
         private final AtomicInteger progressCalls = new AtomicInteger();
         private final AtomicReference<CountDownLatch> progressEntered = new AtomicReference<>();
         private final AtomicReference<CountDownLatch> progressRelease = new AtomicReference<>();
-        @Override public NarrativeTurn createOpening(String worldSetting, String characterSetting) {
-            return turn("opening-title", "opening-story-" + openingCalls.incrementAndGet());
+
+        @Override
+        public NarrativeTurn createOpening(String worldSetting, String characterSetting) {
+            int call = openingCalls.incrementAndGet();
+            return turn("opening-title", "opening-story-" + call);
         }
-        @Override public NarrativeTurn createNextTurn(NarrativeContext context) {
+
+        @Override
+        public NarrativeTurn createNextTurn(NarrativeContext context) {
             int call = progressCalls.incrementAndGet();
             CountDownLatch entered = progressEntered.get();
             CountDownLatch release = progressRelease.get();
             if (entered != null && release != null) {
                 entered.countDown();
                 try {
-                    if (!release.await(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS)) throw new IllegalStateException("fake provider timeout");
+                    if (!release.await(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                        throw new IllegalStateException("fake provider release 신호가 제한 시간 안에 오지 않았습니다.");
+                    }
                 } catch (InterruptedException exception) {
                     Thread.currentThread().interrupt();
-                    throw new IllegalStateException("fake provider interrupted", exception);
+                    throw new IllegalStateException("fake provider가 중단되었습니다.", exception);
                 }
             }
             return turn("progress-title", "progress-story-" + call);
         }
-        void blockNextProgress() { progressEntered.set(new CountDownLatch(1)); progressRelease.set(new CountDownLatch(1)); }
+
+        void blockNextProgress() {
+            progressEntered.set(new CountDownLatch(1));
+            progressRelease.set(new CountDownLatch(1));
+        }
+
         void awaitProgressEntry() throws InterruptedException {
             CountDownLatch entered = progressEntered.get();
-            if (entered != null) assertThat(entered.await(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
+            if (entered != null) {
+                assertThat(entered.await(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                        .as("fake provider가 제한 시간 안에 진입해야 한다")
+                        .isTrue();
+            }
         }
+
         void releaseProgress() {
             CountDownLatch release = progressRelease.getAndSet(null);
-            if (release != null) release.countDown();
+            if (release != null) {
+                release.countDown();
+            }
             progressEntered.set(null);
         }
-        int openingCalls() { return openingCalls.get(); }
-        int progressCalls() { return progressCalls.get(); }
+
+        int openingCalls() {
+            return openingCalls.get();
+        }
+
+        int progressCalls() {
+            return progressCalls.get();
+        }
+
         private NarrativeTurn turn(String title, String story) {
-            return new NarrativeTurn(title, story, List.of(new NarrativeTurn.Choice(1, "문을 연다")),
-                    new NarrativeTurn.VisualAssets(null, List.of(), List.of()));
+            return new NarrativeTurn(
+                    title,
+                    story,
+                    List.of(new NarrativeTurn.Choice(1, "문을 연다")),
+                    new NarrativeTurn.VisualAssets(null, List.of(), List.of())
+            );
         }
     }
 
     private static final class TransactionalMutationService extends GameMutationRequestService {
         private final TransactionTemplate transactionTemplate;
-        TransactionalMutationService(GameMutationRequestRepository repository, JdbcTemplate jdbcTemplate, Clock clock,
-                long leaseSeconds, PlatformTransactionManager transactionManager) {
+
+        TransactionalMutationService(
+                GameMutationRequestRepository repository,
+                JdbcTemplate jdbcTemplate,
+                Clock clock,
+                long leaseSeconds,
+                PlatformTransactionManager transactionManager
+        ) {
             super(repository, jdbcTemplate, clock, leaseSeconds);
             this.transactionTemplate = new TransactionTemplate(transactionManager);
         }
-        @Override public BeginResult begin(String ownerKey, String operation, String idempotencyKey, Long sessionId,
-                Integer expectedTurn, String fingerprint) {
+
+        @Override
+        public BeginResult begin(
+                String ownerKey,
+                String operation,
+                String idempotencyKey,
+                Long sessionId,
+                Integer expectedTurn,
+                String fingerprint
+        ) {
             BeginOutcome outcome = transactionTemplate.execute(status -> {
-                try { return BeginOutcome.success(super.begin(ownerKey, operation, idempotencyKey, sessionId, expectedTurn, fingerprint)); }
-                catch (MutationInProgressException exception) { return BeginOutcome.blocked(exception); }
+                try {
+                    return BeginOutcome.success(super.begin(
+                            ownerKey, operation, idempotencyKey, sessionId, expectedTurn, fingerprint
+                    ));
+                } catch (MutationInProgressException exception) {
+                    return BeginOutcome.blocked(exception);
+                }
             });
-            if (outcome == null) throw new IllegalStateException("mutation begin transaction 결과가 없습니다.");
-            if (outcome.blocked() != null) throw outcome.blocked();
+            if (outcome == null) {
+                throw new IllegalStateException("mutation begin transaction 결과가 없습니다.");
+            }
+            if (outcome.blocked() != null) {
+                throw outcome.blocked();
+            }
             return outcome.result();
         }
-        @Override public void markProviderAttemptStarted(Long requestId, String reservationOwner) {
+
+        @Override
+        public void markProviderAttemptStarted(Long requestId, String reservationOwner) {
             MutationInProgressException blocked = transactionTemplate.execute(status -> {
-                try { super.markProviderAttemptStarted(requestId, reservationOwner); return null; }
-                catch (MutationInProgressException exception) { return exception; }
+                try {
+                    super.markProviderAttemptStarted(requestId, reservationOwner);
+                    return null;
+                } catch (MutationInProgressException exception) {
+                    return exception;
+                }
             });
-            if (blocked != null) throw blocked;
+            if (blocked != null) {
+                throw blocked;
+            }
         }
-        @Override public void markFailed(Long requestId) {
+
+        @Override
+        public void markFailed(Long requestId) {
             transactionTemplate.executeWithoutResult(status -> super.markFailed(requestId, null));
         }
-        @Override public void markFailed(Long requestId, String reservationOwner) {
+
+        @Override
+        public void markFailed(Long requestId, String reservationOwner) {
             transactionTemplate.executeWithoutResult(status -> super.markFailed(requestId, reservationOwner));
         }
+
         private record BeginOutcome(BeginResult result, MutationInProgressException blocked) {
-            static BeginOutcome success(BeginResult result) { return new BeginOutcome(result, null); }
-            static BeginOutcome blocked(MutationInProgressException exception) { return new BeginOutcome(null, exception); }
+            static BeginOutcome success(BeginResult result) {
+                return new BeginOutcome(result, null);
+            }
+
+            static BeginOutcome blocked(MutationInProgressException exception) {
+                return new BeginOutcome(null, exception);
+            }
         }
     }
 
     private static final class CrashBeforeCommitPersistence extends GamePersistenceService {
         private final GamePersistenceService delegate;
+
         CrashBeforeCommitPersistence(GamePersistenceService delegate) {
             super(null, null, null, null, null, null, null);
             this.delegate = delegate;
         }
-        @Override public LoadedTurn loadLatestTurn(String ownerKey, Long sessionId, int expectedTurn) {
+
+        @Override
+        public LoadedTurn loadLatestTurn(String ownerKey, Long sessionId, int expectedTurn) {
             return delegate.loadLatestTurn(ownerKey, sessionId, expectedTurn);
         }
-        @Override public int saveNextTurn(String ownerKey, Long sessionId, GameTurnCommit commit,
-                Long mutationRequestId, String resultTitle, String reservationOwner) {
+
+        @Override
+        public int saveNextTurn(
+                String ownerKey,
+                Long sessionId,
+                GameTurnCommit commit,
+                Long mutationRequestId,
+                String resultTitle,
+                String reservationOwner
+        ) {
             throw new SimulatedCrash();
         }
     }
 
     private static final class MutableClock extends Clock {
         private final AtomicReference<Instant> instant;
-        MutableClock(Instant initialInstant) { this.instant = new AtomicReference<>(initialInstant); }
-        void advance(Duration duration) { instant.updateAndGet(current -> current.plus(duration)); }
-        @Override public ZoneId getZone() { return ZoneOffset.UTC; }
-        @Override public Clock withZone(ZoneId zone) { return this; }
-        @Override public Instant instant() { return instant.get(); }
+
+        MutableClock(Instant initialInstant) {
+            this.instant = new AtomicReference<>(initialInstant);
+        }
+
+        void advance(Duration duration) {
+            instant.updateAndGet(current -> current.plus(duration));
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return instant.get();
+        }
     }
 
     private static final class SimulatedCrash extends Error {
-        SimulatedCrash() { super("simulated process crash after provider success"); }
+        SimulatedCrash() {
+            super("simulated process crash after provider success");
+        }
     }
 }

--- a/src/test/java/com/uctale/uctale/persistence/PostgresM2TurnIntegrityMatrixTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/PostgresM2TurnIntegrityMatrixTest.java
@@ -11,7 +11,9 @@ import com.uctale.uctale.application.game.GameTurnCommit;
 import com.uctale.uctale.application.game.IdempotencyConflictException;
 import com.uctale.uctale.application.game.ImagePromptComposer;
 import com.uctale.uctale.application.game.MutationInProgressException;
+import com.uctale.uctale.application.game.SkillCheckDecisionService;
 import com.uctale.uctale.application.game.TurnConflictException;
+import com.uctale.uctale.application.game.TurnProcessor;
 import com.uctale.uctale.application.image.ImageAssetService;
 import com.uctale.uctale.application.narrative.NarrativeContext;
 import com.uctale.uctale.application.narrative.NarrativeGenerator;
@@ -81,12 +83,7 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
                 """);
         clock = new MutableClock(Instant.parse("2026-08-31T04:00:00Z"));
         mutationService = new TransactionalMutationService(
-                mutationRequestRepository,
-                jdbcTemplate,
-                clock,
-                LEASE_SECONDS,
-                transactionManager
-        );
+                mutationRequestRepository, jdbcTemplate, clock, LEASE_SECONDS, transactionManager);
         narrativeGenerator = new FakeNarrativeGenerator();
         gameService = newGameService(persistenceService);
     }
@@ -96,25 +93,17 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
     void completedInitRetry_ReusesCanonicalOpeningExactlyOnce() {
         String key = "matrix-init-key-001";
         GameInitRequest request = new GameInitRequest("matrix-world", "matrix-character");
-
         GameResponse first = gameService.initGame(initContext(key), request);
         GameResponse retry = gameService.initGame(initContext(key), request);
-
         assertThat(retry.sessionId()).isEqualTo(first.sessionId());
         assertThat(retry.turnNumber()).isEqualTo(1);
         assertThat(retry.storyText()).isEqualTo(first.storyText());
-        assertThat(narrativeGenerator.openingCalls()).as("NarrativeGenerator opening calls").isEqualTo(1);
-        assertThat(jdbcTemplate.queryForObject("select count(*) from game_session", Integer.class))
-                .as("canonical session count after init retry")
-                .isEqualTo(1);
-
-        assertThatThrownBy(() -> gameService.initGame(
-                initContext(key),
-                new GameInitRequest("different-world", "matrix-character")
-        )).as("phase=init-fingerprint-conflict request=%s", key)
+        assertThat(narrativeGenerator.openingCalls()).isEqualTo(1);
+        assertThat(jdbcTemplate.queryForObject("select count(*) from game_session", Integer.class)).isEqualTo(1);
+        assertThatThrownBy(() -> gameService.initGame(initContext(key),
+                new GameInitRequest("different-world", "matrix-character")))
                 .isInstanceOf(IdempotencyConflictException.class);
-        assertThat(narrativeGenerator.openingCalls()).as("provider calls after init fingerprint conflict").isEqualTo(1);
-
+        assertThat(narrativeGenerator.openingCalls()).isEqualTo(1);
         assertCanonicalTurn(first.sessionId(), key, 1, 1);
     }
 
@@ -124,22 +113,16 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
         GameResponse opening = createOpening("matrix-opening-progress");
         String key = "matrix-progress-key-001";
         GameProgressRequest request = new GameProgressRequest(opening.sessionId(), 1, 1);
-
         GameResponse first = gameService.progressGame(progressContext(key, opening.sessionId()), request);
         GameResponse retry = gameService.progressGame(progressContext(key, opening.sessionId()), request);
-
         assertThat(retry.sessionId()).isEqualTo(first.sessionId());
         assertThat(retry.turnNumber()).isEqualTo(2);
         assertThat(retry.storyText()).isEqualTo(first.storyText());
-        assertThat(narrativeGenerator.progressCalls()).as("NarrativeGenerator progress calls").isEqualTo(1);
-
-        assertThatThrownBy(() -> gameService.progressGame(
-                progressContext(key, opening.sessionId()),
-                new GameProgressRequest(opening.sessionId(), 2, 1)
-        )).as(context("progress-fingerprint-conflict", key, opening.sessionId(), 1))
+        assertThat(narrativeGenerator.progressCalls()).isEqualTo(1);
+        assertThatThrownBy(() -> gameService.progressGame(progressContext(key, opening.sessionId()),
+                new GameProgressRequest(opening.sessionId(), 2, 1)))
                 .isInstanceOf(IdempotencyConflictException.class);
-        assertThat(narrativeGenerator.progressCalls()).as("provider calls after progress fingerprint conflict").isEqualTo(1);
-
+        assertThat(narrativeGenerator.progressCalls()).isEqualTo(1);
         assertCanonicalTurn(opening.sessionId(), key, 2, 2);
     }
 
@@ -149,43 +132,29 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
         GameResponse opening = createOpening("matrix-opening-concurrency");
         GameProgressRequest request = new GameProgressRequest(opening.sessionId(), 1, 1);
         narrativeGenerator.blockNextProgress();
-
         CountDownLatch ready = new CountDownLatch(2);
         CountDownLatch start = new CountDownLatch(1);
         CountDownLatch rejected = new CountDownLatch(1);
         ExecutorService executor = Executors.newFixedThreadPool(2);
-
         try {
-            Future<ProgressAttempt> first = executor.submit(concurrentProgressAttempt(
-                    ready, start, rejected, "matrix-concurrent-key-a", request
-            ));
-            Future<ProgressAttempt> second = executor.submit(concurrentProgressAttempt(
-                    ready, start, rejected, "matrix-concurrent-key-b", request
-            ));
-
+            Future<ProgressAttempt> first = executor.submit(concurrentProgressAttempt(ready, start, rejected, "matrix-concurrent-key-a", request));
+            Future<ProgressAttempt> second = executor.submit(concurrentProgressAttempt(ready, start, rejected, "matrix-concurrent-key-b", request));
             awaitLatch(ready, "동시 요청 준비");
             start.countDown();
             narrativeGenerator.awaitProgressEntry();
             awaitLatch(rejected, "reservation 경쟁 요청 거부");
-
-            assertThat(narrativeGenerator.progressCalls()).as("provider calls while lease is active").isEqualTo(1);
-            assertThat(reservationCount(opening.sessionId(), 1)).as("active reservation rows").isEqualTo(1);
-
+            assertThat(narrativeGenerator.progressCalls()).isEqualTo(1);
+            assertThat(reservationCount(opening.sessionId(), 1)).isEqualTo(1);
             narrativeGenerator.releaseProgress();
-            List<ProgressAttempt> attempts = List.of(
-                    first.get(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS),
-                    second.get(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-            );
+            List<ProgressAttempt> attempts = List.of(first.get(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    second.get(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS));
             List<ProgressAttempt> winners = attempts.stream().filter(ProgressAttempt::succeeded).toList();
             List<ProgressAttempt> losers = attempts.stream().filter(attempt -> !attempt.succeeded()).toList();
-
-            assertThat(winners).as("canonical winner session=%d turn=1", opening.sessionId()).hasSize(1);
-            assertThat(losers).as("reservation loser session=%d turn=1", opening.sessionId()).hasSize(1);
+            assertThat(winners).hasSize(1);
+            assertThat(losers).hasSize(1);
             assertThat(losers.getFirst().error()).isInstanceOf(MutationInProgressException.class);
             assertThat(narrativeGenerator.progressCalls()).isEqualTo(1);
-
-            String winnerKey = winners.getFirst().key();
-            assertCanonicalTurn(opening.sessionId(), winnerKey, 2, 2);
+            assertCanonicalTurn(opening.sessionId(), winners.getFirst().key(), 2, 2);
             assertThat(reservationCount(opening.sessionId(), 1)).isZero();
         } finally {
             narrativeGenerator.releaseProgress();
@@ -199,59 +168,36 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
         GameResponse opening = createOpening("matrix-opening-crash");
         GameProgressRequest request = new GameProgressRequest(opening.sessionId(), 1, 1);
         String crashedKey = "matrix-crash-key-a";
-
         GameService crashingService = newGameService(new CrashBeforeCommitPersistence(persistenceService));
-
-        assertThatThrownBy(() -> crashingService.progressGame(
-                progressContext(crashedKey, opening.sessionId()), request
-        )).as(context("provider-success-before-crash", crashedKey, opening.sessionId(), 1))
+        assertThatThrownBy(() -> crashingService.progressGame(progressContext(crashedKey, opening.sessionId()), request))
                 .isInstanceOf(SimulatedCrash.class);
-
         Long crashedRequestId = requestId(crashedKey);
         String staleOwner = reservationOwner(opening.sessionId(), 1);
-        assertThat(narrativeGenerator.progressCalls()).as("provider calls before simulated crash").isEqualTo(1);
-        assertThat(requestStatus(crashedKey)).as("crashed request remains in-flight").isEqualTo("PROCESSING");
-        assertThat(reservationCount(opening.sessionId(), 1)).as("crashed active reservation").isEqualTo(1);
-
+        assertThat(narrativeGenerator.progressCalls()).isEqualTo(1);
+        assertThat(requestStatus(crashedKey)).isEqualTo("PROCESSING");
+        assertThat(reservationCount(opening.sessionId(), 1)).isEqualTo(1);
         clock.advance(Duration.ofSeconds(LEASE_SECONDS + 1));
         narrativeGenerator.blockNextProgress();
-
         String takeoverKey = "matrix-crash-key-b";
         ExecutorService executor = Executors.newSingleThreadExecutor();
         try {
             Future<GameResponse> takeover = executor.submit(() -> gameService.progressGame(
-                    progressContext(takeoverKey, opening.sessionId()), request
-            ));
+                    progressContext(takeoverKey, opening.sessionId()), request));
             narrativeGenerator.awaitProgressEntry();
-
-            assertThat(narrativeGenerator.progressCalls())
-                    .as("provider retry after deterministic lease expiry")
-                    .isEqualTo(2);
-            assertThat(reservationOwner(opening.sessionId(), 1))
-                    .as("reservation owner after takeover")
-                    .isNotEqualTo(staleOwner);
+            assertThat(narrativeGenerator.progressCalls()).isEqualTo(2);
+            assertThat(reservationOwner(opening.sessionId(), 1)).isNotEqualTo(staleOwner);
             assertThat(jdbcTemplate.queryForObject(
                     "select attempt_count from game_turn_reservation where session_id = ? and expected_turn = ?",
-                    Integer.class, opening.sessionId(), 1
-            )).as("legacy lease attempt_count session=%d turn=1", opening.sessionId()).isEqualTo(2);
+                    Integer.class, opening.sessionId(), 1)).isEqualTo(2);
             assertThat(jdbcTemplate.queryForObject(
                     "select provider_attempt_count from game_turn_reservation where session_id = ? and expected_turn = ?",
-                    Integer.class, opening.sessionId(), 1
-            )).as("provider attempt count session=%d turn=1", opening.sessionId()).isEqualTo(2);
-
-            assertThatThrownBy(() -> commitWithReservation(
-                    opening.sessionId(), crashedRequestId, staleOwner, "stale-owner-story"
-            )).as(context("stale-owner-commit", crashedKey, opening.sessionId(), 1))
-                    .isInstanceOf(TurnConflictException.class)
-                    .hasMessageContaining("reservation");
-
+                    Integer.class, opening.sessionId(), 1)).isEqualTo(2);
+            assertThatThrownBy(() -> commitWithReservation(opening.sessionId(), crashedRequestId, staleOwner, "stale-owner-story"))
+                    .isInstanceOf(TurnConflictException.class).hasMessageContaining("reservation");
             narrativeGenerator.releaseProgress();
             GameResponse recovered = takeover.get(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-
             assertThat(recovered.turnNumber()).isEqualTo(2);
-            assertThat(narrativeGenerator.progressCalls())
-                    .as("external provider strict exactly-once is intentionally not guaranteed after lease expiry")
-                    .isEqualTo(2);
+            assertThat(narrativeGenerator.progressCalls()).isEqualTo(2);
             assertCanonicalTurn(opening.sessionId(), takeoverKey, 2, 2);
             assertThat(reservationCount(opening.sessionId(), 1)).isZero();
         } finally {
@@ -260,57 +206,35 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
         }
     }
 
-    private Callable<ProgressAttempt> concurrentProgressAttempt(
-            CountDownLatch ready,
-            CountDownLatch start,
-            CountDownLatch rejected,
-            String key,
-            GameProgressRequest request
-    ) {
+    private Callable<ProgressAttempt> concurrentProgressAttempt(CountDownLatch ready, CountDownLatch start,
+            CountDownLatch rejected, String key, GameProgressRequest request) {
         return () -> {
             ready.countDown();
             if (!start.await(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
                 return ProgressAttempt.failure(key, new IllegalStateException("동시 요청 시작 신호를 받지 못했습니다."));
             }
             try {
-                GameResponse response = gameService.progressGame(
-                        progressContext(key, request.sessionId()), request
-                );
-                return ProgressAttempt.success(key, response);
+                return ProgressAttempt.success(key, gameService.progressGame(progressContext(key, request.sessionId()), request));
             } catch (RuntimeException exception) {
-                if (exception instanceof MutationInProgressException) {
-                    rejected.countDown();
-                }
+                if (exception instanceof MutationInProgressException) rejected.countDown();
                 return ProgressAttempt.failure(key, exception);
             }
         };
     }
 
     private void awaitLatch(CountDownLatch latch, String phase) throws InterruptedException {
-        assertThat(latch.await(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS))
-                .as("%s latch가 제한 시간 안에 완료되어야 한다", phase)
-                .isTrue();
+        assertThat(latch.await(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS)).as(phase).isTrue();
     }
 
     private GameResponse createOpening(String key) {
-        return gameService.initGame(
-                initContext(key),
-                new GameInitRequest("matrix-world", "matrix-character")
-        );
+        return gameService.initGame(initContext(key), new GameInitRequest("matrix-world", "matrix-character"));
     }
 
     private GameService newGameService(GamePersistenceService persistence) {
-        return new GameService(
-                narrativeGenerator,
-                imageAssetService,
-                persistence,
-                choiceCodec,
-                imagePromptComposer,
-                costRateLimiter,
-                providerCallTelemetry,
-                mutationFingerprint,
-                mutationService
-        );
+        SkillCheckDecisionService skillDecisions = new SkillCheckDecisionService(jdbcTemplate, clock);
+        TurnProcessor turnProcessor = new TurnProcessor(skillDecisions, (min, max) -> 10);
+        return new GameService(narrativeGenerator, imageAssetService, persistence, choiceCodec, turnProcessor,
+                imagePromptComposer, costRateLimiter, providerCallTelemetry, mutationFingerprint, mutationService);
     }
 
     private CostRequestContext initContext(String key) {
@@ -324,97 +248,53 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
     private void commitWithReservation(Long sessionId, Long requestId, String reservationOwner, String story) {
         GamePersistenceService.LoadedTurn loaded = persistenceService.loadLatestTurn(OWNER_KEY, sessionId, 1);
         var nextState = loaded.gameState().advance("문을 연다", story);
-        GameTurnCommit commit = new GameTurnCommit(
-                1,
-                1,
-                "문을 연다",
-                loaded.gameState(),
-                nextState,
-                story,
-                loaded.choicesJson(),
-                null
-        );
-        persistenceService.saveNextTurn(
-                OWNER_KEY,
-                sessionId,
-                commit,
-                requestId,
-                "stale-owner-title",
-                reservationOwner
-        );
+        GameTurnCommit commit = new GameTurnCommit(1, 1, "문을 연다", loaded.gameState(), nextState,
+                story, loaded.choicesJson(), null);
+        persistenceService.saveNextTurn(OWNER_KEY, sessionId, commit, requestId, "stale-owner-title", reservationOwner);
     }
 
     private void assertCanonicalTurn(Long sessionId, String completedKey, int expectedTurn, int expectedLogCount) {
-        Integer sessionTurn = jdbcTemplate.queryForObject(
-                "select current_turn from game_session where id = ?", Integer.class, sessionId
-        );
-        Integer logCount = jdbcTemplate.queryForObject(
-                "select count(*) from game_log where session_id = ?", Integer.class, sessionId
-        );
-        Integer latestStateVersion = jdbcTemplate.queryForObject(
-                "select max(state_version) from game_log where session_id = ?", Integer.class, sessionId
-        );
-        Integer snapshotTurn = persistenceService.loadLatestTurn(OWNER_KEY, sessionId, expectedTurn)
-                .gameState()
-                .turnNumber();
+        Integer sessionTurn = jdbcTemplate.queryForObject("select current_turn from game_session where id = ?", Integer.class, sessionId);
+        Integer logCount = jdbcTemplate.queryForObject("select count(*) from game_log where session_id = ?", Integer.class, sessionId);
+        Integer latestStateVersion = jdbcTemplate.queryForObject("select max(state_version) from game_log where session_id = ?", Integer.class, sessionId);
+        Integer snapshotTurn = persistenceService.loadLatestTurn(OWNER_KEY, sessionId, expectedTurn).gameState().turnNumber();
         Integer requestResultTurn = jdbcTemplate.queryForObject(
                 "select result_turn from game_mutation_request where owner_key = ? and idempotency_key = ?",
-                Integer.class, OWNER_KEY, completedKey
-        );
-
-        assertThat(sessionTurn).as("session=%d current_turn", sessionId).isEqualTo(expectedTurn);
-        assertThat(logCount).as("session=%d committed GameLog rows", sessionId).isEqualTo(expectedLogCount);
-        assertThat(latestStateVersion).as("session=%d latest GameLog state_version", sessionId).isEqualTo(expectedTurn);
-        assertThat(snapshotTurn).as("session=%d snapshot/currentTurn", sessionId).isEqualTo(expectedTurn);
-        assertThat(requestStatus(completedKey)).as("request=%s status", completedKey).isEqualTo("COMPLETED");
-        assertThat(requestResultTurn).as("request=%s result_turn", completedKey).isEqualTo(expectedTurn);
+                Integer.class, OWNER_KEY, completedKey);
+        assertThat(sessionTurn).isEqualTo(expectedTurn);
+        assertThat(logCount).isEqualTo(expectedLogCount);
+        assertThat(latestStateVersion).isEqualTo(expectedTurn);
+        assertThat(snapshotTurn).isEqualTo(expectedTurn);
+        assertThat(requestStatus(completedKey)).isEqualTo("COMPLETED");
+        assertThat(requestResultTurn).isEqualTo(expectedTurn);
     }
 
     private Long requestId(String key) {
-        return jdbcTemplate.queryForObject(
-                "select id from game_mutation_request where owner_key = ? and idempotency_key = ?",
-                Long.class, OWNER_KEY, key
-        );
+        return jdbcTemplate.queryForObject("select id from game_mutation_request where owner_key = ? and idempotency_key = ?",
+                Long.class, OWNER_KEY, key);
     }
 
     private String requestStatus(String key) {
-        return jdbcTemplate.queryForObject(
-                "select status from game_mutation_request where owner_key = ? and idempotency_key = ?",
-                String.class, OWNER_KEY, key
-        );
+        return jdbcTemplate.queryForObject("select status from game_mutation_request where owner_key = ? and idempotency_key = ?",
+                String.class, OWNER_KEY, key);
     }
 
     private String reservationOwner(Long sessionId, int expectedTurn) {
-        return jdbcTemplate.queryForObject(
-                "select lease_owner from game_turn_reservation where session_id = ? and expected_turn = ?",
-                String.class, sessionId, expectedTurn
-        );
+        return jdbcTemplate.queryForObject("select lease_owner from game_turn_reservation where session_id = ? and expected_turn = ?",
+                String.class, sessionId, expectedTurn);
     }
 
     private int reservationCount(Long sessionId, int expectedTurn) {
         Integer count = jdbcTemplate.queryForObject(
                 "select count(*) from game_turn_reservation where session_id = ? and expected_turn = ?",
-                Integer.class, sessionId, expectedTurn
-        );
+                Integer.class, sessionId, expectedTurn);
         return count == null ? 0 : count;
     }
 
-    private String context(String phase, String key, Long sessionId, int turn) {
-        return "phase=%s request=%s session=%d turn=%d".formatted(phase, key, sessionId, turn);
-    }
-
     private record ProgressAttempt(String key, GameResponse response, RuntimeException error) {
-        static ProgressAttempt success(String key, GameResponse response) {
-            return new ProgressAttempt(key, response, null);
-        }
-
-        static ProgressAttempt failure(String key, RuntimeException error) {
-            return new ProgressAttempt(key, null, error);
-        }
-
-        boolean succeeded() {
-            return response != null;
-        }
+        static ProgressAttempt success(String key, GameResponse response) { return new ProgressAttempt(key, response, null); }
+        static ProgressAttempt failure(String key, RuntimeException error) { return new ProgressAttempt(key, null, error); }
+        boolean succeeded() { return response != null; }
     }
 
     private static final class FakeNarrativeGenerator implements NarrativeGenerator {
@@ -422,205 +302,103 @@ class PostgresM2TurnIntegrityMatrixTest extends PostgresIntegrationTestSupport {
         private final AtomicInteger progressCalls = new AtomicInteger();
         private final AtomicReference<CountDownLatch> progressEntered = new AtomicReference<>();
         private final AtomicReference<CountDownLatch> progressRelease = new AtomicReference<>();
-
-        @Override
-        public NarrativeTurn createOpening(String worldSetting, String characterSetting) {
-            int call = openingCalls.incrementAndGet();
-            return turn("opening-title", "opening-story-" + call);
+        @Override public NarrativeTurn createOpening(String worldSetting, String characterSetting) {
+            return turn("opening-title", "opening-story-" + openingCalls.incrementAndGet());
         }
-
-        @Override
-        public NarrativeTurn createNextTurn(NarrativeContext context) {
+        @Override public NarrativeTurn createNextTurn(NarrativeContext context) {
             int call = progressCalls.incrementAndGet();
             CountDownLatch entered = progressEntered.get();
             CountDownLatch release = progressRelease.get();
             if (entered != null && release != null) {
                 entered.countDown();
                 try {
-                    if (!release.await(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-                        throw new IllegalStateException("fake provider release 신호가 제한 시간 안에 오지 않았습니다.");
-                    }
+                    if (!release.await(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS)) throw new IllegalStateException("fake provider timeout");
                 } catch (InterruptedException exception) {
                     Thread.currentThread().interrupt();
-                    throw new IllegalStateException("fake provider가 중단되었습니다.", exception);
+                    throw new IllegalStateException("fake provider interrupted", exception);
                 }
             }
             return turn("progress-title", "progress-story-" + call);
         }
-
-        void blockNextProgress() {
-            progressEntered.set(new CountDownLatch(1));
-            progressRelease.set(new CountDownLatch(1));
-        }
-
+        void blockNextProgress() { progressEntered.set(new CountDownLatch(1)); progressRelease.set(new CountDownLatch(1)); }
         void awaitProgressEntry() throws InterruptedException {
             CountDownLatch entered = progressEntered.get();
-            if (entered != null) {
-                assertThat(entered.await(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS))
-                        .as("fake provider가 제한 시간 안에 진입해야 한다")
-                        .isTrue();
-            }
+            if (entered != null) assertThat(entered.await(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
         }
-
         void releaseProgress() {
             CountDownLatch release = progressRelease.getAndSet(null);
-            if (release != null) {
-                release.countDown();
-            }
+            if (release != null) release.countDown();
             progressEntered.set(null);
         }
-
-        int openingCalls() {
-            return openingCalls.get();
-        }
-
-        int progressCalls() {
-            return progressCalls.get();
-        }
-
+        int openingCalls() { return openingCalls.get(); }
+        int progressCalls() { return progressCalls.get(); }
         private NarrativeTurn turn(String title, String story) {
-            return new NarrativeTurn(
-                    title,
-                    story,
-                    List.of(new NarrativeTurn.Choice(1, "문을 연다")),
-                    new NarrativeTurn.VisualAssets(null, List.of(), List.of())
-            );
+            return new NarrativeTurn(title, story, List.of(new NarrativeTurn.Choice(1, "문을 연다")),
+                    new NarrativeTurn.VisualAssets(null, List.of(), List.of()));
         }
     }
 
     private static final class TransactionalMutationService extends GameMutationRequestService {
         private final TransactionTemplate transactionTemplate;
-
-        TransactionalMutationService(
-                GameMutationRequestRepository repository,
-                JdbcTemplate jdbcTemplate,
-                Clock clock,
-                long leaseSeconds,
-                PlatformTransactionManager transactionManager
-        ) {
+        TransactionalMutationService(GameMutationRequestRepository repository, JdbcTemplate jdbcTemplate, Clock clock,
+                long leaseSeconds, PlatformTransactionManager transactionManager) {
             super(repository, jdbcTemplate, clock, leaseSeconds);
             this.transactionTemplate = new TransactionTemplate(transactionManager);
         }
-
-        @Override
-        public BeginResult begin(
-                String ownerKey,
-                String operation,
-                String idempotencyKey,
-                Long sessionId,
-                Integer expectedTurn,
-                String fingerprint
-        ) {
+        @Override public BeginResult begin(String ownerKey, String operation, String idempotencyKey, Long sessionId,
+                Integer expectedTurn, String fingerprint) {
             BeginOutcome outcome = transactionTemplate.execute(status -> {
-                try {
-                    return BeginOutcome.success(super.begin(
-                            ownerKey, operation, idempotencyKey, sessionId, expectedTurn, fingerprint
-                    ));
-                } catch (MutationInProgressException exception) {
-                    return BeginOutcome.blocked(exception);
-                }
+                try { return BeginOutcome.success(super.begin(ownerKey, operation, idempotencyKey, sessionId, expectedTurn, fingerprint)); }
+                catch (MutationInProgressException exception) { return BeginOutcome.blocked(exception); }
             });
-            if (outcome == null) {
-                throw new IllegalStateException("mutation begin transaction 결과가 없습니다.");
-            }
-            if (outcome.blocked() != null) {
-                throw outcome.blocked();
-            }
+            if (outcome == null) throw new IllegalStateException("mutation begin transaction 결과가 없습니다.");
+            if (outcome.blocked() != null) throw outcome.blocked();
             return outcome.result();
         }
-
-        @Override
-        public void markProviderAttemptStarted(Long requestId, String reservationOwner) {
+        @Override public void markProviderAttemptStarted(Long requestId, String reservationOwner) {
             MutationInProgressException blocked = transactionTemplate.execute(status -> {
-                try {
-                    super.markProviderAttemptStarted(requestId, reservationOwner);
-                    return null;
-                } catch (MutationInProgressException exception) {
-                    return exception;
-                }
+                try { super.markProviderAttemptStarted(requestId, reservationOwner); return null; }
+                catch (MutationInProgressException exception) { return exception; }
             });
-            if (blocked != null) {
-                throw blocked;
-            }
+            if (blocked != null) throw blocked;
         }
-
-        @Override
-        public void markFailed(Long requestId) {
+        @Override public void markFailed(Long requestId) {
             transactionTemplate.executeWithoutResult(status -> super.markFailed(requestId, null));
         }
-
-        @Override
-        public void markFailed(Long requestId, String reservationOwner) {
+        @Override public void markFailed(Long requestId, String reservationOwner) {
             transactionTemplate.executeWithoutResult(status -> super.markFailed(requestId, reservationOwner));
         }
-
         private record BeginOutcome(BeginResult result, MutationInProgressException blocked) {
-            static BeginOutcome success(BeginResult result) {
-                return new BeginOutcome(result, null);
-            }
-
-            static BeginOutcome blocked(MutationInProgressException exception) {
-                return new BeginOutcome(null, exception);
-            }
+            static BeginOutcome success(BeginResult result) { return new BeginOutcome(result, null); }
+            static BeginOutcome blocked(MutationInProgressException exception) { return new BeginOutcome(null, exception); }
         }
     }
 
     private static final class CrashBeforeCommitPersistence extends GamePersistenceService {
         private final GamePersistenceService delegate;
-
         CrashBeforeCommitPersistence(GamePersistenceService delegate) {
             super(null, null, null, null, null, null, null);
             this.delegate = delegate;
         }
-
-        @Override
-        public LoadedTurn loadLatestTurn(String ownerKey, Long sessionId, int expectedTurn) {
+        @Override public LoadedTurn loadLatestTurn(String ownerKey, Long sessionId, int expectedTurn) {
             return delegate.loadLatestTurn(ownerKey, sessionId, expectedTurn);
         }
-
-        @Override
-        public int saveNextTurn(
-                String ownerKey,
-                Long sessionId,
-                GameTurnCommit commit,
-                Long mutationRequestId,
-                String resultTitle,
-                String reservationOwner
-        ) {
+        @Override public int saveNextTurn(String ownerKey, Long sessionId, GameTurnCommit commit,
+                Long mutationRequestId, String resultTitle, String reservationOwner) {
             throw new SimulatedCrash();
         }
     }
 
     private static final class MutableClock extends Clock {
         private final AtomicReference<Instant> instant;
-
-        MutableClock(Instant initialInstant) {
-            this.instant = new AtomicReference<>(initialInstant);
-        }
-
-        void advance(Duration duration) {
-            instant.updateAndGet(current -> current.plus(duration));
-        }
-
-        @Override
-        public ZoneId getZone() {
-            return ZoneOffset.UTC;
-        }
-
-        @Override
-        public Clock withZone(ZoneId zone) {
-            return this;
-        }
-
-        @Override
-        public Instant instant() {
-            return instant.get();
-        }
+        MutableClock(Instant initialInstant) { this.instant = new AtomicReference<>(initialInstant); }
+        void advance(Duration duration) { instant.updateAndGet(current -> current.plus(duration)); }
+        @Override public ZoneId getZone() { return ZoneOffset.UTC; }
+        @Override public Clock withZone(ZoneId zone) { return this; }
+        @Override public Instant instant() { return instant.get(); }
     }
 
     private static final class SimulatedCrash extends Error {
-        SimulatedCrash() {
-            super("simulated process crash after provider success");
-        }
+        SimulatedCrash() { super("simulated process crash after provider success"); }
     }
 }

--- a/src/test/java/com/uctale/uctale/persistence/PostgresSkillCheckAuditTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/PostgresSkillCheckAuditTest.java
@@ -27,10 +27,10 @@ class PostgresSkillCheckAuditTest extends PostgresIntegrationTestSupport {
 
     @BeforeEach
     void cleanUp() {
-        jdbcTemplate.update("DELETE FROM game_turn_reservation");
-        jdbcTemplate.update("DELETE FROM game_mutation_request");
-        logRepository.deleteAll();
-        sessionRepository.deleteAll();
+        jdbcTemplate.execute("""
+                truncate table game_turn_reservation, game_mutation_request, image_asset,
+                    game_state_snapshot, game_log, game_session restart identity
+                """);
     }
 
     @Test

--- a/src/test/java/com/uctale/uctale/persistence/PostgresSkillCheckAuditTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/PostgresSkillCheckAuditTest.java
@@ -1,0 +1,57 @@
+package com.uctale.uctale.persistence;
+
+import com.uctale.uctale.domain.GameLog;
+import com.uctale.uctale.domain.GameSession;
+import com.uctale.uctale.domain.game.SkillCheckOutcome;
+import com.uctale.uctale.domain.game.SkillCheckResult;
+import com.uctale.uctale.domain.game.StatType;
+import com.uctale.uctale.repository.GameLogRepository;
+import com.uctale.uctale.repository.GameSessionRepository;
+import com.uctale.uctale.support.PostgresIntegrationTestSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class PostgresSkillCheckAuditTest extends PostgresIntegrationTestSupport {
+    private static final String OWNER_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+    @Autowired private GameSessionRepository sessionRepository;
+    @Autowired private GameLogRepository logRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanUp() {
+        jdbcTemplate.update("DELETE FROM game_turn_reservation");
+        jdbcTemplate.update("DELETE FROM game_mutation_request");
+        logRepository.deleteAll();
+        sessionRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("GameLog에서 raw roll부터 outcome까지 Skill Check 감사 정보를 조회할 수 있다")
+    void committedLog_PersistsCompleteSkillCheckAudit() {
+        GameSession session = sessionRepository.saveAndFlush(new GameSession(OWNER_KEY, "세계", "캐릭터"));
+        SkillCheckResult result = new SkillCheckResult(
+                StatType.WILL, 13, 0, -1, 12, 12, SkillCheckOutcome.SUCCESS, 1);
+        logRepository.saveAndFlush(GameLog.committedTurn(
+                session, 2, 1, "문을 연다", 1, 2,
+                "game-result:1:2:1", "story:test", result,
+                "문이 열렸다.", "[]", null));
+
+        GameLog saved = logRepository.findByGameSessionAndTurnNumber(session, 2).orElseThrow();
+        assertThat(saved.getSkillCheckStatType()).isEqualTo("WILL");
+        assertThat(saved.getSkillCheckRawRoll()).isEqualTo(13);
+        assertThat(saved.getSkillCheckStatModifier()).isZero();
+        assertThat(saved.getSkillCheckSituationalModifier()).isEqualTo(-1);
+        assertThat(saved.getSkillCheckDc()).isEqualTo(12);
+        assertThat(saved.getSkillCheckTotal()).isEqualTo(12);
+        assertThat(saved.getSkillCheckOutcome()).isEqualTo("SUCCESS");
+        assertThat(saved.getSkillCheckRulesetVersion()).isEqualTo(1);
+    }
+}

--- a/src/test/java/com/uctale/uctale/persistence/PostgresSkillCheckDecisionTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/PostgresSkillCheckDecisionTest.java
@@ -1,0 +1,87 @@
+package com.uctale.uctale.persistence;
+
+import com.uctale.uctale.application.game.GameMutationRequestService;
+import com.uctale.uctale.application.game.SkillCheckDecisionService;
+import com.uctale.uctale.domain.game.SkillCheckOutcome;
+import com.uctale.uctale.domain.game.SkillCheckResult;
+import com.uctale.uctale.domain.game.StatType;
+import com.uctale.uctale.repository.GameMutationRequestRepository;
+import com.uctale.uctale.support.PostgresIntegrationTestSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class PostgresSkillCheckDecisionTest extends PostgresIntegrationTestSupport {
+    private static final String OWNER_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    private static final Long SESSION_ID = 5252L;
+    private static final int EXPECTED_TURN = 3;
+    private static final String FINGERPRINT = "a".repeat(64);
+
+    @Autowired private GameMutationRequestService mutationService;
+    @Autowired private SkillCheckDecisionService decisionService;
+    @Autowired private GameMutationRequestRepository mutationRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanUp() {
+        jdbcTemplate.update("DELETE FROM game_turn_reservation");
+        mutationRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("같은 idempotency request는 provider 실패 후 재시도해도 저장된 Skill Check 판정을 재사용한다")
+    void sameMutationRetry_ReusesDecision() {
+        AtomicInteger factoryCalls = new AtomicInteger();
+        var first = mutationService.begin(OWNER_KEY, GameMutationRequestService.PROGRESS, "skill-retry-key-01",
+                SESSION_ID, EXPECTED_TURN, FINGERPRINT);
+        SkillCheckResult firstResult = decisionService.getOrCreate(first.requestId(), first.reservationOwner(), () -> {
+            factoryCalls.incrementAndGet();
+            return result(7);
+        });
+        mutationService.markFailed(first.requestId(), first.reservationOwner());
+
+        var retry = mutationService.begin(OWNER_KEY, GameMutationRequestService.PROGRESS, "skill-retry-key-01",
+                SESSION_ID, EXPECTED_TURN, FINGERPRINT);
+        SkillCheckResult retryResult = decisionService.getOrCreate(retry.requestId(), retry.reservationOwner(), () -> {
+            factoryCalls.incrementAndGet();
+            return result(19);
+        });
+
+        assertThat(retry.requestId()).isEqualTo(first.requestId());
+        assertThat(retryResult).isEqualTo(firstResult);
+        assertThat(retryResult.rawRoll()).isEqualTo(7);
+        assertThat(factoryCalls).hasValue(1);
+    }
+
+    @Test
+    @DisplayName("다른 mutation request가 만료 lease를 takeover하면 이전 request 판정을 재사용하지 않는다")
+    void differentMutationTakeover_ReplacesDecision() {
+        var first = mutationService.begin(OWNER_KEY, GameMutationRequestService.PROGRESS, "skill-owner-key-01",
+                SESSION_ID, EXPECTED_TURN, FINGERPRINT);
+        decisionService.getOrCreate(first.requestId(), first.reservationOwner(), () -> result(5));
+        mutationService.markFailed(first.requestId(), first.reservationOwner());
+
+        var second = mutationService.begin(OWNER_KEY, GameMutationRequestService.PROGRESS, "skill-owner-key-02",
+                SESSION_ID, EXPECTED_TURN, "b".repeat(64));
+        SkillCheckResult secondResult = decisionService.getOrCreate(second.requestId(), second.reservationOwner(), () -> result(15));
+
+        assertThat(second.requestId()).isNotEqualTo(first.requestId());
+        assertThat(secondResult.rawRoll()).isEqualTo(15);
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT skill_check_request_id FROM game_turn_reservation WHERE session_id = ? AND expected_turn = ?",
+                Long.class, SESSION_ID, EXPECTED_TURN)).isEqualTo(second.requestId());
+    }
+
+    private SkillCheckResult result(int rawRoll) {
+        SkillCheckOutcome outcome = rawRoll >= 10 ? SkillCheckOutcome.SUCCESS : SkillCheckOutcome.FAILURE;
+        return new SkillCheckResult(StatType.WILL, rawRoll, 0, 0, 10, rawRoll, outcome, 1);
+    }
+}

--- a/src/test/java/com/uctale/uctale/provider/gemini/GeminiPromptContractTest.java
+++ b/src/test/java/com/uctale/uctale/provider/gemini/GeminiPromptContractTest.java
@@ -6,6 +6,7 @@ import com.uctale.uctale.domain.action.ActionType;
 import com.uctale.uctale.domain.action.PlayerAction;
 import com.uctale.uctale.domain.game.ActionResolver;
 import com.uctale.uctale.domain.game.GameState;
+import com.uctale.uctale.domain.game.SkillCheckResult;
 import com.uctale.uctale.domain.game.TurnResolution;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,5 +44,44 @@ class GeminiPromptContractTest {
                 .contains("[narrative cues]", "문을 잠근다")
                 .contains("[금지 canonical mutation]", "HP", "roll")
                 .doesNotContain("SERVER_ONLY_SECRET_TOKEN");
+    }
+
+    @Test
+    @DisplayName("Skill Check prompt는 서버가 확정한 roll modifier DC total outcome을 그대로 전달한다")
+    void buildProgressPrompt_IncludesCanonicalSkillCheckResult() throws Exception {
+        GeminiNarrativeAdapter adapter = new GeminiNarrativeAdapter(new ObjectMapper(), RestClient.builder());
+        GameState state = GameState.initial("폐허 도시", "정찰자", "오프닝");
+        PlayerAction action = new PlayerAction(
+                7,
+                "SERVER_ONLY_SKILL_TOKEN",
+                ActionType.SKILL_CHECK,
+                1,
+                Map.of(
+                        "choiceId", "7",
+                        "statType", "WILL",
+                        "dc", "10",
+                        "situationalModifier", "0"
+                ),
+                "문을 연다"
+        );
+        ActionResolver resolver = new ActionResolver();
+        SkillCheckResult skillCheck = resolver.rollSkillCheck(state, action, (min, max) -> 10);
+        NarrativeContext context = NarrativeContext.from(
+                "game-result:42:2:101",
+                resolver.resolve(state, action, skillCheck)
+        );
+
+        String prompt = adapter.buildProgressPrompt(context);
+
+        assertThat(prompt)
+                .contains("skill check:")
+                .contains("\"statType\":\"WILL\"")
+                .contains("\"rawRoll\":10")
+                .contains("\"statModifier\":0")
+                .contains("\"situationalModifier\":0")
+                .contains("\"dc\":10")
+                .contains("\"total\":10")
+                .contains("\"outcome\":\"SUCCESS\"")
+                .doesNotContain("SERVER_ONLY_SKILL_TOKEN");
     }
 }

--- a/src/test/java/com/uctale/uctale/service/GameServiceRateLimitTest.java
+++ b/src/test/java/com/uctale/uctale/service/GameServiceRateLimitTest.java
@@ -40,6 +40,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class GameServiceRateLimitTest {
+
     private static final String OWNER_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
     private static final String IDEMPOTENCY_KEY = "rate-limit-test-key";
 
@@ -56,14 +57,26 @@ class GameServiceRateLimitTest {
         ProviderCallTelemetry telemetry = new ProviderCallTelemetry(clock, event -> {});
         given(mutationRequestService.begin(anyString(), anyString(), anyString(), any(), any(), anyString()))
                 .willReturn(new GameMutationRequestService.BeginResult(100L, false, null, null, null));
-        GameService service = new GameService(narrativeGenerator, imageAssetService, gamePersistenceService,
-                new ChoiceCodec(new ObjectMapper()), new TurnProcessor(), new ImagePromptComposer(), limiter,
-                telemetry, new GameMutationFingerprint(), mutationRequestService);
-        CostRequestContext context = new CostRequestContext("request-1", OWNER_KEY, "1.2.3.4", null, 1, IDEMPOTENCY_KEY);
+        GameService service = new GameService(
+                narrativeGenerator,
+                imageAssetService,
+                gamePersistenceService,
+                new ChoiceCodec(new ObjectMapper()),
+                new TurnProcessor(),
+                new ImagePromptComposer(),
+                limiter,
+                telemetry,
+                new GameMutationFingerprint(),
+                mutationRequestService
+        );
+        CostRequestContext context = new CostRequestContext(
+                "request-1", OWNER_KEY, "1.2.3.4", null, 1, IDEMPOTENCY_KEY
+        );
         limiter.check(CostOperation.NARRATIVE, context);
 
         assertThatThrownBy(() -> service.initGame(context, new GameInitRequest("세계관", "캐릭터")))
                 .isInstanceOf(RateLimitExceededException.class);
+
         verify(narrativeGenerator, never()).createOpening(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
         verify(imageAssetService, never()).issue(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
         verify(mutationRequestService).markFailed(100L);
@@ -78,17 +91,32 @@ class GameServiceRateLimitTest {
         ChoiceCodec choiceCodec = new ChoiceCodec(new ObjectMapper());
         given(mutationRequestService.begin(anyString(), anyString(), anyString(), any(), any(), anyString()))
                 .willReturn(new GameMutationRequestService.BeginResult(100L, false, null, null, null));
-        GameService service = new GameService(narrativeGenerator, imageAssetService, gamePersistenceService,
-                choiceCodec, new TurnProcessor(), new ImagePromptComposer(), limiter, telemetry,
-                new GameMutationFingerprint(), mutationRequestService);
+        GameService service = new GameService(
+                narrativeGenerator,
+                imageAssetService,
+                gamePersistenceService,
+                choiceCodec,
+                new TurnProcessor(),
+                new ImagePromptComposer(),
+                limiter,
+                telemetry,
+                new GameMutationFingerprint(),
+                mutationRequestService
+        );
         GameState gameState = GameState.initial("세계관", "캐릭터", "첫 이야기");
         String choicesJson = choiceCodec.serialize(java.util.List.of(new com.uctale.uctale.dto.GameChoice(1, "유효한 선택")));
         when(gamePersistenceService.loadLatestTurn(OWNER_KEY, 10L, 1)).thenReturn(
-                new GamePersistenceService.LoadedTurn(10L, 1, "세계관", "캐릭터", "첫 이야기", choicesJson, "/image", gameState));
-        CostRequestContext context = new CostRequestContext("request-1", OWNER_KEY, "1.2.3.4", 10L, 2, IDEMPOTENCY_KEY);
+                new GamePersistenceService.LoadedTurn(
+                        10L, 1, "세계관", "캐릭터", "첫 이야기", choicesJson, "/image", gameState
+                )
+        );
+        CostRequestContext context = new CostRequestContext(
+                "request-1", OWNER_KEY, "1.2.3.4", 10L, 2, IDEMPOTENCY_KEY
+        );
 
         assertThatThrownBy(() -> service.progressGame(context, new GameProgressRequest(10L, 999, 1)))
                 .isInstanceOf(InvalidChoiceException.class);
+
         assertThatCode(() -> limiter.check(CostOperation.NARRATIVE, context)).doesNotThrowAnyException();
         verify(narrativeGenerator, never()).createNextTurn(org.mockito.ArgumentMatchers.any());
     }

--- a/src/test/java/com/uctale/uctale/service/GameServiceRateLimitTest.java
+++ b/src/test/java/com/uctale/uctale/service/GameServiceRateLimitTest.java
@@ -13,6 +13,7 @@ import com.uctale.uctale.application.game.GameMutationRequestService;
 import com.uctale.uctale.application.game.GamePersistenceService;
 import com.uctale.uctale.application.game.ImagePromptComposer;
 import com.uctale.uctale.application.game.InvalidChoiceException;
+import com.uctale.uctale.application.game.TurnProcessor;
 import com.uctale.uctale.application.image.ImageAssetService;
 import com.uctale.uctale.application.narrative.NarrativeGenerator;
 import com.uctale.uctale.domain.game.GameState;
@@ -39,7 +40,6 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class GameServiceRateLimitTest {
-
     private static final String OWNER_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
     private static final String IDEMPOTENCY_KEY = "rate-limit-test-key";
 
@@ -56,25 +56,14 @@ class GameServiceRateLimitTest {
         ProviderCallTelemetry telemetry = new ProviderCallTelemetry(clock, event -> {});
         given(mutationRequestService.begin(anyString(), anyString(), anyString(), any(), any(), anyString()))
                 .willReturn(new GameMutationRequestService.BeginResult(100L, false, null, null, null));
-        GameService service = new GameService(
-                narrativeGenerator,
-                imageAssetService,
-                gamePersistenceService,
-                new ChoiceCodec(new ObjectMapper()),
-                new ImagePromptComposer(),
-                limiter,
-                telemetry,
-                new GameMutationFingerprint(),
-                mutationRequestService
-        );
-        CostRequestContext context = new CostRequestContext(
-                "request-1", OWNER_KEY, "1.2.3.4", null, 1, IDEMPOTENCY_KEY
-        );
+        GameService service = new GameService(narrativeGenerator, imageAssetService, gamePersistenceService,
+                new ChoiceCodec(new ObjectMapper()), new TurnProcessor(), new ImagePromptComposer(), limiter,
+                telemetry, new GameMutationFingerprint(), mutationRequestService);
+        CostRequestContext context = new CostRequestContext("request-1", OWNER_KEY, "1.2.3.4", null, 1, IDEMPOTENCY_KEY);
         limiter.check(CostOperation.NARRATIVE, context);
 
         assertThatThrownBy(() -> service.initGame(context, new GameInitRequest("세계관", "캐릭터")))
                 .isInstanceOf(RateLimitExceededException.class);
-
         verify(narrativeGenerator, never()).createOpening(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
         verify(imageAssetService, never()).issue(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
         verify(mutationRequestService).markFailed(100L);
@@ -89,31 +78,17 @@ class GameServiceRateLimitTest {
         ChoiceCodec choiceCodec = new ChoiceCodec(new ObjectMapper());
         given(mutationRequestService.begin(anyString(), anyString(), anyString(), any(), any(), anyString()))
                 .willReturn(new GameMutationRequestService.BeginResult(100L, false, null, null, null));
-        GameService service = new GameService(
-                narrativeGenerator,
-                imageAssetService,
-                gamePersistenceService,
-                choiceCodec,
-                new ImagePromptComposer(),
-                limiter,
-                telemetry,
-                new GameMutationFingerprint(),
-                mutationRequestService
-        );
+        GameService service = new GameService(narrativeGenerator, imageAssetService, gamePersistenceService,
+                choiceCodec, new TurnProcessor(), new ImagePromptComposer(), limiter, telemetry,
+                new GameMutationFingerprint(), mutationRequestService);
         GameState gameState = GameState.initial("세계관", "캐릭터", "첫 이야기");
         String choicesJson = choiceCodec.serialize(java.util.List.of(new com.uctale.uctale.dto.GameChoice(1, "유효한 선택")));
         when(gamePersistenceService.loadLatestTurn(OWNER_KEY, 10L, 1)).thenReturn(
-                new GamePersistenceService.LoadedTurn(
-                        10L, 1, "세계관", "캐릭터", "첫 이야기", choicesJson, "/image", gameState
-                )
-        );
-        CostRequestContext context = new CostRequestContext(
-                "request-1", OWNER_KEY, "1.2.3.4", 10L, 2, IDEMPOTENCY_KEY
-        );
+                new GamePersistenceService.LoadedTurn(10L, 1, "세계관", "캐릭터", "첫 이야기", choicesJson, "/image", gameState));
+        CostRequestContext context = new CostRequestContext("request-1", OWNER_KEY, "1.2.3.4", 10L, 2, IDEMPOTENCY_KEY);
 
         assertThatThrownBy(() -> service.progressGame(context, new GameProgressRequest(10L, 999, 1)))
                 .isInstanceOf(InvalidChoiceException.class);
-
         assertThatCode(() -> limiter.check(CostOperation.NARRATIVE, context)).doesNotThrowAnyException();
         verify(narrativeGenerator, never()).createNextTurn(org.mockito.ArgumentMatchers.any());
     }

--- a/src/test/java/com/uctale/uctale/service/GameServiceTest.java
+++ b/src/test/java/com/uctale/uctale/service/GameServiceTest.java
@@ -69,11 +69,13 @@ class GameServiceTest {
         Clock clock = Clock.systemUTC();
         TurnProcessor turnProcessor = new TurnProcessor(skillCheckDecisionService, (min, max) -> 10);
         gameService = new GameService(
-                narrativeGenerator, imageAssetService, gamePersistenceService, choiceCodec, turnProcessor,
+                narrativeGenerator, imageAssetService, gamePersistenceService, choiceCodec,
+                turnProcessor,
                 new ImagePromptComposer(),
                 new CostRateLimiter(new CostRateLimitPolicy(1_000, 1_000, 60), clock),
                 new ProviderCallTelemetry(clock, event -> {}),
-                new GameMutationFingerprint(), mutationRequestService
+                new GameMutationFingerprint(),
+                mutationRequestService
         );
         lenient().when(mutationRequestService.begin(anyString(), anyString(), anyString(), any(), any(), anyString()))
                 .thenReturn(new GameMutationRequestService.BeginResult(100L, false, null, null, null, "lease-owner"));
@@ -86,16 +88,22 @@ class GameServiceTest {
     void initGame_ReturnsFirstTurn() {
         GameInitRequest request = new GameInitRequest("좀비 아포칼립스", "김대리");
         NarrativeTurn opening = new NarrativeTurn(
-                "첫날 밤", "오프닝 스토리", List.of(new NarrativeTurn.Choice(1, "도망간다")),
-                new NarrativeTurn.VisualAssets("dark street", List.of("zombie"), List.of()));
+                "첫날 밤", "오프닝 스토리",
+                List.of(new NarrativeTurn.Choice(1, "도망간다")),
+                new NarrativeTurn.VisualAssets("dark street", List.of("zombie"), List.of())
+        );
         GameSession session = new GameSession(OWNER_KEY, request.worldSetting(), request.characterSetting());
         ReflectionTestUtils.setField(session, "id", 42L);
         ImageAssetService.AssetReference asset = new ImageAssetService.AssetReference(
                 "asset-id", "/api/game/image-assets/asset-id", "prompt", "16:9",
-                "flux", 1024, 576, 123, true, "uctale-charcoal-v2");
+                "flux", 1024, 576, 123, true, "uctale-charcoal-v2"
+        );
+
         given(narrativeGenerator.createOpening("좀비 아포칼립스", "김대리")).willReturn(opening);
         given(imageAssetService.issue(any(String.class), eq("16:9"))).willReturn(asset);
-        given(gamePersistenceService.saveOpening(eq(OWNER_KEY), any(), any(), any(), any(), eq(asset), eq(100L), eq("첫날 밤"))).willReturn(session);
+        given(gamePersistenceService.saveOpening(
+                eq(OWNER_KEY), any(), any(), any(), any(), eq(asset), eq(100L), eq("첫날 밤")
+        )).willReturn(session);
 
         GameResponse response = gameService.initGame(OWNER_KEY, request);
 
@@ -103,6 +111,11 @@ class GameServiceTest {
         assertThat(response.turnNumber()).isEqualTo(1);
         assertThat(response.mainImageUrl()).isEqualTo("/api/game/image-assets/asset-id");
         assertThat(response.choices().getFirst().actionType()).isEqualTo("SKILL_CHECK");
+        ArgumentCaptor<String> promptCaptor = ArgumentCaptor.forClass(String.class);
+        verify(imageAssetService).issue(promptCaptor.capture(), eq("16:9"));
+        assertThat(promptCaptor.getValue())
+                .startsWith("style[uctale-charcoal-v2]")
+                .contains("subjects: zombie", "setting: dark street", "final style lock:");
     }
 
     @Test
@@ -111,8 +124,11 @@ class GameServiceTest {
         given(mutationRequestService.begin(anyString(), eq(GameMutationRequestService.INIT), anyString(), any(), any(), anyString()))
                 .willReturn(new GameMutationRequestService.BeginResult(100L, true, 42L, 1, "기존 오프닝"));
         given(gamePersistenceService.loadCommittedTurn(OWNER_KEY, 42L, 1))
-                .willReturn(new GamePersistenceService.CommittedTurn("기존 스토리",
-                        choiceCodec.serialize(List.of(new GameChoice(3, "계속한다"))), "/api/game/image-assets/replayed"));
+                .willReturn(new GamePersistenceService.CommittedTurn(
+                        "기존 스토리",
+                        choiceCodec.serialize(List.of(new GameChoice(3, "계속한다"))),
+                        "/api/game/image-assets/replayed"
+                ));
 
         GameResponse response = gameService.initGame(OWNER_KEY, new GameInitRequest("세계관", "캐릭터"));
 
@@ -124,45 +140,78 @@ class GameServiceTest {
     }
 
     @Test
-    @DisplayName("legacy progress는 persistence 전에 입력과 다음 canonical state를 확정한다")
+    @DisplayName("progress는 persistence 전에 입력과 다음 canonical state를 확정한다")
     void progressGame_PreparesCommittedStateTransitionBeforePersistence() {
         String choicesJson = choiceCodec.serialize(List.of(new GameChoice(7, "문을 잠근다")));
-        NarrativeTurn nextTurn = nextTurn();
-        given(gamePersistenceService.loadLatestTurn(OWNER_KEY, 42L, 1)).willReturn(loadedTurn(choicesJson));
+        GamePersistenceService.LoadedTurn loadedTurn = loadedTurn(choicesJson);
+        NarrativeTurn nextTurn = new NarrativeTurn(
+                "다음 장면", "다음 스토리",
+                List.of(new NarrativeTurn.Choice(1, "기다린다")),
+                new NarrativeTurn.VisualAssets("", List.of(), List.of())
+        );
+
+        given(gamePersistenceService.loadLatestTurn(OWNER_KEY, 42L, 1)).willReturn(loadedTurn);
         given(narrativeGenerator.createNextTurn(any(NarrativeContext.class))).willReturn(nextTurn);
-        given(gamePersistenceService.saveNextTurn(eq(OWNER_KEY), eq(42L), any(GameTurnCommit.class), eq(100L), eq("다음 장면"), eq("lease-owner"))).willReturn(2);
+        given(gamePersistenceService.saveNextTurn(
+                eq(OWNER_KEY), eq(42L), any(GameTurnCommit.class), eq(100L), eq("다음 장면"), eq("lease-owner")
+        )).willReturn(2);
 
         GameResponse response = gameService.progressGame(OWNER_KEY, new GameProgressRequest(42L, 7, 1));
 
         assertThat(response.turnNumber()).isEqualTo(2);
+        assertThat(response.mainImageUrl()).isEqualTo("/api/game/image-assets/old-asset");
+
+        ArgumentCaptor<NarrativeContext> contextCaptor = ArgumentCaptor.forClass(NarrativeContext.class);
+        verify(narrativeGenerator).createNextTurn(contextCaptor.capture());
+        assertThat(contextCaptor.getValue().playerAction()).isEqualTo("문을 잠근다");
+        assertThat(contextCaptor.getValue().skillCheck()).isNull();
+
         ArgumentCaptor<GameTurnCommit> commitCaptor = ArgumentCaptor.forClass(GameTurnCommit.class);
-        verify(gamePersistenceService).saveNextTurn(eq(OWNER_KEY), eq(42L), commitCaptor.capture(), eq(100L), eq("다음 장면"), eq("lease-owner"));
-        assertThat(commitCaptor.getValue().skillCheckResult()).isNull();
+        verify(gamePersistenceService).saveNextTurn(
+                eq(OWNER_KEY), eq(42L), commitCaptor.capture(), eq(100L), eq("다음 장면"), eq("lease-owner")
+        );
+        GameTurnCommit commit = commitCaptor.getValue();
+        assertThat(commit.inputChoiceId()).isEqualTo(7);
+        assertThat(commit.inputChoiceText()).isEqualTo("문을 잠근다");
+        assertThat(commit.previousStateVersion()).isEqualTo(1);
+        assertThat(commit.nextStateVersion()).isEqualTo(2);
+        assertThat(commit.nextState().storyMemory().recentTurns()).hasSize(2);
+        assertThat(commit.storyText()).isEqualTo("다음 스토리");
+        assertThat(commit.skillCheckResult()).isNull();
         verify(imageAssetService, never()).issue(any(), any());
     }
 
     @Test
-    @DisplayName("서버 발급 Skill Check action은 확정 판정을 NarrativeContext와 GameLog commit 후보에 동일하게 전달한다")
-    void progressGame_SkillCheckUsesServerDecisionForNarrativeAndAudit() {
+    @DisplayName("서버 발급 Skill Check는 같은 확정 판정을 NarrativeContext와 commit audit에 전달한다")
+    void progressGame_SkillCheckUsesSingleServerDecision() {
         GameChoice issued = choiceCodec.issue(List.of(new NarrativeTurn.Choice(7, "위험한 문을 연다")), 1).getFirst();
         String choicesJson = choiceCodec.serialize(List.of(issued));
+        NarrativeTurn nextTurn = new NarrativeTurn(
+                "다음 장면", "문이 열렸다.",
+                List.of(new NarrativeTurn.Choice(1, "안으로 들어간다")),
+                new NarrativeTurn.VisualAssets("", List.of(), List.of())
+        );
         given(gamePersistenceService.loadLatestTurn(OWNER_KEY, 42L, 1)).willReturn(loadedTurn(choicesJson));
-        given(narrativeGenerator.createNextTurn(any(NarrativeContext.class))).willReturn(nextTurn());
-        given(gamePersistenceService.saveNextTurn(eq(OWNER_KEY), eq(42L), any(GameTurnCommit.class), eq(100L), eq("다음 장면"), eq("lease-owner"))).willReturn(2);
-        GameProgressRequest request = new GameProgressRequest(42L, issued.id(), 1, issued.actionToken(),
-                issued.actionType(), issued.sourceTurn(), issued.arguments());
+        given(narrativeGenerator.createNextTurn(any(NarrativeContext.class))).willReturn(nextTurn);
+        given(gamePersistenceService.saveNextTurn(
+                eq(OWNER_KEY), eq(42L), any(GameTurnCommit.class), eq(100L), eq("다음 장면"), eq("lease-owner")
+        )).willReturn(2);
+        GameProgressRequest request = new GameProgressRequest(
+                42L, issued.id(), 1, issued.actionToken(), issued.actionType(), issued.sourceTurn(), issued.arguments()
+        );
 
         gameService.progressGame(OWNER_KEY, request);
 
         ArgumentCaptor<NarrativeContext> contextCaptor = ArgumentCaptor.forClass(NarrativeContext.class);
         verify(narrativeGenerator).createNextTurn(contextCaptor.capture());
-        assertThat(contextCaptor.getValue().skillCheck()).isNotNull();
         assertThat(contextCaptor.getValue().skillCheck().rawRoll()).isEqualTo(10);
         assertThat(contextCaptor.getValue().skillCheck().dc()).isEqualTo(10);
         assertThat(contextCaptor.getValue().skillCheck().outcome()).isEqualTo(SkillCheckOutcome.SUCCESS);
 
         ArgumentCaptor<GameTurnCommit> commitCaptor = ArgumentCaptor.forClass(GameTurnCommit.class);
-        verify(gamePersistenceService).saveNextTurn(eq(OWNER_KEY), eq(42L), commitCaptor.capture(), eq(100L), eq("다음 장면"), eq("lease-owner"));
+        verify(gamePersistenceService).saveNextTurn(
+                eq(OWNER_KEY), eq(42L), commitCaptor.capture(), eq(100L), eq("다음 장면"), eq("lease-owner")
+        );
         assertThat(commitCaptor.getValue().skillCheckResult().rawRoll()).isEqualTo(10);
         assertThat(commitCaptor.getValue().skillCheckResult().outcome()).isEqualTo(SkillCheckOutcome.SUCCESS);
     }
@@ -173,8 +222,11 @@ class GameServiceTest {
         given(mutationRequestService.begin(anyString(), eq(GameMutationRequestService.PROGRESS), anyString(), eq(42L), eq(1), anyString()))
                 .willReturn(new GameMutationRequestService.BeginResult(100L, true, 42L, 2, "기존 장면"));
         given(gamePersistenceService.loadCommittedTurn(OWNER_KEY, 42L, 2))
-                .willReturn(new GamePersistenceService.CommittedTurn("기존 스토리",
-                        choiceCodec.serialize(List.of(new GameChoice(3, "계속한다"))), "/api/game/image-assets/replayed"));
+                .willReturn(new GamePersistenceService.CommittedTurn(
+                        "기존 스토리",
+                        choiceCodec.serialize(List.of(new GameChoice(3, "계속한다"))),
+                        "/api/game/image-assets/replayed"
+                ));
 
         GameResponse response = gameService.progressGame(OWNER_KEY, new GameProgressRequest(42L, 7, 1));
 
@@ -183,6 +235,7 @@ class GameServiceTest {
         assertThat(response.storyText()).isEqualTo("기존 스토리");
         verify(narrativeGenerator, never()).createNextTurn(any());
         verify(gamePersistenceService, never()).loadLatestTurn(anyString(), any(), anyInt());
+        verify(gamePersistenceService, never()).saveNextTurn(anyString(), any(), any(GameTurnCommit.class), any(), any());
     }
 
     @Test
@@ -193,18 +246,18 @@ class GameServiceTest {
 
         assertThatThrownBy(() -> gameService.progressGame(OWNER_KEY, new GameProgressRequest(42L, 1, 1)))
                 .isInstanceOf(TurnConflictException.class);
+
         verify(narrativeGenerator, never()).createNextTurn(any(NarrativeContext.class));
         verify(imageAssetService, never()).issue(any(), any());
+        verify(gamePersistenceService, never()).saveNextTurn(any(), any(), any(GameTurnCommit.class), any(), any());
         verify(mutationRequestService).markFailed(100L, "lease-owner");
     }
 
-    private NarrativeTurn nextTurn() {
-        return new NarrativeTurn("다음 장면", "다음 스토리",
-                List.of(new NarrativeTurn.Choice(1, "기다린다")), new NarrativeTurn.VisualAssets("", List.of(), List.of()));
-    }
-
     private GamePersistenceService.LoadedTurn loadedTurn(String choicesJson) {
-        return new GamePersistenceService.LoadedTurn(42L, 1, "좀비 아포칼립스", "김대리", "직전 스토리",
-                choicesJson, "/api/game/image-assets/old-asset", GameState.initial("좀비 아포칼립스", "김대리", "직전 스토리"));
+        return new GamePersistenceService.LoadedTurn(
+                42L, 1, "좀비 아포칼립스", "김대리", "직전 스토리", choicesJson,
+                "/api/game/image-assets/old-asset",
+                GameState.initial("좀비 아포칼립스", "김대리", "직전 스토리")
+        );
     }
 }

--- a/src/test/java/com/uctale/uctale/service/GameServiceTest.java
+++ b/src/test/java/com/uctale/uctale/service/GameServiceTest.java
@@ -10,13 +10,16 @@ import com.uctale.uctale.application.game.GameMutationRequestService;
 import com.uctale.uctale.application.game.GamePersistenceService;
 import com.uctale.uctale.application.game.GameTurnCommit;
 import com.uctale.uctale.application.game.ImagePromptComposer;
+import com.uctale.uctale.application.game.SkillCheckDecisionService;
 import com.uctale.uctale.application.game.TurnConflictException;
+import com.uctale.uctale.application.game.TurnProcessor;
 import com.uctale.uctale.application.image.ImageAssetService;
 import com.uctale.uctale.application.narrative.NarrativeContext;
 import com.uctale.uctale.application.narrative.NarrativeGenerator;
 import com.uctale.uctale.application.narrative.NarrativeTurn;
 import com.uctale.uctale.domain.GameSession;
 import com.uctale.uctale.domain.game.GameState;
+import com.uctale.uctale.domain.game.SkillCheckOutcome;
 import com.uctale.uctale.dto.GameChoice;
 import com.uctale.uctale.dto.GameInitRequest;
 import com.uctale.uctale.dto.GameProgressRequest;
@@ -32,11 +35,13 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Clock;
 import java.util.List;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -53,6 +58,7 @@ class GameServiceTest {
     @Mock private ImageAssetService imageAssetService;
     @Mock private GamePersistenceService gamePersistenceService;
     @Mock private GameMutationRequestService mutationRequestService;
+    @Mock private SkillCheckDecisionService skillCheckDecisionService;
 
     private ChoiceCodec choiceCodec;
     private GameService gameService;
@@ -61,16 +67,18 @@ class GameServiceTest {
     void setUp() {
         choiceCodec = new ChoiceCodec(new ObjectMapper());
         Clock clock = Clock.systemUTC();
+        TurnProcessor turnProcessor = new TurnProcessor(skillCheckDecisionService, (min, max) -> 10);
         gameService = new GameService(
-                narrativeGenerator, imageAssetService, gamePersistenceService, choiceCodec,
+                narrativeGenerator, imageAssetService, gamePersistenceService, choiceCodec, turnProcessor,
                 new ImagePromptComposer(),
                 new CostRateLimiter(new CostRateLimitPolicy(1_000, 1_000, 60), clock),
                 new ProviderCallTelemetry(clock, event -> {}),
-                new GameMutationFingerprint(),
-                mutationRequestService
+                new GameMutationFingerprint(), mutationRequestService
         );
         lenient().when(mutationRequestService.begin(anyString(), anyString(), anyString(), any(), any(), anyString()))
                 .thenReturn(new GameMutationRequestService.BeginResult(100L, false, null, null, null, "lease-owner"));
+        lenient().when(skillCheckDecisionService.getOrCreate(anyLong(), anyString(), any()))
+                .thenAnswer(invocation -> ((Supplier<?>) invocation.getArgument(2)).get());
     }
 
     @Test
@@ -78,33 +86,23 @@ class GameServiceTest {
     void initGame_ReturnsFirstTurn() {
         GameInitRequest request = new GameInitRequest("좀비 아포칼립스", "김대리");
         NarrativeTurn opening = new NarrativeTurn(
-                "첫날 밤", "오프닝 스토리",
-                List.of(new NarrativeTurn.Choice(1, "도망간다")),
-                new NarrativeTurn.VisualAssets("dark street", List.of("zombie"), List.of())
-        );
+                "첫날 밤", "오프닝 스토리", List.of(new NarrativeTurn.Choice(1, "도망간다")),
+                new NarrativeTurn.VisualAssets("dark street", List.of("zombie"), List.of()));
         GameSession session = new GameSession(OWNER_KEY, request.worldSetting(), request.characterSetting());
         ReflectionTestUtils.setField(session, "id", 42L);
         ImageAssetService.AssetReference asset = new ImageAssetService.AssetReference(
                 "asset-id", "/api/game/image-assets/asset-id", "prompt", "16:9",
-                "flux", 1024, 576, 123, true, "uctale-charcoal-v2"
-        );
-
+                "flux", 1024, 576, 123, true, "uctale-charcoal-v2");
         given(narrativeGenerator.createOpening("좀비 아포칼립스", "김대리")).willReturn(opening);
         given(imageAssetService.issue(any(String.class), eq("16:9"))).willReturn(asset);
-        given(gamePersistenceService.saveOpening(
-                eq(OWNER_KEY), any(), any(), any(), any(), eq(asset), eq(100L), eq("첫날 밤")
-        )).willReturn(session);
+        given(gamePersistenceService.saveOpening(eq(OWNER_KEY), any(), any(), any(), any(), eq(asset), eq(100L), eq("첫날 밤"))).willReturn(session);
 
         GameResponse response = gameService.initGame(OWNER_KEY, request);
 
         assertThat(response.sessionId()).isEqualTo(42L);
         assertThat(response.turnNumber()).isEqualTo(1);
         assertThat(response.mainImageUrl()).isEqualTo("/api/game/image-assets/asset-id");
-        ArgumentCaptor<String> promptCaptor = ArgumentCaptor.forClass(String.class);
-        verify(imageAssetService).issue(promptCaptor.capture(), eq("16:9"));
-        assertThat(promptCaptor.getValue())
-                .startsWith("style[uctale-charcoal-v2]")
-                .contains("subjects: zombie", "setting: dark street", "final style lock:");
+        assertThat(response.choices().getFirst().actionType()).isEqualTo("SKILL_CHECK");
     }
 
     @Test
@@ -113,11 +111,8 @@ class GameServiceTest {
         given(mutationRequestService.begin(anyString(), eq(GameMutationRequestService.INIT), anyString(), any(), any(), anyString()))
                 .willReturn(new GameMutationRequestService.BeginResult(100L, true, 42L, 1, "기존 오프닝"));
         given(gamePersistenceService.loadCommittedTurn(OWNER_KEY, 42L, 1))
-                .willReturn(new GamePersistenceService.CommittedTurn(
-                        "기존 스토리",
-                        choiceCodec.serialize(List.of(new GameChoice(3, "계속한다"))),
-                        "/api/game/image-assets/replayed"
-                ));
+                .willReturn(new GamePersistenceService.CommittedTurn("기존 스토리",
+                        choiceCodec.serialize(List.of(new GameChoice(3, "계속한다"))), "/api/game/image-assets/replayed"));
 
         GameResponse response = gameService.initGame(OWNER_KEY, new GameInitRequest("세계관", "캐릭터"));
 
@@ -129,43 +124,47 @@ class GameServiceTest {
     }
 
     @Test
-    @DisplayName("progress는 persistence 전에 입력과 다음 canonical state를 확정한다")
+    @DisplayName("legacy progress는 persistence 전에 입력과 다음 canonical state를 확정한다")
     void progressGame_PreparesCommittedStateTransitionBeforePersistence() {
         String choicesJson = choiceCodec.serialize(List.of(new GameChoice(7, "문을 잠근다")));
-        GamePersistenceService.LoadedTurn loadedTurn = loadedTurn(choicesJson);
-        NarrativeTurn nextTurn = new NarrativeTurn(
-                "다음 장면", "다음 스토리",
-                List.of(new NarrativeTurn.Choice(1, "기다린다")),
-                new NarrativeTurn.VisualAssets("", List.of(), List.of())
-        );
-
-        given(gamePersistenceService.loadLatestTurn(OWNER_KEY, 42L, 1)).willReturn(loadedTurn);
+        NarrativeTurn nextTurn = nextTurn();
+        given(gamePersistenceService.loadLatestTurn(OWNER_KEY, 42L, 1)).willReturn(loadedTurn(choicesJson));
         given(narrativeGenerator.createNextTurn(any(NarrativeContext.class))).willReturn(nextTurn);
-        given(gamePersistenceService.saveNextTurn(
-                eq(OWNER_KEY), eq(42L), any(GameTurnCommit.class), eq(100L), eq("다음 장면"), eq("lease-owner")
-        )).willReturn(2);
+        given(gamePersistenceService.saveNextTurn(eq(OWNER_KEY), eq(42L), any(GameTurnCommit.class), eq(100L), eq("다음 장면"), eq("lease-owner"))).willReturn(2);
 
         GameResponse response = gameService.progressGame(OWNER_KEY, new GameProgressRequest(42L, 7, 1));
 
         assertThat(response.turnNumber()).isEqualTo(2);
-        assertThat(response.mainImageUrl()).isEqualTo("/api/game/image-assets/old-asset");
+        ArgumentCaptor<GameTurnCommit> commitCaptor = ArgumentCaptor.forClass(GameTurnCommit.class);
+        verify(gamePersistenceService).saveNextTurn(eq(OWNER_KEY), eq(42L), commitCaptor.capture(), eq(100L), eq("다음 장면"), eq("lease-owner"));
+        assertThat(commitCaptor.getValue().skillCheckResult()).isNull();
+        verify(imageAssetService, never()).issue(any(), any());
+    }
+
+    @Test
+    @DisplayName("서버 발급 Skill Check action은 확정 판정을 NarrativeContext와 GameLog commit 후보에 동일하게 전달한다")
+    void progressGame_SkillCheckUsesServerDecisionForNarrativeAndAudit() {
+        GameChoice issued = choiceCodec.issue(List.of(new NarrativeTurn.Choice(7, "위험한 문을 연다")), 1).getFirst();
+        String choicesJson = choiceCodec.serialize(List.of(issued));
+        given(gamePersistenceService.loadLatestTurn(OWNER_KEY, 42L, 1)).willReturn(loadedTurn(choicesJson));
+        given(narrativeGenerator.createNextTurn(any(NarrativeContext.class))).willReturn(nextTurn());
+        given(gamePersistenceService.saveNextTurn(eq(OWNER_KEY), eq(42L), any(GameTurnCommit.class), eq(100L), eq("다음 장면"), eq("lease-owner"))).willReturn(2);
+        GameProgressRequest request = new GameProgressRequest(42L, issued.id(), 1, issued.actionToken(),
+                issued.actionType(), issued.sourceTurn(), issued.arguments());
+
+        gameService.progressGame(OWNER_KEY, request);
 
         ArgumentCaptor<NarrativeContext> contextCaptor = ArgumentCaptor.forClass(NarrativeContext.class);
         verify(narrativeGenerator).createNextTurn(contextCaptor.capture());
-        assertThat(contextCaptor.getValue().playerAction()).isEqualTo("문을 잠근다");
+        assertThat(contextCaptor.getValue().skillCheck()).isNotNull();
+        assertThat(contextCaptor.getValue().skillCheck().rawRoll()).isEqualTo(10);
+        assertThat(contextCaptor.getValue().skillCheck().dc()).isEqualTo(10);
+        assertThat(contextCaptor.getValue().skillCheck().outcome()).isEqualTo(SkillCheckOutcome.SUCCESS);
 
         ArgumentCaptor<GameTurnCommit> commitCaptor = ArgumentCaptor.forClass(GameTurnCommit.class);
-        verify(gamePersistenceService).saveNextTurn(
-                eq(OWNER_KEY), eq(42L), commitCaptor.capture(), eq(100L), eq("다음 장면"), eq("lease-owner")
-        );
-        GameTurnCommit commit = commitCaptor.getValue();
-        assertThat(commit.inputChoiceId()).isEqualTo(7);
-        assertThat(commit.inputChoiceText()).isEqualTo("문을 잠근다");
-        assertThat(commit.previousStateVersion()).isEqualTo(1);
-        assertThat(commit.nextStateVersion()).isEqualTo(2);
-        assertThat(commit.nextState().storyMemory().recentTurns()).hasSize(2);
-        assertThat(commit.storyText()).isEqualTo("다음 스토리");
-        verify(imageAssetService, never()).issue(any(), any());
+        verify(gamePersistenceService).saveNextTurn(eq(OWNER_KEY), eq(42L), commitCaptor.capture(), eq(100L), eq("다음 장면"), eq("lease-owner"));
+        assertThat(commitCaptor.getValue().skillCheckResult().rawRoll()).isEqualTo(10);
+        assertThat(commitCaptor.getValue().skillCheckResult().outcome()).isEqualTo(SkillCheckOutcome.SUCCESS);
     }
 
     @Test
@@ -174,11 +173,8 @@ class GameServiceTest {
         given(mutationRequestService.begin(anyString(), eq(GameMutationRequestService.PROGRESS), anyString(), eq(42L), eq(1), anyString()))
                 .willReturn(new GameMutationRequestService.BeginResult(100L, true, 42L, 2, "기존 장면"));
         given(gamePersistenceService.loadCommittedTurn(OWNER_KEY, 42L, 2))
-                .willReturn(new GamePersistenceService.CommittedTurn(
-                        "기존 스토리",
-                        choiceCodec.serialize(List.of(new GameChoice(3, "계속한다"))),
-                        "/api/game/image-assets/replayed"
-                ));
+                .willReturn(new GamePersistenceService.CommittedTurn("기존 스토리",
+                        choiceCodec.serialize(List.of(new GameChoice(3, "계속한다"))), "/api/game/image-assets/replayed"));
 
         GameResponse response = gameService.progressGame(OWNER_KEY, new GameProgressRequest(42L, 7, 1));
 
@@ -187,7 +183,6 @@ class GameServiceTest {
         assertThat(response.storyText()).isEqualTo("기존 스토리");
         verify(narrativeGenerator, never()).createNextTurn(any());
         verify(gamePersistenceService, never()).loadLatestTurn(anyString(), any(), anyInt());
-        verify(gamePersistenceService, never()).saveNextTurn(anyString(), any(), any(GameTurnCommit.class), any(), any());
     }
 
     @Test
@@ -198,18 +193,18 @@ class GameServiceTest {
 
         assertThatThrownBy(() -> gameService.progressGame(OWNER_KEY, new GameProgressRequest(42L, 1, 1)))
                 .isInstanceOf(TurnConflictException.class);
-
         verify(narrativeGenerator, never()).createNextTurn(any(NarrativeContext.class));
         verify(imageAssetService, never()).issue(any(), any());
-        verify(gamePersistenceService, never()).saveNextTurn(any(), any(), any(GameTurnCommit.class), any(), any());
         verify(mutationRequestService).markFailed(100L, "lease-owner");
     }
 
+    private NarrativeTurn nextTurn() {
+        return new NarrativeTurn("다음 장면", "다음 스토리",
+                List.of(new NarrativeTurn.Choice(1, "기다린다")), new NarrativeTurn.VisualAssets("", List.of(), List.of()));
+    }
+
     private GamePersistenceService.LoadedTurn loadedTurn(String choicesJson) {
-        return new GamePersistenceService.LoadedTurn(
-                42L, 1, "좀비 아포칼립스", "김대리", "직전 스토리", choicesJson,
-                "/api/game/image-assets/old-asset",
-                GameState.initial("좀비 아포칼립스", "김대리", "직전 스토리")
-        );
+        return new GamePersistenceService.LoadedTurn(42L, 1, "좀비 아포칼립스", "김대리", "직전 스토리",
+                choicesJson, "/api/game/image-assets/old-asset", GameState.initial("좀비 아포칼립스", "김대리", "직전 스토리"));
     }
 }

--- a/src/test/java/com/uctale/uctale/service/GameServiceValidationTest.java
+++ b/src/test/java/com/uctale/uctale/service/GameServiceValidationTest.java
@@ -34,11 +34,14 @@ import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class GameServiceValidationTest {
+
     private static final String OWNER_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
     @Mock private NarrativeGenerator narrativeGenerator;
     @Mock private ImageAssetService imageAssetService;
     @Mock private GamePersistenceService gamePersistenceService;
     @Mock private GameMutationRequestService mutationRequestService;
+
     private GameService gameService;
 
     @BeforeEach
@@ -46,21 +49,33 @@ class GameServiceValidationTest {
         Clock clock = Clock.systemUTC();
         given(mutationRequestService.begin(anyString(), anyString(), anyString(), any(), any(), anyString()))
                 .willReturn(new GameMutationRequestService.BeginResult(100L, false, null, null, null));
-        gameService = new GameService(narrativeGenerator, imageAssetService, gamePersistenceService,
-                new ChoiceCodec(new ObjectMapper()), new TurnProcessor(), new ImagePromptComposer(),
+        gameService = new GameService(
+                narrativeGenerator,
+                imageAssetService,
+                gamePersistenceService,
+                new ChoiceCodec(new ObjectMapper()),
+                new TurnProcessor(),
+                new ImagePromptComposer(),
                 new CostRateLimiter(new CostRateLimitPolicy(1_000, 1_000, 60), clock),
-                new ProviderCallTelemetry(clock, event -> {}), new GameMutationFingerprint(), mutationRequestService);
+                new ProviderCallTelemetry(clock, event -> {}),
+                new GameMutationFingerprint(),
+                mutationRequestService
+        );
     }
 
     @Test
     @DisplayName("DB user_choice 한계를 넘는 provider 선택지는 asset 발급과 저장 전에 거부한다")
     void initGame_RejectsOversizedProviderChoiceBeforeSideEffects() {
         GameInitRequest request = new GameInitRequest("세계관", "캐릭터");
-        NarrativeTurn invalidTurn = new NarrativeTurn("제목", "본문",
-                List.of(new NarrativeTurn.Choice(1, "가".repeat(256))),
-                new NarrativeTurn.VisualAssets("street", List.of(), List.of()));
+        NarrativeTurn invalidTurn = new NarrativeTurn(
+                "제목", "본문", List.of(new NarrativeTurn.Choice(1, "가".repeat(256))),
+                new NarrativeTurn.VisualAssets("street", List.of(), List.of())
+        );
         given(narrativeGenerator.createOpening("세계관", "캐릭터")).willReturn(invalidTurn);
-        assertThatThrownBy(() -> gameService.initGame(OWNER_KEY, request)).isInstanceOf(InvalidNarrativeResponseException.class);
+
+        assertThatThrownBy(() -> gameService.initGame(OWNER_KEY, request))
+                .isInstanceOf(InvalidNarrativeResponseException.class);
+
         verify(imageAssetService, never()).issue(any(), any());
         verify(gamePersistenceService, never()).saveOpening(any(), any(), any(), any(), any(), any(), any(), any());
         verify(mutationRequestService).markFailed(100L);
@@ -70,11 +85,16 @@ class GameServiceValidationTest {
     @DisplayName("중복 선택지 ID가 있는 provider 응답은 asset 발급과 저장 전에 거부한다")
     void initGame_RejectsDuplicateProviderChoiceIds() {
         GameInitRequest request = new GameInitRequest("세계관", "캐릭터");
-        NarrativeTurn invalidTurn = new NarrativeTurn("제목", "본문",
+        NarrativeTurn invalidTurn = new NarrativeTurn(
+                "제목", "본문",
                 List.of(new NarrativeTurn.Choice(1, "간다"), new NarrativeTurn.Choice(1, "멈춘다")),
-                new NarrativeTurn.VisualAssets("", List.of(), List.of()));
+                new NarrativeTurn.VisualAssets("", List.of(), List.of())
+        );
         given(narrativeGenerator.createOpening("세계관", "캐릭터")).willReturn(invalidTurn);
-        assertThatThrownBy(() -> gameService.initGame(OWNER_KEY, request)).isInstanceOf(InvalidNarrativeResponseException.class);
+
+        assertThatThrownBy(() -> gameService.initGame(OWNER_KEY, request))
+                .isInstanceOf(InvalidNarrativeResponseException.class);
+
         verify(imageAssetService, never()).issue(any(), any());
         verify(gamePersistenceService, never()).saveOpening(any(), any(), any(), any(), any(), any(), any(), any());
         verify(mutationRequestService).markFailed(100L);

--- a/src/test/java/com/uctale/uctale/service/GameServiceValidationTest.java
+++ b/src/test/java/com/uctale/uctale/service/GameServiceValidationTest.java
@@ -9,6 +9,7 @@ import com.uctale.uctale.application.game.GameMutationFingerprint;
 import com.uctale.uctale.application.game.GameMutationRequestService;
 import com.uctale.uctale.application.game.GamePersistenceService;
 import com.uctale.uctale.application.game.ImagePromptComposer;
+import com.uctale.uctale.application.game.TurnProcessor;
 import com.uctale.uctale.application.image.ImageAssetService;
 import com.uctale.uctale.application.narrative.InvalidNarrativeResponseException;
 import com.uctale.uctale.application.narrative.NarrativeGenerator;
@@ -33,14 +34,11 @@ import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class GameServiceValidationTest {
-
     private static final String OWNER_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-
     @Mock private NarrativeGenerator narrativeGenerator;
     @Mock private ImageAssetService imageAssetService;
     @Mock private GamePersistenceService gamePersistenceService;
     @Mock private GameMutationRequestService mutationRequestService;
-
     private GameService gameService;
 
     @BeforeEach
@@ -48,32 +46,21 @@ class GameServiceValidationTest {
         Clock clock = Clock.systemUTC();
         given(mutationRequestService.begin(anyString(), anyString(), anyString(), any(), any(), anyString()))
                 .willReturn(new GameMutationRequestService.BeginResult(100L, false, null, null, null));
-        gameService = new GameService(
-                narrativeGenerator,
-                imageAssetService,
-                gamePersistenceService,
-                new ChoiceCodec(new ObjectMapper()),
-                new ImagePromptComposer(),
+        gameService = new GameService(narrativeGenerator, imageAssetService, gamePersistenceService,
+                new ChoiceCodec(new ObjectMapper()), new TurnProcessor(), new ImagePromptComposer(),
                 new CostRateLimiter(new CostRateLimitPolicy(1_000, 1_000, 60), clock),
-                new ProviderCallTelemetry(clock, event -> {}),
-                new GameMutationFingerprint(),
-                mutationRequestService
-        );
+                new ProviderCallTelemetry(clock, event -> {}), new GameMutationFingerprint(), mutationRequestService);
     }
 
     @Test
     @DisplayName("DB user_choice 한계를 넘는 provider 선택지는 asset 발급과 저장 전에 거부한다")
     void initGame_RejectsOversizedProviderChoiceBeforeSideEffects() {
         GameInitRequest request = new GameInitRequest("세계관", "캐릭터");
-        NarrativeTurn invalidTurn = new NarrativeTurn(
-                "제목", "본문", List.of(new NarrativeTurn.Choice(1, "가".repeat(256))),
-                new NarrativeTurn.VisualAssets("street", List.of(), List.of())
-        );
+        NarrativeTurn invalidTurn = new NarrativeTurn("제목", "본문",
+                List.of(new NarrativeTurn.Choice(1, "가".repeat(256))),
+                new NarrativeTurn.VisualAssets("street", List.of(), List.of()));
         given(narrativeGenerator.createOpening("세계관", "캐릭터")).willReturn(invalidTurn);
-
-        assertThatThrownBy(() -> gameService.initGame(OWNER_KEY, request))
-                .isInstanceOf(InvalidNarrativeResponseException.class);
-
+        assertThatThrownBy(() -> gameService.initGame(OWNER_KEY, request)).isInstanceOf(InvalidNarrativeResponseException.class);
         verify(imageAssetService, never()).issue(any(), any());
         verify(gamePersistenceService, never()).saveOpening(any(), any(), any(), any(), any(), any(), any(), any());
         verify(mutationRequestService).markFailed(100L);
@@ -83,16 +70,11 @@ class GameServiceValidationTest {
     @DisplayName("중복 선택지 ID가 있는 provider 응답은 asset 발급과 저장 전에 거부한다")
     void initGame_RejectsDuplicateProviderChoiceIds() {
         GameInitRequest request = new GameInitRequest("세계관", "캐릭터");
-        NarrativeTurn invalidTurn = new NarrativeTurn(
-                "제목", "본문",
+        NarrativeTurn invalidTurn = new NarrativeTurn("제목", "본문",
                 List.of(new NarrativeTurn.Choice(1, "간다"), new NarrativeTurn.Choice(1, "멈춘다")),
-                new NarrativeTurn.VisualAssets("", List.of(), List.of())
-        );
+                new NarrativeTurn.VisualAssets("", List.of(), List.of()));
         given(narrativeGenerator.createOpening("세계관", "캐릭터")).willReturn(invalidTurn);
-
-        assertThatThrownBy(() -> gameService.initGame(OWNER_KEY, request))
-                .isInstanceOf(InvalidNarrativeResponseException.class);
-
+        assertThatThrownBy(() -> gameService.initGame(OWNER_KEY, request)).isInstanceOf(InvalidNarrativeResponseException.class);
         verify(imageAssetService, never()).issue(any(), any());
         verify(gamePersistenceService, never()).saveOpening(any(), any(), any(), any(), any(), any(), any(), any());
         verify(mutationRequestService).markFailed(100L);


### PR DESCRIPTION
## 왜 필요한가요?

#7의 pure Skill Check 규칙은 아직 실제 `/progress` turn pipeline과 연결되지 않아 서버가 roll/DC/modifier/outcome을 canonical turn의 일부로 확정·감사할 수 없었습니다. 특히 단순히 resolver에서 난수를 생성하면 provider 실패 후 같은 idempotency retry가 다시 resolver를 실행하면서 d20이 바뀔 수 있습니다.

이번 변경은 reservation 소유 요청이 Skill Check 판정을 한 번 고정하고, 같은 mutation retry에서는 이를 재사용한 뒤 canonical state transition과 GameLog audit을 한 commit으로 저장하는 첫 end-to-end vertical slice를 추가합니다.

- Closes #37

## 무엇이 바뀌나요?

- 게임 규칙·상태: `SKILL_CHECK` action type을 추가하고 `ActionResolver`가 서버 소유 stat/DC/situational modifier와 `SkillCheckResult`를 검증해 `GameResult`에 포함합니다. 현재 첫 vertical slice 정책은 `WILL`, DC 10, 상황 modifier 0이며 최종 balancing/action 분류 정책은 범위 밖입니다.
- Backend / API / DB: reservation에 provisional Skill Check 판정을 mutation request ID와 함께 보존하는 `SkillCheckDecisionService`를 추가했습니다. V12 migration으로 reservation 판정 필드와 GameLog audit 필드를 추가하고 nullable legacy 호환, 전체-field CHECK, mutation request FK를 적용합니다. API wire shape는 변경하지 않습니다.
- AI narrative / prompt: `NarrativeContext`에 provider-safe Skill Check projection을 추가해 raw roll, stat/situational modifier, DC, total, success/failure, rulesetVersion을 전달합니다. Gemini는 이를 재판정하지 않고 서술하며 action token은 계속 노출하지 않습니다.
- Image generation: 변경 없음.
- Frontend / UX: 상세 판정 UI는 #38 범위로 유지합니다. 현재 frontend가 보내는 typed action metadata는 기존 계약을 사용합니다. metadata 없는 legacy wire 요청은 기존 `NARRATIVE_CHOICE` compatibility 의미를 유지합니다.
- Build / deploy / docs: README를 현재 구현 상태에 맞게 갱신하고 `docs/architecture/skill-check-turn.md`에 판정 수명주기, retry/takeover, 감사 경계를 문서화했습니다.

## 책임 경계

- **서버가 결정하는 사실:** Skill Check 필요 action type, stat, DC, situational modifier, d20 raw roll, stat modifier, total, success/failure, rulesetVersion, reservation 소유권, canonical commit 여부
- **LLM이 서술하는 내용:** 서버가 확정한 Skill Check 결과가 드러나는 story prose, 다음 choice 문구, 선택적 visual assets
- **LLM이 변경하면 안 되는 사실:** roll/DC/modifier/total/success/failure, canonical state/stateChanges, reservation/idempotency 결과

## 어떻게 검증했나요?

- [x] PR 작성 전 변경 diff를 비판적으로 검토하고 타당한 지적을 반영했습니다.
- [x] `./gradlew clean test`
- [x] `./gradlew postgresIntegrationTest`
- [x] `./gradlew build`
- [x] `cd frontend && npm ci && npm test && npm run lint && npm run build`
- [ ] 정상 흐름을 직접 확인했습니다.
- [x] 잘못된 입력/실패 흐름을 확인했습니다.
- [x] 중복 요청 또는 상태 전이가 관련되면 이를 검증했습니다.

GitHub Actions CI run #181 (`33468543903`)에서 backend unit/H2 test, PostgreSQL integration test, backend build, frontend test/lint/build가 모두 성공했습니다. 수동 smoke는 별도로 수행하지 않았으므로 정상 흐름 직접 확인 항목은 체크하지 않았습니다.

추가/보강한 테스트는 다음 경계를 대상으로 합니다.

- `ActionResolverTest`: fixed `RandomSource` 성공/실패 경계, stale/invalid action, 저장 판정 재검증
- `GameServiceTest`: 동일 Skill Check 결과의 NarrativeContext/commit audit 전달
- `GeminiPromptContractTest`: raw roll부터 outcome까지 prompt projection과 action token 비노출
- `PostgresSkillCheckDecisionTest`: 같은 mutation retry 판정 재사용, 다른 takeover request의 새 판정
- `PostgresSkillCheckAuditTest`: 실제 PostgreSQL GameLog에서 raw roll부터 outcome까지 조회
- 기존 `PostgresM2TurnIntegrityMatrixTest`는 원형을 보존해 idempotency/concurrency/crash/stale-owner 회귀를 계속 검증합니다.

PR 전 비판적 리뷰에서 다음 문제를 발견하고 반영했습니다.

1. resolver에서 직접 매번 roll하면 provider 실패 후 같은 idempotency retry가 d20을 다시 굴릴 수 있어, reservation에 provisional 판정을 먼저 영속화하고 같은 mutation request에서 재사용하도록 변경했습니다.
2. 초기 수정 과정에서 기존 테스트/클래스를 불필요하게 압축해 diff churn이 커진 문제를 발견해 기존 검증을 복구하고 신규 검증만 추가했습니다. 특히 M2 PostgreSQL matrix는 원형으로 되돌렸습니다.
3. metadata 없는 legacy wire 요청까지 `SKILL_CHECK` 의미로 바꾸면 compatibility 계약이 깨지므로 legacy 요청은 기존 `NARRATIVE_CHOICE` 의미를 유지하도록 분리했습니다.
4. `GameService`에 호환 생성자를 추가하면서 Spring이 production 생성자를 모호하게 선택할 수 있어, TurnProcessor를 받는 production 생성자에 `@Autowired`를 명시했습니다.
5. provisional 판정의 `skill_check_request_id`가 mutation request에 귀속되지만 DB FK가 없던 점을 보완해 V12에 nullable FK를 추가했습니다.
6. 모든 신규 typed choice를 `WILL/DC10/0`으로 발급하는 정책이 최종 gameplay semantics로 오해될 수 있음을 검토했습니다. 이번 Issue의 첫 vertical slice를 위한 명시적 서버 정책으로 유지하되, provider가 stat/DC를 정하지 않도록 하고 최종 행동별 stat/DC 선택 및 balancing은 범위 밖임을 문서화했습니다.
7. 첫 CI에서 V12 migration의 복수 `ADD COLUMN`/constraint 문법이 H2에서 실패하는 문제를 확인해, PostgreSQL 의미를 유지하면서 각 schema 변경을 개별 `ALTER TABLE` 문으로 분리했습니다.

## 게임 상태·AI 안전성

- [x] 게임의 결정적 상태는 서버에서 검증·저장됩니다.
- [x] LLM 출력만으로 HP, 보상, 성공/실패 등 결정적 상태가 임의 변경되지 않습니다.
- [x] AI 요청에 필요한 최소 문맥만 전달합니다.
- [x] AI 응답 파싱 실패와 provider 오류가 게임 상태를 오염시키지 않습니다.
- [x] 기존 저장 데이터 또는 GameState 호환성 영향을 확인했습니다.

Skill Check 결과는 provider 응답에서 파싱하지 않습니다. reservation owner가 서버 규칙과 `SecureRandomSource`로 판정을 만들고, same-idempotency retry는 같은 판정을 재사용합니다. provider 실패 시 canonical turn은 진행하지 않습니다. legacy reservation/GameLog row는 신규 Skill Check 필드가 전부 NULL인 상태로 호환됩니다.

## 보안·비용

- [x] API Key, 토큰, 비밀번호가 코드·로그·URL·클라이언트 응답에 노출되지 않습니다.
- [x] 외부 AI/Image 호출 횟수와 실패 시 동작을 검토했습니다.
- [x] 사용자 입력 길이와 외부 API 비용 증가 가능성을 검토했습니다.
- [x] CORS 또는 공개 endpoint 변경이 있다면 의도된 변경입니다.

Skill Check 판정은 로컬 pure rule/DB operation이라 외부 provider 호출을 추가하지 않습니다. `provider_attempt_count`는 기존처럼 실제 Narrative provider 호출 직전에만 증가합니다. `PlayerAction.token`은 NarrativeContext/Gemini prompt에 포함하지 않습니다. CORS/public endpoint 변경은 없습니다.

## API·DB·운영 영향

- [x] API 계약 변경 시 Frontend 호출부와 문서를 함께 갱신했습니다.
- [x] DB schema 변경 시 migration 전략을 포함했습니다.
- [x] 환경변수는 이름과 용도만 문서화했고 실제 Secret은 포함하지 않았습니다.
- [x] 배포 후 확인할 smoke test가 있습니다.

API wire contract와 환경변수 변경은 없습니다. V12는 기존 row를 변경하지 않고 nullable 컬럼만 추가하며, Skill Check가 존재할 때만 전체 audit field가 함께 있어야 하는 CHECK constraint를 적용합니다. production smoke는 기존 `/init`/`progress` 계약을 유지하며, typed frontend 요청에서는 신규 `SKILL_CHECK` action metadata가 기존 필드를 통해 전달됩니다.

## 화면 / 응답 예시

Frontend 표시 변경은 없습니다. #38에서 서버가 확정한 능력치와 Skill Check 결과를 UI에 표시합니다.