### PR TITLE
feat(frontend): 능력치와 Skill Check 결과 한국어 UI 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ UCTale의 핵심 원칙은 **게임의 결정적 사실과 규칙은 서버가 �
 - 서버: 세션 소유권, 현재 턴, idempotency, reservation lease, canonical state, Skill Check 판정, `GameResult`, GameLog, provider attempt 상한을 검증합니다.
 - Narrative AI: 서버가 확정한 결과와 제한된 state/memory projection을 바탕으로 이야기와 다음 선택지 표현을 생성합니다.
 - Image AI: 브라우저의 임의 prompt가 아니라 서버가 발급한 image asset 계약만 실행합니다.
-- Frontend: 서버가 반환한 선택 행동과 상태를 표시하고, 규칙을 재계산하지 않습니다.
+- Frontend: 서버가 반환한 선택 행동, 캐릭터 능력치, Skill Check 결과를 표시하고 규칙을 재계산하지 않습니다.
 
 ---
 
@@ -80,7 +80,7 @@ UCTale의 핵심 원칙은 **게임의 결정적 사실과 규칙은 서버가 �
 
 ### 타입 안전한 능력치와 Skill Check
 
-#7의 순수 규칙 기반에 #37의 실제 turn 통합을 연결합니다.
+#7의 순수 규칙 기반에 #37의 실제 turn 통합과 #38의 frontend projection을 연결합니다.
 
 - `StatType`: `MIGHT`, `AGILITY`, `INTELLECT`, `WILL`, `PRESENCE`
 - 신규·legacy 캐릭터는 기본 능력치 10을 사용합니다.
@@ -92,7 +92,7 @@ UCTale의 핵심 원칙은 **게임의 결정적 사실과 규칙은 서버가 �
 - production random adapter는 `SecureRandom`, 테스트는 fixed/sequence `RandomSource`를 사용합니다.
 - 같은 idempotency mutation retry는 reservation에 보존된 동일 판정을 재사용하고, 다른 request가 만료 lease를 takeover하면 새 판정을 확정합니다.
 - canonical commit은 Skill Check 결과와 state transition을 같은 transaction에서 `GameLog`에 기록합니다.
-- frontend의 능력치/판정 결과 표시는 #38 범위입니다.
+- frontend는 서버가 반환한 능력치와 Skill Check projection을 한국어로 표시하며 modifier/outcome을 재계산하지 않습니다.
 
 ### GameState와 Story Memory
 
@@ -158,6 +158,7 @@ M2의 턴 무결성·복구 구현 범위와 완료 조건은 main에 반영되�
 - Charcoal Folio 기반 narrative-first single-column UI를 사용합니다.
 - React 19, Vite 8, plain CSS, SUIT Variable을 사용합니다.
 - `system | light | dark` 테마를 지원합니다.
+- 캐릭터 능력치와 최근 Skill Check roll/modifier/DC/total/outcome을 story 아래의 읽기 흐름에서 표시합니다.
 - API 오류는 화면 문맥 안에서 표시하고 가능한 경우 retry를 제공합니다.
 - 진행 중 중복 요청을 막고 typewriter skip 및 `prefers-reduced-motion`을 지원합니다.
 - image loading/failure, keyboard focus 이동, live-region 등 공유 베타 accessibility behavior를 포함합니다.
@@ -328,8 +329,6 @@ GitHub Actions CI도 backend unit test → PostgreSQL integration test → backe
 
 진행 중.
 
-현재 #33 `AvailableAction` / `PlayerAction`, #34 `ActionResolver` / `GameResult`, #36 확정 결과 기반 `NarrativeContext`, #7 typed `CharacterStats` / pure Skill Check 규칙에 더해 #37 Skill Check turn 통합과 감사 저장이 반영됩니다.
+현재 #33 `AvailableAction` / `PlayerAction`, #34 `ActionResolver` / `GameResult`, #36 확정 결과 기반 `NarrativeContext`, #7 typed `CharacterStats` / pure Skill Check 규칙에 더해 #37 Skill Check turn 통합·감사 저장과 #38 능력치·Skill Check 결과 frontend projection이 반영됩니다.
 
-다음 UI 단계는 #38 능력치·Skill Check 결과 표시입니다. Gemini structured output 검증과 bounded recovery는 #35의 별도 P1 작업입니다.
-
-아직 구현되지 않은 전투·인벤토리·퀘스트·NPC 관계 기능은 현재 기능처럼 문서에 표시하지 않습니다.
+Gemini structured output 검증과 bounded recovery는 #35의 별도 P1 작업입니다. 아직 구현되지 않은 전투·인벤토리·퀘스트·NPC 관계 기능은 현재 기능처럼 문서에 표시하지 않습니다.

--- a/docs/architecture/skill-check-turn.md
+++ b/docs/architecture/skill-check-turn.md
@@ -2,11 +2,11 @@
 
 ## 목적
 
-#37은 #7의 pure `SkillCheck` 규칙을 실제 `/progress` turn pipeline에 연결하는 첫 서버 주도 판정 vertical slice다.
+#37은 #7의 pure `SkillCheck` 규칙을 실제 `/progress` turn pipeline에 연결하는 첫 서버 주도 판정 vertical slice다. #38은 이 서버 확정 결과와 캐릭터 능력치를 frontend에 표시하는 projection 경계를 완성한다.
 
 핵심 원칙은 다음과 같다.
 
-> roll, modifier, DC, total, success/failure는 서버가 한 번 확정하고, Narrative provider는 그 결과를 서술만 한다.
+> roll, modifier, DC, total, success/failure는 서버가 한 번 확정하고, Narrative provider와 frontend는 그 결과를 재판정하지 않는다.
 
 ## 현재 action 정책
 
@@ -37,6 +37,8 @@ metadata가 없는 legacy wire 요청은 기존 `NARRATIVE_CHOICE` compatibility
 8. `GameResult`와 canonical next state를 확정한다.
 9. `NarrativeContext`에는 provider-safe `SkillCheckProjection`만 전달한다.
 10. provider story가 유효하면 state transition과 동일 canonical commit에서 Skill Check audit을 `GameLog`에 기록한다.
+11. API 응답은 canonical `GameState`의 능력치와 서버 확정 Skill Check 결과를 frontend-safe projection으로 반환한다.
+12. frontend mapper는 한국어 라벨과 표시 문자열만 구성하고 modifier/outcome을 계산하지 않는다.
 
 ## retry와 concurrency
 
@@ -45,6 +47,8 @@ metadata가 없는 legacy wire 요청은 기존 `NARRATIVE_CHOICE` compatibility
 provider 실패나 DB 실패 뒤 같은 idempotency request가 재시작돼도 `game_turn_reservation.skill_check_request_id`가 같은 mutation request ID를 가리키면 저장된 판정을 재사용한다.
 
 따라서 같은 사용자 mutation에서 provider retry나 canonical commit retry 때문에 d20이 바뀌지 않는다.
+
+완료된 mutation replay는 `GameLog`에 저장된 Skill Check audit 값을 다시 도메인 규칙으로 재판정하지 않고 응답 projection으로 복원한다. 현재 snapshot이 replay 대상 turn보다 최신이면 과거 능력치를 추측하지 않고 능력치 projection을 비워 frontend가 명시적인 표시 오류 상태로 처리한다.
 
 ### 다른 request takeover
 
@@ -92,6 +96,24 @@ Skill Check가 있는 turn은 CHECK constraint로 전체 필드가 함께 존재
 
 Gemini prompt는 서버가 확정한 roll/modifier/DC/total/outcome을 변경하거나 재판정하지 않도록 명시한다. provider 응답은 canonical Skill Check 결과의 근거가 아니다.
 
+## Frontend projection 경계
+
+`GameResponse`는 현재 canonical 캐릭터의 능력치와 해당 응답 turn에서 확정된 Skill Check 결과를 별도 projection으로 제공한다.
+
+능력치 projection은 각 stat의 서버 key, score, modifier를 제공한다. Skill Check projection은 stat type, raw roll, stat/situational modifier, DC, total, outcome, ruleset version을 제공한다.
+
+frontend의 `gameResponseMapper`는 다음만 담당한다.
+
+- `MIGHT`, `AGILITY`, `INTELLECT`, `WILL`, `PRESENCE`를 한국어 라벨로 매핑
+- 숫자 modifier의 부호 표시
+- `SUCCESS` / `FAILURE`의 한국어 표시
+- 새로운 enum key가 생겼을 때 서버 key를 보존하는 fallback
+- 누락/중복/불완전 응답을 기본값으로 보정하지 않고 오류 상태로 변환
+
+frontend는 `score`에서 modifier를 계산하거나 `total >= DC`로 outcome을 다시 판정하지 않는다.
+
+진행 중에는 기존 canonical `gameData`를 유지하므로 loading/retry/conflict가 같은 판정을 새 결과처럼 중복 표시하지 않는다. 성공 응답이 도착한 경우에만 새 projection으로 교체한다.
+
 ## 테스트 경계
 
 - `ActionResolverTest`: fixed `RandomSource` 성공/실패 경계, stale/invalid action, 저장 판정 재검증
@@ -99,6 +121,8 @@ Gemini prompt는 서버가 확정한 roll/modifier/DC/total/outcome을 변경하
 - `GeminiPromptContractTest`: raw roll부터 outcome까지 prompt projection 및 token 비노출 검증
 - `PostgresSkillCheckDecisionTest`: 같은 mutation retry의 판정 재사용, 다른 takeover request의 새 판정 검증
 - `PostgresSkillCheckAuditTest`: PostgreSQL `GameLog`에서 raw roll부터 outcome까지 조회 가능함을 검증
+- `GameResponseProjectorTest`: canonical 능력치/판정 projection, 저장 audit replay, 불완전 audit, 과거 replay의 최신 snapshot 오염 방지 검증
+- `gameResponseMapper.test.js`: 한국어 stat mapping, 서버 modifier/outcome 비재계산, 성공/실패, enum fallback, 누락/중복/불완전 fixture, replay 결정성 검증
 - 기존 M2 PostgreSQL matrix는 수정하지 않고 idempotency/concurrency/crash/stale-owner 회귀를 계속 검증한다.
 
 ## 범위 밖
@@ -107,4 +131,7 @@ Gemini prompt는 서버가 확정한 roll/modifier/DC/total/outcome을 변경하
 - natural 1/20 특수 규칙
 - advantage/disadvantage
 - 행동별 stat/DC 자동 선택 또는 balancing
-- frontend 판정 상세 UI (#38)
+- 직접 능력치 배분
+- 레벨업/장비 modifier
+- inventory/quest UI
+- 전체 디자인 시스템 개편

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -21,7 +21,8 @@ UCTale의 공유 베타 웹 클라이언트입니다. 서버가 소유한 게임
 
 - `AccessScreen`: 공유 베타 접근 인증
 - `GameSetupScreen`: 세계관/주인공 입력과 게임 시작
-- `GamePlayScreen`: 장면 이미지, story, 서버 발급 선택 행동 표시
+- `GamePlayScreen`: 장면 이미지, story, 서버 발급 선택 행동, 캐릭터 규칙 projection 표시
+- `GameRulesPanel`: 서버가 반환한 능력치와 최근 Skill Check 결과 표시
 - `ThemeSelector`: system/light/dark 테마
 - `GameImage`: 인증된 image asset fetch와 loading/failure 처리
 - `TypewriterText`: story typing, skip, reduced-motion 처리
@@ -56,12 +57,21 @@ npm run build
 
 GitHub Actions도 위 test/lint/build 경계를 검증합니다.
 
+`gameResponseMapper.test.js`는 fixture 기반으로 다음 계약을 검증합니다.
+
+- 현재 5개 능력치 key의 한국어 라벨
+- 서버가 반환한 modifier/outcome을 재계산하지 않는 표현
+- 성공/실패 판정 표시
+- 미지원 enum key의 명시적 fallback
+- 누락/중복/불완전 응답의 오류 상태
+- 동일 canonical 응답 replay의 결정적 표시
+
 ## 주요 디렉터리
 
 ```text
 src/
-├── api/            # API 호출과 오류 계약
-├── components/     # BrandHeader, GameImage, ThemeSelector, TypewriterText
+├── api/            # API 호출, 오류 계약, 게임 응답 표시 mapper
+├── components/     # BrandHeader, GameImage, GameRulesPanel, ThemeSelector, TypewriterText
 ├── screens/        # Access / Setup / Play 화면
 ├── theme/          # theme 상태와 semantic token 연결
 ├── App.jsx         # auth/game orchestration
@@ -73,5 +83,8 @@ src/
 
 - access/owner token은 HttpOnly cookie로 관리하며 Web Storage에 저장하지 않습니다.
 - `/progress`에는 서버가 반환한 action payload를 그대로 전달하며 성공/실패 판정을 frontend에서 재계산하지 않습니다.
+- 능력치 score/modifier와 Skill Check roll/modifier/DC/total/outcome은 backend projection을 그대로 표시합니다.
+- backend에 새 능력치 enum이 추가되어 한국어 매핑이 없으면 임의 번역하지 않고 서버 key를 포함한 fallback을 표시합니다.
+- 응답 필드가 누락되거나 중복된 경우 기본값을 추측하지 않고 명시적인 표시 오류 상태로 남깁니다.
 - image provider prompt, provider URL, API secret은 frontend에 노출하지 않습니다.
 - request 중 중복 진행을 막고, 실패 시 기존 화면 상태를 보존한 채 명시적 retry UX를 제공합니다.

--- a/frontend/src/api/gameApi.js
+++ b/frontend/src/api/gameApi.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { mapGameResponse } from './gameResponseMapper.js';
 
 const BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080/api/game';
 const API_ORIGIN = new URL(BASE_URL).origin;
@@ -16,7 +17,7 @@ export const initGame = async (worldSetting, characterSetting, idempotencyKey) =
     }, {
         headers: { 'Idempotency-Key': idempotencyKey }
     });
-    return response.data;
+    return mapGameResponse(response.data);
 };
 
 export const progressGame = async (sessionId, choice, expectedTurn, idempotencyKey) => {
@@ -31,7 +32,7 @@ export const progressGame = async (sessionId, choice, expectedTurn, idempotencyK
     }, {
         headers: { 'Idempotency-Key': idempotencyKey }
     });
-    return response.data;
+    return mapGameResponse(response.data);
 };
 
 export const resolveGameAssetUrl = (assetUrl) => {

--- a/frontend/src/api/gameResponseMapper.js
+++ b/frontend/src/api/gameResponseMapper.js
@@ -1,0 +1,163 @@
+const STAT_LABELS = Object.freeze({
+  MIGHT: '근력',
+  AGILITY: '민첩',
+  INTELLECT: '지능',
+  WILL: '의지',
+  PRESENCE: '매력',
+})
+
+const STAT_ORDER = Object.freeze(Object.keys(STAT_LABELS))
+const OUTCOME_LABELS = Object.freeze({
+  SUCCESS: '성공',
+  FAILURE: '실패',
+})
+
+const formatSignedInteger = (value) => (value >= 0 ? `+${value}` : String(value))
+const unknownStatLabel = (key) => `알 수 없는 능력치 (${key})`
+
+function mapCharacterStats(characterStats) {
+  if (!Array.isArray(characterStats) || characterStats.length === 0) {
+    return {
+      state: 'error',
+      message: '캐릭터 능력치 정보를 표시할 수 없습니다.',
+      items: [],
+      notice: null,
+    }
+  }
+
+  const byKey = new Map()
+  for (const stat of characterStats) {
+    if (
+      !stat ||
+      typeof stat.key !== 'string' ||
+      stat.key.length === 0 ||
+      !Number.isInteger(stat.score) ||
+      !Number.isInteger(stat.modifier) ||
+      byKey.has(stat.key)
+    ) {
+      return {
+        state: 'error',
+        message: '캐릭터 능력치 정보가 불완전합니다.',
+        items: [],
+        notice: null,
+      }
+    }
+    byKey.set(stat.key, stat)
+  }
+
+  if (STAT_ORDER.some((key) => !byKey.has(key))) {
+    return {
+      state: 'error',
+      message: '캐릭터 능력치 정보가 불완전합니다.',
+      items: [],
+      notice: null,
+    }
+  }
+
+  const knownItems = STAT_ORDER.map((key) => {
+    const stat = byKey.get(key)
+    return {
+      key,
+      label: STAT_LABELS[key],
+      score: stat.score,
+      modifier: stat.modifier,
+      modifierText: formatSignedInteger(stat.modifier),
+      isUnknown: false,
+    }
+  })
+
+  const unknownItems = characterStats
+    .filter((stat) => !STAT_LABELS[stat.key])
+    .map((stat) => ({
+      key: stat.key,
+      label: unknownStatLabel(stat.key),
+      score: stat.score,
+      modifier: stat.modifier,
+      modifierText: formatSignedInteger(stat.modifier),
+      isUnknown: true,
+    }))
+
+  return {
+    state: 'ready',
+    items: [...knownItems, ...unknownItems],
+    notice: unknownItems.length > 0
+      ? '새로운 능력치 이름의 한국어 번역이 없어 서버 키를 함께 표시합니다.'
+      : null,
+  }
+}
+
+function mapSkillCheck(latestSkillCheck, turnNumber) {
+  if (latestSkillCheck == null) {
+    return {
+      state: 'empty',
+      message: '아직 Skill Check 판정 기록이 없습니다.',
+    }
+  }
+
+  const requiredIntegerFields = [
+    'rawRoll',
+    'statModifier',
+    'situationalModifier',
+    'dc',
+    'total',
+    'rulesetVersion',
+  ]
+  if (
+    typeof latestSkillCheck !== 'object' ||
+    typeof latestSkillCheck.statType !== 'string' ||
+    latestSkillCheck.statType.length === 0 ||
+    typeof latestSkillCheck.outcome !== 'string' ||
+    latestSkillCheck.outcome.length === 0 ||
+    requiredIntegerFields.some((field) => !Number.isInteger(latestSkillCheck[field]))
+  ) {
+    return {
+      state: 'error',
+      message: '최근 Skill Check 결과를 표시할 수 없습니다.',
+    }
+  }
+
+  const statLabel = STAT_LABELS[latestSkillCheck.statType] ?? unknownStatLabel(latestSkillCheck.statType)
+  const outcomeLabel = OUTCOME_LABELS[latestSkillCheck.outcome]
+    ?? `알 수 없는 결과 (${latestSkillCheck.outcome})`
+  const tone = latestSkillCheck.outcome === 'SUCCESS'
+    ? 'success'
+    : latestSkillCheck.outcome === 'FAILURE'
+      ? 'failure'
+      : 'unknown'
+
+  return {
+    state: 'ready',
+    turnLabel: Number.isInteger(turnNumber) ? `턴 ${turnNumber}` : '최근 턴',
+    statType: latestSkillCheck.statType,
+    statLabel,
+    rawRoll: latestSkillCheck.rawRoll,
+    statModifier: latestSkillCheck.statModifier,
+    statModifierText: formatSignedInteger(latestSkillCheck.statModifier),
+    situationalModifier: latestSkillCheck.situationalModifier,
+    situationalModifierText: formatSignedInteger(latestSkillCheck.situationalModifier),
+    dc: latestSkillCheck.dc,
+    total: latestSkillCheck.total,
+    outcome: latestSkillCheck.outcome,
+    outcomeLabel,
+    tone,
+    rulesetVersion: latestSkillCheck.rulesetVersion,
+    notice: STAT_LABELS[latestSkillCheck.statType]
+      ? null
+      : '새로운 능력치 이름의 한국어 번역이 없어 서버 키를 함께 표시합니다.',
+  }
+}
+
+export function mapGameResponse(response) {
+  return {
+    ...response,
+    rules: {
+      stats: mapCharacterStats(response?.characterStats),
+      skillCheck: mapSkillCheck(response?.latestSkillCheck, response?.turnNumber),
+    },
+  }
+}
+
+export const gameResponsePresentation = {
+  mapCharacterStats,
+  mapSkillCheck,
+}

--- a/frontend/src/api/gameResponseMapper.test.js
+++ b/frontend/src/api/gameResponseMapper.test.js
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { mapGameResponse } from './gameResponseMapper.js'
+
+const statsFixture = [
+  { key: 'MIGHT', score: 14, modifier: 2 },
+  { key: 'AGILITY', score: 12, modifier: 1 },
+  { key: 'INTELLECT', score: 10, modifier: 0 },
+  { key: 'WILL', score: 8, modifier: -1 },
+  { key: 'PRESENCE', score: 16, modifier: 3 },
+]
+
+const successFixture = {
+  sessionId: 42,
+  turnNumber: 2,
+  title: '판정 장면',
+  storyText: '문이 열렸다.',
+  choices: [],
+  mainImageUrl: null,
+  characterStats: statsFixture,
+  latestSkillCheck: {
+    statType: 'WILL',
+    rawRoll: 7,
+    statModifier: 5,
+    situationalModifier: -2,
+    dc: 30,
+    total: 1,
+    outcome: 'SUCCESS',
+    rulesetVersion: 1,
+  },
+}
+
+test('모든 현재 능력치 key를 한국어 라벨로 매핑한다', () => {
+  const mapped = mapGameResponse(successFixture)
+
+  assert.deepEqual(
+    mapped.rules.stats.items.map(({ key, label }) => [key, label]),
+    [
+      ['MIGHT', '근력'],
+      ['AGILITY', '민첩'],
+      ['INTELLECT', '지능'],
+      ['WILL', '의지'],
+      ['PRESENCE', '매력'],
+    ],
+  )
+})
+
+test('modifier와 outcome은 서버 값을 재계산하지 않고 그대로 표현한다', () => {
+  const mapped = mapGameResponse(successFixture)
+
+  assert.equal(mapped.rules.skillCheck.statModifierText, '+5')
+  assert.equal(mapped.rules.skillCheck.situationalModifierText, '-2')
+  assert.equal(mapped.rules.skillCheck.total, 1)
+  assert.equal(mapped.rules.skillCheck.dc, 30)
+  assert.equal(mapped.rules.skillCheck.outcome, 'SUCCESS')
+  assert.equal(mapped.rules.skillCheck.outcomeLabel, '성공')
+})
+
+test('실패 outcome은 서버 FAILURE를 그대로 실패로 표현한다', () => {
+  const mapped = mapGameResponse({
+    ...successFixture,
+    latestSkillCheck: {
+      ...successFixture.latestSkillCheck,
+      total: 99,
+      dc: 1,
+      outcome: 'FAILURE',
+    },
+  })
+
+  assert.equal(mapped.rules.skillCheck.outcome, 'FAILURE')
+  assert.equal(mapped.rules.skillCheck.outcomeLabel, '실패')
+  assert.equal(mapped.rules.skillCheck.tone, 'failure')
+})
+
+test('새로운 enum key는 잘못 번역하지 않고 서버 key를 포함한 fallback으로 표시한다', () => {
+  const mapped = mapGameResponse({
+    ...successFixture,
+    characterStats: [
+      ...statsFixture,
+      { key: 'FORTUNE', score: 11, modifier: 9 },
+    ],
+  })
+
+  assert.equal(mapped.rules.stats.state, 'ready')
+  assert.equal(mapped.rules.stats.items.at(-1).label, '알 수 없는 능력치 (FORTUNE)')
+  assert.equal(mapped.rules.stats.items.at(-1).modifierText, '+9')
+  assert.match(mapped.rules.stats.notice, /서버 키/)
+})
+
+test('필수 능력치가 누락되거나 중복되면 조용히 기본값으로 보정하지 않는다', () => {
+  const missing = mapGameResponse({
+    ...successFixture,
+    characterStats: statsFixture.filter((stat) => stat.key !== 'WILL'),
+  })
+  const duplicate = mapGameResponse({
+    ...successFixture,
+    characterStats: [...statsFixture, statsFixture[0]],
+  })
+
+  assert.equal(missing.rules.stats.state, 'error')
+  assert.equal(duplicate.rules.stats.state, 'error')
+})
+
+test('불완전한 Skill Check fixture는 판정값을 추측하지 않고 오류 상태로 남긴다', () => {
+  const mapped = mapGameResponse({
+    ...successFixture,
+    latestSkillCheck: {
+      statType: 'WILL',
+      rawRoll: 10,
+      outcome: 'SUCCESS',
+    },
+  })
+
+  assert.equal(mapped.rules.skillCheck.state, 'error')
+  assert.match(mapped.rules.skillCheck.message, /표시할 수 없습니다/)
+})
+
+test('opening에는 Skill Check가 없음을 명시적인 empty 상태로 표현한다', () => {
+  const mapped = mapGameResponse({
+    ...successFixture,
+    turnNumber: 1,
+    latestSkillCheck: null,
+  })
+
+  assert.equal(mapped.rules.skillCheck.state, 'empty')
+})
+
+test('동일 canonical 응답을 다시 매핑해도 표시 결과가 결정적으로 동일하다', () => {
+  const first = mapGameResponse(successFixture)
+  const replay = mapGameResponse(structuredClone(successFixture))
+
+  assert.deepEqual(replay.rules, first.rules)
+})

--- a/frontend/src/components/GameRulesPanel.css
+++ b/frontend/src/components/GameRulesPanel.css
@@ -1,0 +1,155 @@
+.rules-panel {
+  width: min(100%, var(--reading-width));
+  margin: clamp(2rem, 6vw, 3rem) auto 0;
+  padding: var(--space-5);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+}
+
+.rules-panel__heading {
+  margin-bottom: var(--space-5);
+}
+
+.rules-panel__heading h2,
+.rules-panel h3 {
+  margin: 0;
+}
+
+.rules-panel__heading h2 {
+  font-size: 1.15rem;
+  letter-spacing: -0.02em;
+}
+
+.rules-panel h3 {
+  font-size: 0.95rem;
+  font-weight: 750;
+}
+
+.rules-panel__content {
+  display: grid;
+  gap: var(--space-5);
+}
+
+.stats-grid {
+  margin: var(--space-3) 0 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-2);
+}
+
+.stat-card {
+  min-width: 0;
+  padding: var(--space-3);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-raised);
+}
+
+.stat-card dt {
+  color: var(--color-text-muted);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.stat-card dd {
+  margin: var(--space-1) 0 0;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.stat-card strong {
+  font-size: 1.15rem;
+}
+
+.stat-card span {
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+}
+
+.skill-check-card {
+  padding-top: var(--space-5);
+  border-top: 1px solid var(--color-border-subtle);
+}
+
+.skill-check-card__heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.skill-check-card__summary,
+.rules-panel__notice {
+  color: var(--color-text-muted);
+  font-size: 0.86rem;
+  line-height: 1.55;
+}
+
+.skill-check-card__summary {
+  margin: var(--space-2) 0 var(--space-3);
+}
+
+.rules-panel__notice {
+  margin: var(--space-3) 0 0;
+}
+
+.skill-check-outcome {
+  flex: 0 0 auto;
+  padding: 0.22rem 0.48rem;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.skill-check-outcome--success {
+  border-color: var(--color-action);
+  color: var(--color-action);
+}
+
+.skill-check-outcome--failure {
+  border-color: var(--color-danger);
+  color: var(--color-danger);
+}
+
+.skill-check-grid {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: var(--space-2);
+}
+
+.skill-check-grid div {
+  min-width: 0;
+}
+
+.skill-check-grid dt {
+  color: var(--color-text-muted);
+  font-size: 0.74rem;
+}
+
+.skill-check-grid dd {
+  margin: var(--space-1) 0 0;
+  font-size: 0.95rem;
+  font-weight: 750;
+}
+
+@media (min-width: 48rem) {
+  .stats-grid {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 35rem) {
+  .rules-panel {
+    padding: var(--space-4);
+  }
+
+  .skill-check-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    row-gap: var(--space-3);
+  }
+}

--- a/frontend/src/components/GameRulesPanel.jsx
+++ b/frontend/src/components/GameRulesPanel.jsx
@@ -1,0 +1,70 @@
+function GameRulesPanel({ rules, isProgressing }) {
+  const stats = rules?.stats
+  const skillCheck = rules?.skillCheck
+
+  return (
+    <section className="rules-panel" aria-labelledby="rules-panel-title" aria-busy={isProgressing}>
+      <div className="rules-panel__heading">
+        <p className="eyebrow">Character rules</p>
+        <h2 id="rules-panel-title">캐릭터 능력치와 최근 판정</h2>
+      </div>
+
+      <div className="rules-panel__content">
+        <section aria-labelledby="stats-title">
+          <h3 id="stats-title">능력치</h3>
+          {stats?.state === 'ready' ? (
+            <>
+              <dl className="stats-grid">
+                {stats.items.map((stat) => (
+                  <div className="stat-card" key={stat.key}>
+                    <dt>{stat.label}</dt>
+                    <dd>
+                      <strong>{stat.score}</strong>
+                      <span>수정치 {stat.modifierText}</span>
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+              {stats.notice && <p className="rules-panel__notice" role="status">{stats.notice}</p>}
+            </>
+          ) : (
+            <p className="rules-panel__notice" role="status">{stats?.message ?? '능력치 정보를 표시할 수 없습니다.'}</p>
+          )}
+        </section>
+
+        <section className="skill-check-card" aria-labelledby="skill-check-title">
+          <div className="skill-check-card__heading">
+            <h3 id="skill-check-title">최근 Skill Check</h3>
+            {skillCheck?.state === 'ready' && (
+              <span className={`skill-check-outcome skill-check-outcome--${skillCheck.tone}`}>
+                {skillCheck.outcomeLabel}
+              </span>
+            )}
+          </div>
+
+          {skillCheck?.state === 'ready' ? (
+            <>
+              <p className="skill-check-card__summary">
+                {skillCheck.turnLabel} · {skillCheck.statLabel}
+              </p>
+              <dl className="skill-check-grid">
+                <div><dt>주사위</dt><dd>{skillCheck.rawRoll}</dd></div>
+                <div><dt>능력 수정치</dt><dd>{skillCheck.statModifierText}</dd></div>
+                <div><dt>상황 수정치</dt><dd>{skillCheck.situationalModifierText}</dd></div>
+                <div><dt>DC</dt><dd>{skillCheck.dc}</dd></div>
+                <div><dt>합계</dt><dd>{skillCheck.total}</dd></div>
+              </dl>
+              {skillCheck.notice && <p className="rules-panel__notice" role="status">{skillCheck.notice}</p>}
+            </>
+          ) : (
+            <p className="rules-panel__notice" role="status">
+              {skillCheck?.message ?? '최근 Skill Check 결과를 표시할 수 없습니다.'}
+            </p>
+          )}
+        </section>
+      </div>
+    </section>
+  )
+}
+
+export default GameRulesPanel

--- a/frontend/src/components/GameRulesPanel.jsx
+++ b/frontend/src/components/GameRulesPanel.jsx
@@ -1,3 +1,5 @@
+import './GameRulesPanel.css'
+
 function GameRulesPanel({ rules, isProgressing }) {
   const stats = rules?.stats
   const skillCheck = rules?.skillCheck

--- a/frontend/src/screens/GamePlayScreen.jsx
+++ b/frontend/src/screens/GamePlayScreen.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 import BrandHeader from '../components/BrandHeader'
 import GameImage from '../components/GameImage'
+import GameRulesPanel from '../components/GameRulesPanel'
 import TypewriterText from '../components/TypewriterText'
 
 function GamePlayScreen({
@@ -50,6 +51,8 @@ function GamePlayScreen({
             onComplete={onTypingComplete}
           />
         </article>
+
+        <GameRulesPanel rules={gameData.rules} isProgressing={isProgressing} />
 
         <section className="choices-section" aria-labelledby="choices-title" aria-busy={isProgressing}>
           <div className="choices-heading">

--- a/src/main/java/com/uctale/uctale/application/game/GamePersistenceService.java
+++ b/src/main/java/com/uctale/uctale/application/game/GamePersistenceService.java
@@ -86,7 +86,14 @@ public class GamePersistenceService {
         GameSession session = findOwnedSession(ownerKey, sessionId);
         GameLog log = gameLogRepository.findByGameSessionAndTurnNumber(session, turnNumber)
                 .orElseThrow(() -> new IllegalStateException("완료된 게임 로그를 찾을 수 없습니다."));
-        return new CommittedTurn(log.getStoryText(), log.getChoicesJson(), log.getImageUrl());
+        GameState gameState = loadOrRecoverState(session);
+        return new CommittedTurn(
+                log.getStoryText(),
+                log.getChoicesJson(),
+                log.getImageUrl(),
+                gameState,
+                SkillCheckAudit.from(log)
+        );
     }
 
     @Transactional
@@ -200,5 +207,41 @@ public class GamePersistenceService {
 
     public record LoadedTurn(Long sessionId, int turnNumber, String worldSetting, String characterSetting,
             String storyText, String choicesJson, String imageUrl, GameState gameState) {}
-    public record CommittedTurn(String storyText, String choicesJson, String imageUrl) {}
+
+    public record CommittedTurn(
+            String storyText,
+            String choicesJson,
+            String imageUrl,
+            GameState gameState,
+            SkillCheckAudit skillCheckAudit
+    ) {
+        public CommittedTurn(String storyText, String choicesJson, String imageUrl) {
+            this(storyText, choicesJson, imageUrl, null, null);
+        }
+    }
+
+    public record SkillCheckAudit(
+            String statType,
+            Integer rawRoll,
+            Integer statModifier,
+            Integer situationalModifier,
+            Integer dc,
+            Integer total,
+            String outcome,
+            Integer rulesetVersion
+    ) {
+        static SkillCheckAudit from(GameLog log) {
+            if (log.getSkillCheckStatType() == null) return null;
+            return new SkillCheckAudit(
+                    log.getSkillCheckStatType(),
+                    log.getSkillCheckRawRoll(),
+                    log.getSkillCheckStatModifier(),
+                    log.getSkillCheckSituationalModifier(),
+                    log.getSkillCheckDc(),
+                    log.getSkillCheckTotal(),
+                    log.getSkillCheckOutcome(),
+                    log.getSkillCheckRulesetVersion()
+            );
+        }
+    }
 }

--- a/src/main/java/com/uctale/uctale/application/game/GameResponseProjector.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameResponseProjector.java
@@ -1,0 +1,109 @@
+package com.uctale.uctale.application.game;
+
+import com.uctale.uctale.domain.game.CharacterStats;
+import com.uctale.uctale.domain.game.GameState;
+import com.uctale.uctale.domain.game.SkillCheckResult;
+import com.uctale.uctale.domain.game.StatType;
+import com.uctale.uctale.dto.GameChoice;
+import com.uctale.uctale.dto.GameResponse;
+
+import java.util.Arrays;
+import java.util.List;
+
+public final class GameResponseProjector {
+    private GameResponseProjector() {}
+
+    public static GameResponse project(
+            Long sessionId,
+            int turnNumber,
+            String title,
+            String storyText,
+            List<GameChoice> choices,
+            String imageUrl,
+            GameState gameState,
+            SkillCheckResult skillCheckResult
+    ) {
+        return new GameResponse(
+                sessionId,
+                turnNumber,
+                title,
+                storyText,
+                choices,
+                imageUrl,
+                projectStats(gameState),
+                projectSkillCheck(skillCheckResult)
+        );
+    }
+
+    public static GameResponse projectReplay(
+            Long sessionId,
+            int turnNumber,
+            String title,
+            String storyText,
+            List<GameChoice> choices,
+            String imageUrl,
+            GameState gameState,
+            GamePersistenceService.SkillCheckAudit skillCheckAudit
+    ) {
+        return new GameResponse(
+                sessionId,
+                turnNumber,
+                title,
+                storyText,
+                choices,
+                imageUrl,
+                projectStats(gameState),
+                projectSkillCheckAudit(skillCheckAudit)
+        );
+    }
+
+    private static List<GameResponse.CharacterStat> projectStats(GameState gameState) {
+        if (gameState == null) return List.of();
+        CharacterStats stats = gameState.playerCharacter().stats();
+        return Arrays.stream(StatType.values())
+                .map(statType -> new GameResponse.CharacterStat(
+                        statType.name(),
+                        stats.score(statType),
+                        stats.modifier(statType)
+                ))
+                .toList();
+    }
+
+    private static GameResponse.SkillCheckView projectSkillCheck(SkillCheckResult result) {
+        if (result == null) return null;
+        return new GameResponse.SkillCheckView(
+                result.statType().name(),
+                result.rawRoll(),
+                result.statModifier(),
+                result.situationalModifier(),
+                result.dc(),
+                result.total(),
+                result.outcome().name(),
+                result.rulesetVersion()
+        );
+    }
+
+    private static GameResponse.SkillCheckView projectSkillCheckAudit(GamePersistenceService.SkillCheckAudit audit) {
+        if (audit == null) return null;
+        if (audit.statType() == null
+                || audit.rawRoll() == null
+                || audit.statModifier() == null
+                || audit.situationalModifier() == null
+                || audit.dc() == null
+                || audit.total() == null
+                || audit.outcome() == null
+                || audit.rulesetVersion() == null) {
+            throw new IllegalStateException("저장된 Skill Check audit이 불완전합니다.");
+        }
+        return new GameResponse.SkillCheckView(
+                audit.statType(),
+                audit.rawRoll(),
+                audit.statModifier(),
+                audit.situationalModifier(),
+                audit.dc(),
+                audit.total(),
+                audit.outcome(),
+                audit.rulesetVersion()
+        );
+    }
+}

--- a/src/main/java/com/uctale/uctale/application/game/GameResponseProjector.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameResponseProjector.java
@@ -45,6 +45,7 @@ public final class GameResponseProjector {
             GameState gameState,
             GamePersistenceService.SkillCheckAudit skillCheckAudit
     ) {
+        GameState exactReplayState = gameState != null && gameState.turnNumber() == turnNumber ? gameState : null;
         return new GameResponse(
                 sessionId,
                 turnNumber,
@@ -52,7 +53,7 @@ public final class GameResponseProjector {
                 storyText,
                 choices,
                 imageUrl,
-                projectStats(gameState),
+                projectStats(exactReplayState),
                 projectSkillCheckAudit(skillCheckAudit)
         );
     }

--- a/src/main/java/com/uctale/uctale/dto/GameResponse.java
+++ b/src/main/java/com/uctale/uctale/dto/GameResponse.java
@@ -8,5 +8,35 @@ public record GameResponse(
         String title,
         String storyText,
         List<GameChoice> choices,
-        String mainImageUrl
-) {}
+        String mainImageUrl,
+        List<CharacterStat> characterStats,
+        SkillCheckView latestSkillCheck
+) {
+    public GameResponse(
+            Long sessionId,
+            int turnNumber,
+            String title,
+            String storyText,
+            List<GameChoice> choices,
+            String mainImageUrl
+    ) {
+        this(sessionId, turnNumber, title, storyText, choices, mainImageUrl, List.of(), null);
+    }
+
+    public record CharacterStat(
+            String key,
+            int score,
+            int modifier
+    ) {}
+
+    public record SkillCheckView(
+            String statType,
+            int rawRoll,
+            int statModifier,
+            int situationalModifier,
+            int dc,
+            int total,
+            String outcome,
+            int rulesetVersion
+    ) {}
+}

--- a/src/main/java/com/uctale/uctale/service/GameService.java
+++ b/src/main/java/com/uctale/uctale/service/GameService.java
@@ -8,6 +8,7 @@ import com.uctale.uctale.application.game.ChoiceCodec;
 import com.uctale.uctale.application.game.GameMutationFingerprint;
 import com.uctale.uctale.application.game.GameMutationRequestService;
 import com.uctale.uctale.application.game.GamePersistenceService;
+import com.uctale.uctale.application.game.GameResponseProjector;
 import com.uctale.uctale.application.game.GameTurnCommit;
 import com.uctale.uctale.application.game.ImagePromptComposer;
 import com.uctale.uctale.application.game.TurnProcessor;
@@ -17,6 +18,7 @@ import com.uctale.uctale.application.narrative.NarrativeContext;
 import com.uctale.uctale.application.narrative.NarrativeGenerator;
 import com.uctale.uctale.application.narrative.NarrativeTurn;
 import com.uctale.uctale.domain.action.PlayerAction;
+import com.uctale.uctale.domain.game.GameState;
 import com.uctale.uctale.domain.game.StateTransition;
 import com.uctale.uctale.domain.game.TurnResolution;
 import com.uctale.uctale.dto.GameChoice;
@@ -136,7 +138,11 @@ public class GameService {
                     costContext.ownerKey(), request.worldSetting(), request.characterSetting(), opening.storyText(),
                     choiceCodec.serialize(choices), imageAsset, mutation.requestId(), opening.title()
             );
-            return toResponse(session.getId(), session.getCurrentTurn(), opening, choices, imageAsset.publicUrl());
+            GameState initialState = GameState.initial(request.worldSetting(), request.characterSetting(), opening.storyText());
+            return GameResponseProjector.project(
+                    session.getId(), session.getCurrentTurn(), opening.title(), opening.storyText(), choices,
+                    imageAsset.publicUrl(), initialState, null
+            );
         } catch (RuntimeException exception) {
             mutationRequestService.markFailed(mutation.requestId());
             throw exception;
@@ -208,7 +214,10 @@ public class GameService {
                     costContext.ownerKey(), loadedTurn.sessionId(), commit, mutation.requestId(), nextTurn.title(),
                     mutation.reservationOwner()
             );
-            return toResponse(loadedTurn.sessionId(), savedTurn, nextTurn, choices, imageUrl);
+            return GameResponseProjector.project(
+                    loadedTurn.sessionId(), savedTurn, nextTurn.title(), nextTurn.storyText(), choices, imageUrl,
+                    committedTransition.nextState(), resolution.gameResult().skillCheckResult()
+            );
         } catch (RuntimeException exception) {
             mutationRequestService.markFailed(mutation.requestId(), mutation.reservationOwner());
             throw exception;
@@ -222,9 +231,9 @@ public class GameService {
         GamePersistenceService.CommittedTurn turn = gamePersistenceService.loadCommittedTurn(
                 ownerKey, mutation.resultSessionId(), mutation.resultTurn()
         );
-        return new GameResponse(
+        return GameResponseProjector.projectReplay(
                 mutation.resultSessionId(), mutation.resultTurn(), mutation.resultTitle(), turn.storyText(),
-                choiceCodec.deserialize(turn.choicesJson()), turn.imageUrl()
+                choiceCodec.deserialize(turn.choicesJson()), turn.imageUrl(), turn.gameState(), turn.skillCheckAudit()
         );
     }
 
@@ -261,9 +270,5 @@ public class GameService {
         if (imagePrompt != null && imagePrompt.length() > MAX_IMAGE_PROMPT_LENGTH) {
             throw new InvalidNarrativeResponseException("이미지 prompt가 너무 깁니다.");
         }
-    }
-
-    private GameResponse toResponse(Long sessionId, int turnNumber, NarrativeTurn turn, List<GameChoice> choices, String imageUrl) {
-        return new GameResponse(sessionId, turnNumber, turn.title(), turn.storyText(), choices, imageUrl);
     }
 }

--- a/src/test/java/com/uctale/uctale/application/game/GameResponseProjectorTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/GameResponseProjectorTest.java
@@ -45,7 +45,7 @@ class GameResponseProjectorTest {
         );
 
         GameResponse response = GameResponseProjector.projectReplay(
-                42L, 2, "장면", "스토리", List.of(), null,
+                42L, 1, "장면", "스토리", List.of(), null,
                 GameState.initial("세계", "캐릭터", "오프닝"), audit
         );
 
@@ -57,13 +57,24 @@ class GameResponseProjectorTest {
     }
 
     @Test
+    void replayDoesNotUseNewerStateAsHistoricalStats() {
+        GameState newerState = GameState.initial("세계", "캐릭터", "오프닝").advance("행동", "다음 이야기");
+
+        GameResponse response = GameResponseProjector.projectReplay(
+                42L, 1, "과거 장면", "오프닝", List.of(), null, newerState, null
+        );
+
+        assertThat(response.characterStats()).isEmpty();
+    }
+
+    @Test
     void replayRejectsPartialAuditInsteadOfSilentlyDefaulting() {
         GamePersistenceService.SkillCheckAudit partial = new GamePersistenceService.SkillCheckAudit(
                 "WILL", 10, null, 0, 10, 10, "SUCCESS", 1
         );
 
         assertThatThrownBy(() -> GameResponseProjector.projectReplay(
-                42L, 2, "장면", "스토리", List.of(), null,
+                42L, 1, "장면", "스토리", List.of(), null,
                 GameState.initial("세계", "캐릭터", "오프닝"), partial
         )).isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("불완전");

--- a/src/test/java/com/uctale/uctale/application/game/GameResponseProjectorTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/GameResponseProjectorTest.java
@@ -1,0 +1,71 @@
+package com.uctale.uctale.application.game;
+
+import com.uctale.uctale.domain.game.GameState;
+import com.uctale.uctale.domain.game.SkillCheckOutcome;
+import com.uctale.uctale.domain.game.SkillCheckResult;
+import com.uctale.uctale.domain.game.StatType;
+import com.uctale.uctale.dto.GameResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GameResponseProjectorTest {
+
+    @Test
+    void projectsCanonicalStatsAndServerSkillCheckWithoutRecalculation() {
+        GameState state = GameState.initial("세계", "캐릭터", "오프닝");
+        SkillCheckResult result = new SkillCheckResult(
+                StatType.WILL, 10, 0, 0, 10, 10, SkillCheckOutcome.SUCCESS, 1
+        );
+
+        GameResponse response = GameResponseProjector.project(
+                42L, 2, "장면", "스토리", List.of(), null, state, result
+        );
+
+        assertThat(response.characterStats())
+                .extracting(GameResponse.CharacterStat::key)
+                .containsExactly("MIGHT", "AGILITY", "INTELLECT", "WILL", "PRESENCE");
+        assertThat(response.characterStats())
+                .allSatisfy(stat -> {
+                    assertThat(stat.score()).isEqualTo(10);
+                    assertThat(stat.modifier()).isZero();
+                });
+        assertThat(response.latestSkillCheck().statType()).isEqualTo("WILL");
+        assertThat(response.latestSkillCheck().rawRoll()).isEqualTo(10);
+        assertThat(response.latestSkillCheck().outcome()).isEqualTo("SUCCESS");
+    }
+
+    @Test
+    void replayUsesStoredAuditValuesWithoutConstructingDomainResult() {
+        GamePersistenceService.SkillCheckAudit audit = new GamePersistenceService.SkillCheckAudit(
+                "FUTURE_STAT", 20, 99, -99, 1, -123, "FUTURE_OUTCOME", 999
+        );
+
+        GameResponse response = GameResponseProjector.projectReplay(
+                42L, 2, "장면", "스토리", List.of(), null,
+                GameState.initial("세계", "캐릭터", "오프닝"), audit
+        );
+
+        assertThat(response.latestSkillCheck().statType()).isEqualTo("FUTURE_STAT");
+        assertThat(response.latestSkillCheck().statModifier()).isEqualTo(99);
+        assertThat(response.latestSkillCheck().total()).isEqualTo(-123);
+        assertThat(response.latestSkillCheck().outcome()).isEqualTo("FUTURE_OUTCOME");
+        assertThat(response.latestSkillCheck().rulesetVersion()).isEqualTo(999);
+    }
+
+    @Test
+    void replayRejectsPartialAuditInsteadOfSilentlyDefaulting() {
+        GamePersistenceService.SkillCheckAudit partial = new GamePersistenceService.SkillCheckAudit(
+                "WILL", 10, null, 0, 10, 10, "SUCCESS", 1
+        );
+
+        assertThatThrownBy(() -> GameResponseProjector.projectReplay(
+                42L, 2, "장면", "스토리", List.of(), null,
+                GameState.initial("세계", "캐릭터", "오프닝"), partial
+        )).isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("불완전");
+    }
+}


### PR DESCRIPTION
## 왜 필요한가요?

#37에서 서버가 확정·감사 저장하는 캐릭터 능력치와 Skill Check 결과가 실제 플레이 화면에는 노출되지 않아, 플레이어가 판정 근거를 확인할 수 없었습니다. 또한 frontend가 규칙을 재구현하지 않고 backend projection만 표현하는 경계를 명시할 필요가 있습니다.

- Closes #38

## 무엇이 바뀌나요?

- 게임 규칙·상태: canonical `GameState`의 능력치와 서버가 확정한 Skill Check 결과를 응답 projection으로 노출합니다. 완료 mutation replay는 저장된 Skill Check audit 값을 재판정하지 않고 복원합니다.
- Backend / API / DB: `GameResponse`에 `characterStats`, `latestSkillCheck` projection을 추가했습니다. DB schema 변경은 없습니다.
- AI narrative / prompt: 변경 없습니다.
- Image generation: 변경 없습니다.
- Frontend / UX: `gameResponseMapper`에서 한국어 라벨/표시 문자열만 구성하고 `GameRulesPanel`에서 능력치, roll, modifier, DC, total, 성공/실패를 표시합니다. 미지원 enum과 불완전 응답은 추측하지 않고 fallback/error 상태로 표시합니다.
- Build / deploy / docs: root README, frontend README, Skill Check architecture 문서를 현재 projection 경계에 맞게 갱신했습니다.

## 책임 경계

게임 기능이나 AI 변경이 있다면 아래를 명확히 적어 주세요.

- **서버가 결정하는 사실:** 능력치 score/modifier, Skill Check raw roll/stat modifier/situational modifier/DC/total/outcome/ruleset version.
- **LLM이 서술하는 내용:** 기존과 동일하게 서버가 확정한 결과에 대한 story prose와 다음 choice 후보.
- **LLM이 변경하면 안 되는 사실:** 능력치와 Skill Check 계산 근거 및 성공/실패 결과.

Frontend도 `score`에서 modifier를 계산하거나 `total >= DC`로 outcome을 재판정하지 않습니다.

## 어떻게 검증했나요?

- [x] PR 작성 전 변경 diff를 비판적으로 검토하고 타당한 지적을 반영했습니다.
- [x] `./gradlew clean test`
- [x] `./gradlew postgresIntegrationTest`
- [ ] `./gradlew build`
- [x] `cd frontend && npm ci && npm test && npm run lint && npm run build`
- [ ] 정상 흐름을 직접 확인했습니다.
- [x] 잘못된 입력/실패 흐름을 확인했습니다.
- [x] 중복 요청 또는 상태 전이가 관련되면 이를 검증했습니다.

GitHub Actions CI run #184에서 `./gradlew clean test`, `./gradlew postgresIntegrationTest`, frontend `npm ci`/test/lint/build가 모두 성공했습니다. Backend build step은 `./gradlew build -x test`로 성공했으므로 template의 정확한 `./gradlew build` 항목은 체크하지 않았습니다.

Frontend fixture 테스트는 능력치·성공·실패·미지원 enum·누락/중복/불완전 응답·replay 결정성을 검증합니다. Backend 전체 unit/H2 및 PostgreSQL regression suite가 통과해 기존 idempotency/concurrency/state transition 경계 회귀가 없음을 확인했습니다.

비판적 검토에서 완료된 과거 mutation을 replay할 때 현재 최신 snapshot의 능력치를 과거 응답의 능력치처럼 노출할 수 있는 문제를 발견했습니다. 과거 turn과 snapshot turn이 다르면 historical stat을 추측하지 않고 stats projection을 비우도록 fail-closed 처리하고 회귀 테스트를 추가했습니다. Skill Check 자체는 해당 turn의 `GameLog` audit 원문을 재판정 없이 사용합니다.

## 게임 상태·AI 안전성

해당하지 않는 항목은 이유를 적어 주세요.

- [x] 게임의 결정적 상태는 서버에서 검증·저장됩니다.
- [x] LLM 출력만으로 HP, 보상, 성공/실패 등 결정적 상태가 임의 변경되지 않습니다.
- [x] AI 요청에 필요한 최소 문맥만 전달합니다.
- [x] AI 응답 파싱 실패와 provider 오류가 게임 상태를 오염시키지 않습니다.
- [x] 기존 저장 데이터 또는 GameState 호환성 영향을 확인했습니다.

이번 변경은 provider 요청 문맥이나 canonical commit 경계를 변경하지 않습니다. 기존 `GameLog` Skill Check nullable audit과 snapshot을 읽기 전용 projection으로 사용하며 migration은 추가하지 않습니다.

## 보안·비용

- [x] API Key, 토큰, 비밀번호가 코드·로그·URL·클라이언트 응답에 노출되지 않습니다.
- [x] 외부 AI/Image 호출 횟수와 실패 시 동작을 검토했습니다.
- [x] 사용자 입력 길이와 외부 API 비용 증가 가능성을 검토했습니다.
- [x] CORS 또는 공개 endpoint 변경이 있다면 의도된 변경입니다.

새 provider 호출은 없고 기존 공개 game API 응답에 서버 소유 projection만 추가합니다. CORS/endpoint 자체 변경은 없습니다.

## API·DB·운영 영향

- [x] API 계약 변경 시 Frontend 호출부와 문서를 함께 갱신했습니다.
- [x] DB schema 변경 시 migration 전략을 포함했습니다.
- [x] 환경변수는 이름과 용도만 문서화했고 실제 Secret은 포함하지 않았습니다.
- [ ] 배포 후 확인할 smoke test가 있습니다.

DB schema 변경은 없어 migration이 필요하지 않습니다. 배포 후 수동 UI smoke는 아직 수행하지 않았습니다.

## 화면 / 응답 예시

응답에 다음 projection이 추가됩니다.

```json
{
  "characterStats": [
    { "key": "WILL", "score": 10, "modifier": 0 }
  ],
  "latestSkillCheck": {
    "statType": "WILL",
    "rawRoll": 10,
    "statModifier": 0,
    "situationalModifier": 0,
    "dc": 10,
    "total": 10,
    "outcome": "SUCCESS",
    "rulesetVersion": 1
  }
}
```

화면은 story 아래, 선택지 위의 읽기 흐름 안에서 능력치와 최근 판정을 표시하며 fixed/overlay UI를 사용하지 않습니다.