### PR TITLE
fix(ai): Gemini structured output 검증과 bounded recovery 적용

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,9 @@ snapshot JSON은 schema/ruleset version을 가지며 legacy production snapshot�
 - provider story는 canonical state를 직접 변경하지 않고 기존 StoryMemory transcript만 완성합니다.
 - `game_log`는 progress turn의 `canonical_result_id` / `generated_story_id`와 선택적 Skill Check audit 필드를 기록합니다. legacy/opening 행은 Skill Check 필드가 모두 비어 있을 수 있습니다.
 - provider failure 시 canonical turn은 진행하지 않으며 같은 idempotent 요청은 reservation에 저장된 Skill Check 판정과 동일 canonical result link를 재사용합니다.
+- Gemini `generateContent`는 JSON response schema를 사용하고 adapter가 필수 필드, 길이, choice 수/ID를 다시 검증합니다. 구조 오류는 최대 3 provider attempt의 bounded recovery를 거치며 raw 응답 전문은 진단 로그에 남기지 않습니다.
 
-Gemini structured output의 provider-specific schema validation과 bounded repair/retry 강화는 #35의 별도 범위입니다. Story Memory projection/token budget 전면 개선은 #46 범위입니다.
+Story Memory projection/token budget 전면 개선은 #46 범위입니다.
 
 ### 신뢰 가능한 턴 파이프라인
 
@@ -130,6 +131,7 @@ M2의 턴 무결성·복구 구현 범위와 완료 조건은 main에 반영되�
 - `(session_id, expected_turn)` reservation lease로 유효 lease 동안 중복 provider 진입을 억제합니다.
 - Skill Check가 필요한 typed action은 provider 호출 전에 현재 reservation owner가 판정을 한 번 저장합니다.
 - provider attempt는 reservation 획득 횟수와 분리된 `provider_attempt_count`로 관리하며 turn당 최대 3회로 제한합니다.
+- Gemini response repair의 각 progress provider retry도 같은 reservation owner와 attempt 상한을 다시 검증합니다.
 - validation, rate limit, budget guard 같은 pre-provider 실패는 provider attempt를 소비하지 않습니다.
 - stale lease owner는 takeover 이후 canonical commit을 수행할 수 없습니다.
 - `GameLog`는 append-only committed-turn ledger이고 `GameStateSnapshot`은 최신 상태 복구용 materialized snapshot입니다.
@@ -329,6 +331,6 @@ GitHub Actions CI도 backend unit test → PostgreSQL integration test → backe
 
 진행 중.
 
-현재 #33 `AvailableAction` / `PlayerAction`, #34 `ActionResolver` / `GameResult`, #36 확정 결과 기반 `NarrativeContext`, #7 typed `CharacterStats` / pure Skill Check 규칙에 더해 #37 Skill Check turn 통합·감사 저장과 #38 능력치·Skill Check 결과 frontend projection이 반영됩니다.
+현재 #33 `AvailableAction` / `PlayerAction`, #34 `ActionResolver` / `GameResult`, #36 확정 결과 기반 `NarrativeContext`, #7 typed `CharacterStats` / pure Skill Check 규칙에 더해 #37 Skill Check turn 통합·감사 저장과 #38 능력치·Skill Check 결과 frontend projection, #35 Gemini structured output 검증과 bounded recovery가 반영됩니다.
 
-Gemini structured output 검증과 bounded recovery는 #35의 별도 P1 작업입니다. 아직 구현되지 않은 전투·인벤토리·퀘스트·NPC 관계 기능은 현재 기능처럼 문서에 표시하지 않습니다.
+아직 구현되지 않은 전투·인벤토리·퀘스트·NPC 관계 기능은 현재 기능처럼 문서에 표시하지 않습니다.

--- a/docs/architecture/narrative-context.md
+++ b/docs/architecture/narrative-context.md
@@ -46,7 +46,20 @@ provider는 다음을 할 수 없다.
 - state changes에 없는 HP, 능력치, 아이템, 레벨, 위치, 생사 변경 확정
 - state projection/canonical facts 변경
 
-현재 adapter의 provider-specific structured output 강화와 bounded repair/retry는 #35 범위로 남긴다.
+## Gemini structured output 경계
+
+#35 이후 Gemini `generateContent` 요청은 JSON MIME과 response schema를 함께 사용하고, provider 응답은 adapter 내부에서 다시 검증한다.
+
+- 필수 `title`, `story_text`, `choices`가 누락되거나 잘못된 타입이면 기본값으로 보정하지 않는다.
+- choice는 1~8개, 양의 정수 ID, unique ID, non-blank text와 저장 한계에 맞는 길이를 검증한다.
+- story/title/visual field의 길이와 제어 문자를 검증한다.
+- optional `visual_assets`가 없으면 canonical 사실을 추측하지 않고 빈 visual projection으로 취급한다.
+- malformed JSON, missing field, duplicate ID 같은 복구 가능한 구조 오류는 raw 응답 대신 bounded reason code로 분류한다.
+- transport/provider HTTP 오류와 같은 hard failure는 response repair 대상으로 바꾸지 않는다.
+- 로그에는 raw provider 응답 전문을 남기지 않고 `context`와 bounded reason code만 남긴다.
+- Gemini API key는 query string이 아니라 `x-goog-api-key` header로 전달한다.
+
+JSON parsing, Gemini response wrapper, response schema 같은 provider-specific 처리는 `provider/gemini` adapter 경계에 남기고 application/domain은 `NarrativeTurn`과 일반적인 recoverable/hard failure 의미만 다룬다.
 
 ## GameLog narrative linkage
 
@@ -65,7 +78,12 @@ legacy/opening row는 두 값이 모두 `NULL`일 수 있다. DB CHECK constrain
 
 provider 호출 전에 `TurnResolution`과 canonical next state는 이미 결정되어 있지만 DB에는 아직 commit하지 않는다.
 
-- provider 실패: mutation을 failed 처리하고 reservation lease를 만료시키며 GameLog/GameState turn은 진행하지 않는다.
+- Gemini 구조 오류 recovery는 최대 3 provider attempt로 제한한다. 첫 실패 뒤 50ms, 두 번째 실패 뒤 150ms의 bounded backoff를 사용한다.
+- recovery prompt에는 실패한 raw 응답을 다시 주입하지 않고 bounded reason code와 동일 요청/확정 결과를 사용한다.
+- progress의 첫 provider attempt와 각 recovery attempt는 현재 reservation owner에 대해 `provider_attempt_count`를 다시 검증·증가시킨다. stale owner 또는 attempt 상한에 도달한 요청은 다음 provider 호출 전에 중단된다.
+- telemetry는 하나의 logical narrative operation에 실제 retry count와 attempt count를 기록해 비용 ledger가 내부 recovery 횟수를 반영하도록 한다.
+- provider/transport hard failure는 추가 response repair 없이 실패 처리한다.
+- provider 실패 또는 recovery 소진: mutation을 failed 처리하고 reservation lease를 만료시키며 GameLog/GameState turn은 진행하지 않는다.
 - 같은 idempotent 요청 재시도: unchanged canonical previous state와 같은 action으로 pure resolution을 다시 계산하고 동일 `canonicalResultId`를 재사용한다.
 - provider 성공 후 commit 실패/stale owner: stale owner는 canonical commit할 수 없다. 이후 재시도에서 provider가 다시 호출될 수 있다는 bounded at-least-once 정책은 유지한다.
 - 완료된 mutation retry: 기존 committed turn을 replay하고 provider를 재호출하지 않는다.

--- a/src/main/java/com/uctale/uctale/application/cost/ProviderCallTelemetry.java
+++ b/src/main/java/com/uctale/uctale/application/cost/ProviderCallTelemetry.java
@@ -79,6 +79,27 @@ public class ProviderCallTelemetry {
 
     public <T> T observe(
             String provider,
+            String operation,
+            CostRequestContext context,
+            Runnable beforeInvocation,
+            Supplier<T> invocation,
+            ToIntFunction<T> successRetryCount,
+            ToIntFunction<RuntimeException> failureRetryCount
+    ) {
+        return observe(
+                provider,
+                defaultModel(provider),
+                operation,
+                context,
+                beforeInvocation,
+                invocation,
+                successRetryCount,
+                failureRetryCount
+        );
+    }
+
+    public <T> T observe(
+            String provider,
             String model,
             String operation,
             CostRequestContext context,

--- a/src/main/java/com/uctale/uctale/application/narrative/InvalidNarrativeResponseException.java
+++ b/src/main/java/com/uctale/uctale/application/narrative/InvalidNarrativeResponseException.java
@@ -4,4 +4,8 @@ public class InvalidNarrativeResponseException extends RuntimeException {
     public InvalidNarrativeResponseException(String message) {
         super(message);
     }
+
+    public InvalidNarrativeResponseException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/src/main/java/com/uctale/uctale/application/narrative/NarrativeGenerator.java
+++ b/src/main/java/com/uctale/uctale/application/narrative/NarrativeGenerator.java
@@ -5,4 +5,12 @@ public interface NarrativeGenerator {
     NarrativeTurn createOpening(String worldSetting, String characterSetting);
 
     NarrativeTurn createNextTurn(NarrativeContext context);
+
+    default NarrativeTurn repairOpening(String worldSetting, String characterSetting, String reasonCode) {
+        return createOpening(worldSetting, characterSetting);
+    }
+
+    default NarrativeTurn repairNextTurn(NarrativeContext context, String reasonCode) {
+        return createNextTurn(context);
+    }
 }

--- a/src/main/java/com/uctale/uctale/application/narrative/NarrativeRecoveryExecutor.java
+++ b/src/main/java/com/uctale/uctale/application/narrative/NarrativeRecoveryExecutor.java
@@ -1,0 +1,96 @@
+package com.uctale.uctale.application.narrative;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public final class NarrativeRecoveryExecutor {
+
+    private static final int DEFAULT_MAX_ATTEMPTS = 3;
+    private static final long[] DEFAULT_BACKOFF_MILLIS = {50L, 150L};
+
+    private final int maxAttempts;
+    private final Sleeper sleeper;
+
+    public NarrativeRecoveryExecutor(int maxAttempts, Sleeper sleeper) {
+        if (maxAttempts < 1) {
+            throw new IllegalArgumentException("Narrative provider attempt 상한은 1 이상이어야 합니다.");
+        }
+        this.maxAttempts = maxAttempts;
+        this.sleeper = sleeper == null ? ignored -> {} : sleeper;
+    }
+
+    public static NarrativeRecoveryExecutor production() {
+        return new NarrativeRecoveryExecutor(DEFAULT_MAX_ATTEMPTS, millis -> {
+            try {
+                Thread.sleep(millis);
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Narrative recovery backoff가 중단되었습니다.", exception);
+            }
+        });
+    }
+
+    public Result execute(
+            Supplier<NarrativeTurn> initialAttempt,
+            Function<String, NarrativeTurn> repairAttempt,
+            Runnable beforeRetryProviderAttempt
+    ) {
+        if (initialAttempt == null || repairAttempt == null || beforeRetryProviderAttempt == null) {
+            throw new IllegalArgumentException("Narrative recovery callback은 필수입니다.");
+        }
+
+        String previousReason = null;
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            if (attempt > 1) {
+                try {
+                    beforeRetryProviderAttempt.run();
+                } catch (RuntimeException exception) {
+                    throw new NarrativeRecoveryInterruptedException(Math.max(0, attempt - 2), exception);
+                }
+            }
+
+            try {
+                NarrativeTurn turn = attempt == 1
+                        ? initialAttempt.get()
+                        : repairAttempt.apply(previousReason);
+                return new Result(turn, attempt - 1);
+            } catch (RecoverableNarrativeResponseException exception) {
+                previousReason = exception.reasonCode();
+                if (attempt == maxAttempts) {
+                    throw new NarrativeRecoveryExhaustedException(attempt - 1, previousReason, exception);
+                }
+                sleeper.sleep(backoffMillis(attempt - 1));
+            } catch (RuntimeException exception) {
+                if (attempt == 1) {
+                    throw exception;
+                }
+                throw new NarrativeRecoveryInterruptedException(attempt - 1, exception);
+            }
+        }
+        throw new IllegalStateException("도달할 수 없는 Narrative recovery 상태입니다.");
+    }
+
+    private long backoffMillis(int retryIndex) {
+        if (retryIndex <= 0) {
+            return 0L;
+        }
+        int index = Math.min(retryIndex - 1, DEFAULT_BACKOFF_MILLIS.length - 1);
+        return DEFAULT_BACKOFF_MILLIS[index];
+    }
+
+    @FunctionalInterface
+    public interface Sleeper {
+        void sleep(long millis);
+    }
+
+    public record Result(NarrativeTurn turn, int retryCount) {
+        public Result {
+            if (turn == null) {
+                throw new IllegalArgumentException("Narrative turn은 필수입니다.");
+            }
+            if (retryCount < 0) {
+                throw new IllegalArgumentException("retryCount는 0 이상이어야 합니다.");
+            }
+        }
+    }
+}

--- a/src/main/java/com/uctale/uctale/application/narrative/NarrativeRecoveryExecutor.java
+++ b/src/main/java/com/uctale/uctale/application/narrative/NarrativeRecoveryExecutor.java
@@ -59,7 +59,7 @@ public final class NarrativeRecoveryExecutor {
                 if (attempt == maxAttempts) {
                     throw new NarrativeRecoveryExhaustedException(attempt - 1, previousReason, exception);
                 }
-                sleeper.sleep(backoffMillis(attempt - 1));
+                sleeper.sleep(backoffMillis(attempt));
             } catch (RuntimeException exception) {
                 if (attempt == 1) {
                     throw exception;
@@ -71,10 +71,7 @@ public final class NarrativeRecoveryExecutor {
     }
 
     private long backoffMillis(int retryIndex) {
-        if (retryIndex <= 0) {
-            return 0L;
-        }
-        int index = Math.min(retryIndex - 1, DEFAULT_BACKOFF_MILLIS.length - 1);
+        int index = Math.min(Math.max(retryIndex, 1) - 1, DEFAULT_BACKOFF_MILLIS.length - 1);
         return DEFAULT_BACKOFF_MILLIS[index];
     }
 

--- a/src/main/java/com/uctale/uctale/application/narrative/NarrativeRecoveryExhaustedException.java
+++ b/src/main/java/com/uctale/uctale/application/narrative/NarrativeRecoveryExhaustedException.java
@@ -1,0 +1,24 @@
+package com.uctale.uctale.application.narrative;
+
+public class NarrativeRecoveryExhaustedException extends InvalidNarrativeResponseException {
+
+    private final int retryCount;
+    private final String reasonCode;
+
+    public NarrativeRecoveryExhaustedException(int retryCount, String reasonCode, Throwable cause) {
+        super("Narrative provider 응답 복구 한도를 초과했습니다.", cause);
+        if (retryCount < 0) {
+            throw new IllegalArgumentException("retryCount는 0 이상이어야 합니다.");
+        }
+        this.retryCount = retryCount;
+        this.reasonCode = reasonCode == null || reasonCode.isBlank() ? "UNKNOWN" : reasonCode;
+    }
+
+    public int retryCount() {
+        return retryCount;
+    }
+
+    public String reasonCode() {
+        return reasonCode;
+    }
+}

--- a/src/main/java/com/uctale/uctale/application/narrative/NarrativeRecoveryInterruptedException.java
+++ b/src/main/java/com/uctale/uctale/application/narrative/NarrativeRecoveryInterruptedException.java
@@ -1,0 +1,27 @@
+package com.uctale.uctale.application.narrative;
+
+public class NarrativeRecoveryInterruptedException extends RuntimeException {
+
+    private final int retryCount;
+    private final RuntimeException originalCause;
+
+    public NarrativeRecoveryInterruptedException(int retryCount, RuntimeException originalCause) {
+        super("Narrative recovery가 완료되기 전에 중단되었습니다.", originalCause);
+        if (retryCount < 0) {
+            throw new IllegalArgumentException("retryCount는 0 이상이어야 합니다.");
+        }
+        if (originalCause == null) {
+            throw new IllegalArgumentException("원래 예외는 필수입니다.");
+        }
+        this.retryCount = retryCount;
+        this.originalCause = originalCause;
+    }
+
+    public int retryCount() {
+        return retryCount;
+    }
+
+    public RuntimeException originalCause() {
+        return originalCause;
+    }
+}

--- a/src/main/java/com/uctale/uctale/application/narrative/RecoverableNarrativeResponseException.java
+++ b/src/main/java/com/uctale/uctale/application/narrative/RecoverableNarrativeResponseException.java
@@ -1,0 +1,26 @@
+package com.uctale.uctale.application.narrative;
+
+public class RecoverableNarrativeResponseException extends InvalidNarrativeResponseException {
+
+    private final String reasonCode;
+
+    public RecoverableNarrativeResponseException(String reasonCode, String message) {
+        super(message);
+        if (reasonCode == null || reasonCode.isBlank()) {
+            throw new IllegalArgumentException("Narrative recovery reason code는 필수입니다.");
+        }
+        this.reasonCode = reasonCode;
+    }
+
+    public RecoverableNarrativeResponseException(String reasonCode, String message, Throwable cause) {
+        super(message, cause);
+        if (reasonCode == null || reasonCode.isBlank()) {
+            throw new IllegalArgumentException("Narrative recovery reason code는 필수입니다.");
+        }
+        this.reasonCode = reasonCode;
+    }
+
+    public String reasonCode() {
+        return reasonCode;
+    }
+}

--- a/src/main/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapter.java
+++ b/src/main/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapter.java
@@ -212,7 +212,8 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
         try {
             String requestBody = createRequestBody(prompt);
             String response = restClient.post()
-                    .uri(GEMINI_API_URL + "?key=" + apiKey)
+                    .uri(GEMINI_API_URL)
+                    .header("x-goog-api-key", apiKey)
                     .contentType(MediaType.APPLICATION_JSON)
                     .body(requestBody)
                     .retrieve()
@@ -236,8 +237,8 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
         Map<String, Object> requestMap = Map.of(
                 "contents", List.of(Map.of("parts", List.of(Map.of("text", SYSTEM_INSTRUCTION + "\n\n" + userPrompt)))),
                 "generationConfig", Map.of(
-                        "response_mime_type", "application/json",
-                        "response_schema", RESPONSE_SCHEMA
+                        "responseMimeType", "application/json",
+                        "responseSchema", RESPONSE_SCHEMA
                 )
         );
         return objectMapper.writeValueAsString(requestMap);

--- a/src/main/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapter.java
+++ b/src/main/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapter.java
@@ -6,6 +6,7 @@ import tools.jackson.databind.ObjectMapper;
 import com.uctale.uctale.application.narrative.NarrativeContext;
 import com.uctale.uctale.application.narrative.NarrativeGenerator;
 import com.uctale.uctale.application.narrative.NarrativeTurn;
+import com.uctale.uctale.application.narrative.RecoverableNarrativeResponseException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
@@ -13,14 +14,23 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @Slf4j
 @Component
 public class GeminiNarrativeAdapter implements NarrativeGenerator {
 
     private static final String GEMINI_API_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent";
+    private static final int MAX_TITLE_LENGTH = 200;
+    private static final int MAX_STORY_LENGTH = 50_000;
+    private static final int MAX_CHOICE_TEXT_LENGTH = 255;
+    private static final int MAX_CHOICES = 8;
+    private static final int MAX_VISUAL_ITEMS = 8;
+    private static final int MAX_VISUAL_TEXT_LENGTH = 1_000;
+
     private static final String SYSTEM_INSTRUCTION = """
             당신은 UCTale의 Narrative Engine입니다.
             게임의 결정적 상태와 사실은 서버가 소유하며, 당신은 전달받은 확정 결과를 서사로 표현합니다.
@@ -43,21 +53,46 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
                - `assets`: 현재 상호작용 중인 핵심 사물
                - 모든 묘사는 **영어(English)**로 작성해야 합니다.
 
-            [JSON 응답 형식]
-            {
-              "title": "string (한국어)",
-              "story_text": "string (한국어, 3~5문장)",
-              "choices": [
-                { "id": 1, "text": "행동 1" },
-                { "id": 2, "text": "행동 2" }
-              ],
-              "visual_assets": {
-                "background": "string (English or empty)",
-                "characters": ["string (English or empty)"],
-                "assets": ["string (English or empty)"]
-              }
-            }
+            JSON 구조는 API의 response schema를 반드시 따르세요.
             """;
+
+    private static final Map<String, Object> RESPONSE_SCHEMA = Map.of(
+            "type", "OBJECT",
+            "required", List.of("title", "story_text", "choices"),
+            "properties", Map.of(
+                    "title", Map.of("type", "STRING"),
+                    "story_text", Map.of("type", "STRING"),
+                    "choices", Map.of(
+                            "type", "ARRAY",
+                            "minItems", 1,
+                            "maxItems", MAX_CHOICES,
+                            "items", Map.of(
+                                    "type", "OBJECT",
+                                    "required", List.of("id", "text"),
+                                    "properties", Map.of(
+                                            "id", Map.of("type", "INTEGER", "minimum", 1),
+                                            "text", Map.of("type", "STRING")
+                                    )
+                            )
+                    ),
+                    "visual_assets", Map.of(
+                            "type", "OBJECT",
+                            "properties", Map.of(
+                                    "background", Map.of("type", "STRING"),
+                                    "characters", Map.of(
+                                            "type", "ARRAY",
+                                            "maxItems", MAX_VISUAL_ITEMS,
+                                            "items", Map.of("type", "STRING")
+                                    ),
+                                    "assets", Map.of(
+                                            "type", "ARRAY",
+                                            "maxItems", MAX_VISUAL_ITEMS,
+                                            "items", Map.of("type", "STRING")
+                                    )
+                            )
+                    )
+            )
+    );
 
     @Value("${google.ai.api-key}")
     private String apiKey;
@@ -72,29 +107,50 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
 
     @Override
     public NarrativeTurn createOpening(String worldSetting, String characterSetting) {
-        try {
-            String prompt = String.format("""
-                    [세계관 설정]: %s
-                    [캐릭터 설정]: %s
+        return generate(openingPrompt(worldSetting, characterSetting), "opening");
+    }
 
-                    위 설정을 바탕으로 게임의 오프닝을 생성하세요.
-                    첫 장면이므로 visual_assets(배경, 분위기 등)를 반드시 상세하게 채워주세요.
-                    """, worldSetting, characterSetting);
-            return generate(prompt, "Gemini API Error");
-        } catch (Exception e) {
-            log.error("Gemini 오프닝 생성 실패: {}", e.getClass().getSimpleName());
-            throw new RuntimeException("AI 서버 연결 실패: 잠시 후 다시 시도해주세요.", e);
-        }
+    @Override
+    public NarrativeTurn repairOpening(String worldSetting, String characterSetting, String reasonCode) {
+        return generate(openingPrompt(worldSetting, characterSetting) + recoveryInstruction(reasonCode), "opening_repair");
     }
 
     @Override
     public NarrativeTurn createNextTurn(NarrativeContext context) {
         try {
-            return generate(buildProgressPrompt(context), "Gemini API Progress Error");
-        } catch (Exception e) {
-            log.error("Gemini 다음 턴 생성 실패: {}", e.getClass().getSimpleName());
-            throw new RuntimeException("AI 서버 연결 실패 (진행 중): 잠시 후 다시 시도해주세요.", e);
+            return generate(buildProgressPrompt(context), "progress");
+        } catch (JacksonException exception) {
+            throw new IllegalStateException("Narrative progress prompt 직렬화에 실패했습니다.", exception);
         }
+    }
+
+    @Override
+    public NarrativeTurn repairNextTurn(NarrativeContext context, String reasonCode) {
+        try {
+            return generate(buildProgressPrompt(context) + recoveryInstruction(reasonCode), "progress_repair");
+        } catch (JacksonException exception) {
+            throw new IllegalStateException("Narrative recovery prompt 직렬화에 실패했습니다.", exception);
+        }
+    }
+
+    private String openingPrompt(String worldSetting, String characterSetting) {
+        return String.format("""
+                [세계관 설정]: %s
+                [캐릭터 설정]: %s
+
+                위 설정을 바탕으로 게임의 오프닝을 생성하세요.
+                첫 장면이므로 visual_assets(배경, 분위기 등)를 반드시 상세하게 채워주세요.
+                """, worldSetting, characterSetting);
+    }
+
+    private String recoveryInstruction(String reasonCode) {
+        return """
+
+                [응답 수정 요청]
+                직전 provider 응답이 구조 계약을 만족하지 않았습니다.
+                실패 분류: %s
+                원래 게임 결과나 사실을 바꾸지 말고, 동일 요청을 response schema에 맞는 JSON으로 다시 작성하세요.
+                """.formatted(safeReasonCode(reasonCode));
     }
 
     String buildProgressPrompt(NarrativeContext context) throws JacksonException {
@@ -152,74 +208,182 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
         );
     }
 
-    private NarrativeTurn generate(String prompt, String errorContext) throws JacksonException {
-        String requestBody = createRequestBody(prompt);
-        String response = restClient.post()
-                .uri(GEMINI_API_URL + "?key=" + apiKey)
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(requestBody)
-                .retrieve()
-                .body(String.class);
-        if (response == null || response.isBlank()) throw new IllegalStateException(errorContext + ": empty response");
-        return parseResponse(response);
+    private NarrativeTurn generate(String prompt, String errorContext) {
+        try {
+            String requestBody = createRequestBody(prompt);
+            String response = restClient.post()
+                    .uri(GEMINI_API_URL + "?key=" + apiKey)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(requestBody)
+                    .retrieve()
+                    .body(String.class);
+            if (response == null || response.isBlank()) {
+                throw recoverable("EMPTY_RESPONSE", "Gemini 응답 body가 비어 있습니다.", null);
+            }
+            return parseResponse(response);
+        } catch (RecoverableNarrativeResponseException exception) {
+            log.warn("gemini_response_invalid context={} reason={}", errorContext, exception.reasonCode());
+            throw exception;
+        } catch (JacksonException exception) {
+            throw new IllegalStateException("Gemini 요청 직렬화에 실패했습니다.", exception);
+        } catch (RuntimeException exception) {
+            log.error("Gemini provider 호출 실패 context={} error={}", errorContext, exception.getClass().getSimpleName());
+            throw exception;
+        }
     }
 
-    private String createRequestBody(String userPrompt) throws JacksonException {
+    String createRequestBody(String userPrompt) throws JacksonException {
         Map<String, Object> requestMap = Map.of(
                 "contents", List.of(Map.of("parts", List.of(Map.of("text", SYSTEM_INSTRUCTION + "\n\n" + userPrompt)))),
-                "generationConfig", Map.of("response_mime_type", "application/json")
+                "generationConfig", Map.of(
+                        "response_mime_type", "application/json",
+                        "response_schema", RESPONSE_SCHEMA
+                )
         );
         return objectMapper.writeValueAsString(requestMap);
     }
 
-    private NarrativeTurn parseResponse(String rawResponse) throws JacksonException {
-        GeminiApiResponse apiResponse = objectMapper.readValue(rawResponse, GeminiApiResponse.class);
-        if (apiResponse.candidates() == null || apiResponse.candidates().isEmpty()) throw new IllegalStateException("AI 응답이 비어있습니다.");
-
-        String jsonText = apiResponse.candidates().get(0).content().parts().get(0).text();
-        JsonNode rootNode = objectMapper.readTree(jsonText);
-        List<NarrativeTurn.Choice> choices = new ArrayList<>();
-        JsonNode choicesNode = rootNode.path("choices");
-        if (choicesNode.isArray()) {
-            int index = 1;
-            for (JsonNode node : choicesNode) {
-                if (node.isString()) {
-                    choices.add(new NarrativeTurn.Choice(index++, node.asString()));
-                } else if (node.isObject()) {
-                    int id = node.has("id") ? node.get("id").asInt() : index++;
-                    String text = node.has("text") ? node.get("text").asString() : "내용 없음";
-                    choices.add(new NarrativeTurn.Choice(id, text));
-                }
+    NarrativeTurn parseResponse(String rawResponse) {
+        try {
+            GeminiApiResponse apiResponse = objectMapper.readValue(rawResponse, GeminiApiResponse.class);
+            if (apiResponse.candidates() == null || apiResponse.candidates().isEmpty()) {
+                throw recoverable("MISSING_CANDIDATE", "Gemini candidate가 없습니다.", null);
             }
+            Candidate candidate = apiResponse.candidates().getFirst();
+            if (candidate == null || candidate.content() == null || candidate.content().parts() == null || candidate.content().parts().isEmpty()) {
+                throw recoverable("MISSING_CONTENT", "Gemini content part가 없습니다.", null);
+            }
+            Part part = candidate.content().parts().getFirst();
+            if (part == null || part.text() == null || part.text().isBlank()) {
+                throw recoverable("MISSING_TEXT", "Gemini content text가 없습니다.", null);
+            }
+
+            JsonNode rootNode = objectMapper.readTree(part.text());
+            return mapNarrative(rootNode);
+        } catch (RecoverableNarrativeResponseException exception) {
+            throw exception;
+        } catch (JacksonException exception) {
+            throw recoverable("MALFORMED_JSON", "Gemini JSON을 파싱할 수 없습니다.", exception);
+        }
+    }
+
+    private NarrativeTurn mapNarrative(JsonNode rootNode) {
+        if (rootNode == null || !rootNode.isObject()) {
+            throw recoverable("ROOT_NOT_OBJECT", "Narrative root는 object여야 합니다.", null);
         }
 
-        JsonNode visualNode = rootNode.path("visual_assets");
-        return new NarrativeTurn(
-                rootNode.path("title").asString("제목 없음"),
-                rootNode.path("story_text").asString("스토리가 없습니다."),
-                choices,
-                new NarrativeTurn.VisualAssets(
-                        visualNode.path("background").asString(""),
-                        readNonBlankStrings(visualNode.path("characters")),
-                        readNonBlankStrings(visualNode.path("assets"))
-                )
+        String title = requiredText(rootNode, "title", MAX_TITLE_LENGTH, false, "INVALID_TITLE");
+        String storyText = requiredText(rootNode, "story_text", MAX_STORY_LENGTH, true, "INVALID_STORY");
+
+        JsonNode choicesNode = rootNode.get("choices");
+        if (choicesNode == null || !choicesNode.isArray() || choicesNode.size() == 0 || choicesNode.size() > MAX_CHOICES) {
+            throw recoverable("INVALID_CHOICES", "Narrative choices 배열이 올바르지 않습니다.", null);
+        }
+
+        List<NarrativeTurn.Choice> choices = new ArrayList<>();
+        Set<Integer> ids = new HashSet<>();
+        for (JsonNode choiceNode : choicesNode) {
+            if (choiceNode == null || !choiceNode.isObject()) {
+                throw recoverable("INVALID_CHOICE", "Narrative choice는 object여야 합니다.", null);
+            }
+            JsonNode idNode = choiceNode.get("id");
+            if (idNode == null || !idNode.isIntegralNumber() || !idNode.canConvertToInt()) {
+                throw recoverable("INVALID_CHOICE_ID", "Narrative choice id가 정수가 아닙니다.", null);
+            }
+            int id = idNode.intValue();
+            if (id <= 0 || !ids.add(id)) {
+                throw recoverable("INVALID_CHOICE_ID", "Narrative choice id가 중복되었거나 범위를 벗어났습니다.", null);
+            }
+            String text = requiredText(choiceNode, "text", MAX_CHOICE_TEXT_LENGTH, false, "INVALID_CHOICE_TEXT");
+            choices.add(new NarrativeTurn.Choice(id, text));
+        }
+
+        JsonNode visualNode = rootNode.get("visual_assets");
+        NarrativeTurn.VisualAssets visualAssets = visualNode == null || visualNode.isNull()
+                ? new NarrativeTurn.VisualAssets("", List.of(), List.of())
+                : parseVisualAssets(visualNode);
+
+        return new NarrativeTurn(title, storyText, List.copyOf(choices), visualAssets);
+    }
+
+    private NarrativeTurn.VisualAssets parseVisualAssets(JsonNode visualNode) {
+        if (!visualNode.isObject()) {
+            throw recoverable("INVALID_VISUAL_ASSETS", "visual_assets는 object여야 합니다.", null);
+        }
+        String background = optionalText(visualNode.get("background"), MAX_VISUAL_TEXT_LENGTH, "INVALID_VISUAL_ASSETS");
+        return new NarrativeTurn.VisualAssets(
+                background,
+                readStringArray(visualNode.get("characters"), "INVALID_VISUAL_CHARACTERS"),
+                readStringArray(visualNode.get("assets"), "INVALID_VISUAL_ASSETS_LIST")
         );
     }
 
-    private List<String> readNonBlankStrings(JsonNode node) {
-        List<String> values = new ArrayList<>();
-        if (node.isArray()) {
-            for (JsonNode item : node) {
-                String value = item.asString();
-                if (value != null && !value.isBlank()) values.add(value);
-            }
+    private List<String> readStringArray(JsonNode node, String reasonCode) {
+        if (node == null || node.isNull()) return List.of();
+        if (!node.isArray() || node.size() > MAX_VISUAL_ITEMS) {
+            throw recoverable(reasonCode, "visual asset 배열이 올바르지 않습니다.", null);
         }
-        return values;
+        List<String> values = new ArrayList<>();
+        for (JsonNode item : node) {
+            if (item == null || !item.isTextual()) {
+                throw recoverable(reasonCode, "visual asset 항목은 문자열이어야 합니다.", null);
+            }
+            String value = item.asString();
+            if (value.length() > MAX_VISUAL_TEXT_LENGTH || containsDisallowedControl(value, true)) {
+                throw recoverable(reasonCode, "visual asset 문자열이 허용 범위를 벗어났습니다.", null);
+            }
+            if (!value.isBlank()) values.add(value);
+        }
+        return List.copyOf(values);
     }
 
-    private record GeminiApiResponse(List<Candidate> candidates) {
-        record Candidate(Content content) {}
-        record Content(List<Part> parts) {}
-        record Part(String text) {}
+    private String requiredText(JsonNode parent, String field, int maxLength, boolean allowFormattingControls, String reasonCode) {
+        JsonNode node = parent.get(field);
+        if (node == null || !node.isTextual()) {
+            throw recoverable(reasonCode, "필수 문자열 필드가 누락되었습니다: " + field, null);
+        }
+        String value = node.asString();
+        if (value.isBlank() || value.length() > maxLength || containsDisallowedControl(value, allowFormattingControls)) {
+            throw recoverable(reasonCode, "문자열 필드가 허용 범위를 벗어났습니다: " + field, null);
+        }
+        return value;
     }
+
+    private String optionalText(JsonNode node, int maxLength, String reasonCode) {
+        if (node == null || node.isNull()) return "";
+        if (!node.isTextual()) {
+            throw recoverable(reasonCode, "선택 문자열 필드의 타입이 올바르지 않습니다.", null);
+        }
+        String value = node.asString();
+        if (value.length() > maxLength || containsDisallowedControl(value, true)) {
+            throw recoverable(reasonCode, "선택 문자열 필드가 허용 범위를 벗어났습니다.", null);
+        }
+        return value;
+    }
+
+    private boolean containsDisallowedControl(String value, boolean allowFormattingControls) {
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            if (!Character.isISOControl(ch)) continue;
+            if (allowFormattingControls && (ch == '\n' || ch == '\r' || ch == '\t')) continue;
+            return true;
+        }
+        return false;
+    }
+
+    private RecoverableNarrativeResponseException recoverable(String reasonCode, String message, Throwable cause) {
+        return cause == null
+                ? new RecoverableNarrativeResponseException(reasonCode, message)
+                : new RecoverableNarrativeResponseException(reasonCode, message, cause);
+    }
+
+    private String safeReasonCode(String reasonCode) {
+        if (reasonCode == null || reasonCode.isBlank()) return "UNKNOWN";
+        return reasonCode.replaceAll("[^A-Z0-9_]", "_");
+    }
+
+    private record GeminiApiResponse(List<Candidate> candidates) {}
+    private record Candidate(Content content) {}
+    private record Content(List<Part> parts) {}
+    private record Part(String text) {}
 }

--- a/src/main/java/com/uctale/uctale/service/GameService.java
+++ b/src/main/java/com/uctale/uctale/service/GameService.java
@@ -60,7 +60,18 @@ public class GameService {
     private final NarrativeRecoveryExecutor narrativeRecoveryExecutor = NarrativeRecoveryExecutor.production();
 
     @Autowired
-    public GameService(NarrativeGenerator narrativeGenerator, ImageAssetService imageAssetService, GamePersistenceService gamePersistenceService, ChoiceCodec choiceCodec, TurnProcessor turnProcessor, ImagePromptComposer imagePromptComposer, CostRateLimiter costRateLimiter, ProviderCallTelemetry providerCallTelemetry, GameMutationFingerprint mutationFingerprint, GameMutationRequestService mutationRequestService) {
+    public GameService(
+            NarrativeGenerator narrativeGenerator,
+            ImageAssetService imageAssetService,
+            GamePersistenceService gamePersistenceService,
+            ChoiceCodec choiceCodec,
+            TurnProcessor turnProcessor,
+            ImagePromptComposer imagePromptComposer,
+            CostRateLimiter costRateLimiter,
+            ProviderCallTelemetry providerCallTelemetry,
+            GameMutationFingerprint mutationFingerprint,
+            GameMutationRequestService mutationRequestService
+    ) {
         this.narrativeGenerator = narrativeGenerator;
         this.imageAssetService = imageAssetService;
         this.gamePersistenceService = gamePersistenceService;
@@ -73,45 +84,101 @@ public class GameService {
         this.mutationRequestService = mutationRequestService;
     }
 
-    public GameService(NarrativeGenerator narrativeGenerator, ImageAssetService imageAssetService, GamePersistenceService gamePersistenceService, ChoiceCodec choiceCodec, ImagePromptComposer imagePromptComposer, CostRateLimiter costRateLimiter, ProviderCallTelemetry providerCallTelemetry, GameMutationFingerprint mutationFingerprint, GameMutationRequestService mutationRequestService) {
-        this(narrativeGenerator, imageAssetService, gamePersistenceService, choiceCodec, new TurnProcessor(), imagePromptComposer, costRateLimiter, providerCallTelemetry, mutationFingerprint, mutationRequestService);
+    public GameService(
+            NarrativeGenerator narrativeGenerator,
+            ImageAssetService imageAssetService,
+            GamePersistenceService gamePersistenceService,
+            ChoiceCodec choiceCodec,
+            ImagePromptComposer imagePromptComposer,
+            CostRateLimiter costRateLimiter,
+            ProviderCallTelemetry providerCallTelemetry,
+            GameMutationFingerprint mutationFingerprint,
+            GameMutationRequestService mutationRequestService
+    ) {
+        this(
+                narrativeGenerator,
+                imageAssetService,
+                gamePersistenceService,
+                choiceCodec,
+                new TurnProcessor(),
+                imagePromptComposer,
+                costRateLimiter,
+                providerCallTelemetry,
+                mutationFingerprint,
+                mutationRequestService
+        );
     }
 
-    public GameResponse initGame(String ownerKey, GameInitRequest request) { return initGame(CostRequestContext.internal(ownerKey, null, 1), request); }
+    public GameResponse initGame(String ownerKey, GameInitRequest request) {
+        return initGame(CostRequestContext.internal(ownerKey, null, 1), request);
+    }
 
     public GameResponse initGame(CostRequestContext costContext, GameInitRequest request) {
-        GameMutationRequestService.BeginResult mutation = mutationRequestService.begin(costContext.ownerKey(), GameMutationRequestService.INIT, costContext.idempotencyKey(), null, null, mutationFingerprint.init(request));
-        if (mutation.replay()) return replay(costContext.ownerKey(), mutation);
+        GameMutationRequestService.BeginResult mutation = mutationRequestService.begin(
+                costContext.ownerKey(), GameMutationRequestService.INIT, costContext.idempotencyKey(), null, null,
+                mutationFingerprint.init(request)
+        );
+        if (mutation.replay()) {
+            return replay(costContext.ownerKey(), mutation);
+        }
+
         try {
             costRateLimiter.check(CostOperation.NARRATIVE, costContext);
             NarrativeTurn opening = observeOpening(costContext, request).turn();
             validateNarrativeTurn(opening);
             List<GameChoice> choices = choiceCodec.issue(opening.choices(), 1);
+
             String imagePrompt = imagePromptComposer.compose(opening.visualAssets());
-            if (imagePrompt == null || imagePrompt.isBlank()) imagePrompt = imagePromptComposer.composeFallback(request.worldSetting());
+            if (imagePrompt == null || imagePrompt.isBlank()) {
+                imagePrompt = imagePromptComposer.composeFallback(request.worldSetting());
+            }
             validateImagePrompt(imagePrompt);
             ImageAssetService.AssetReference imageAsset = imageAssetService.issue(imagePrompt, "16:9");
-            var session = gamePersistenceService.saveOpening(costContext.ownerKey(), request.worldSetting(), request.characterSetting(), opening.storyText(), choiceCodec.serialize(choices), imageAsset, mutation.requestId(), opening.title());
+
+            var session = gamePersistenceService.saveOpening(
+                    costContext.ownerKey(), request.worldSetting(), request.characterSetting(), opening.storyText(),
+                    choiceCodec.serialize(choices), imageAsset, mutation.requestId(), opening.title()
+            );
             GameState initialState = GameState.initial(request.worldSetting(), request.characterSetting(), opening.storyText());
-            return GameResponseProjector.project(session.getId(), session.getCurrentTurn(), opening.title(), opening.storyText(), choices, imageAsset.publicUrl(), initialState, null);
+            return GameResponseProjector.project(
+                    session.getId(), session.getCurrentTurn(), opening.title(), opening.storyText(), choices,
+                    imageAsset.publicUrl(), initialState, null
+            );
         } catch (RuntimeException exception) {
             mutationRequestService.markFailed(mutation.requestId());
             throw exception;
         }
     }
 
-    public GameResponse progressGame(String ownerKey, GameProgressRequest request) { return progressGame(CostRequestContext.internal(ownerKey, request.sessionId(), request.expectedTurn() + 1), request); }
+    public GameResponse progressGame(String ownerKey, GameProgressRequest request) {
+        return progressGame(CostRequestContext.internal(ownerKey, request.sessionId(), request.expectedTurn() + 1), request);
+    }
 
     public GameResponse progressGame(CostRequestContext costContext, GameProgressRequest request) {
-        GameMutationRequestService.BeginResult mutation = mutationRequestService.begin(costContext.ownerKey(), GameMutationRequestService.PROGRESS, costContext.idempotencyKey(), request.sessionId(), request.expectedTurn(), mutationFingerprint.progress(request));
-        if (mutation.replay()) return replay(costContext.ownerKey(), mutation);
+        GameMutationRequestService.BeginResult mutation = mutationRequestService.begin(
+                costContext.ownerKey(), GameMutationRequestService.PROGRESS, costContext.idempotencyKey(),
+                request.sessionId(), request.expectedTurn(), mutationFingerprint.progress(request)
+        );
+        if (mutation.replay()) {
+            return replay(costContext.ownerKey(), mutation);
+        }
+
         try {
-            GamePersistenceService.LoadedTurn loadedTurn = gamePersistenceService.loadLatestTurn(costContext.ownerKey(), request.sessionId(), request.expectedTurn());
-            CostRequestContext providerContext = new CostRequestContext(costContext.requestId(), costContext.ownerKey(), costContext.clientIp(), loadedTurn.sessionId(), request.expectedTurn() + 1, costContext.idempotencyKey());
+            GamePersistenceService.LoadedTurn loadedTurn = gamePersistenceService.loadLatestTurn(
+                    costContext.ownerKey(), request.sessionId(), request.expectedTurn()
+            );
+            CostRequestContext providerContext = new CostRequestContext(
+                    costContext.requestId(), costContext.ownerKey(), costContext.clientIp(), loadedTurn.sessionId(),
+                    request.expectedTurn() + 1, costContext.idempotencyKey()
+            );
+
             PlayerAction playerAction = choiceCodec.resolve(loadedTurn.choicesJson(), request);
-            TurnResolution resolution = turnProcessor.resolve(loadedTurn.gameState(), playerAction, mutation.requestId(), mutation.reservationOwner());
+            TurnResolution resolution = turnProcessor.resolve(
+                    loadedTurn.gameState(), playerAction, mutation.requestId(), mutation.reservationOwner()
+            );
             String userChoiceText = resolution.gameResult().resolvedAction().displayText();
-            String canonicalResultId = canonicalResultId(mutation.requestId(), loadedTurn.sessionId(), resolution.stateTransition().nextState().turnNumber());
+            String canonicalResultId = canonicalResultId(mutation.requestId(), loadedTurn.sessionId(),
+                    resolution.stateTransition().nextState().turnNumber());
             NarrativeContext narrativeContext = NarrativeContext.from(canonicalResultId, resolution);
             costRateLimiter.check(CostOperation.NARRATIVE, providerContext);
             NarrativeTurn nextTurn = observeProgress(providerContext, mutation, narrativeContext).turn();
@@ -119,6 +186,7 @@ public class GameService {
             String generatedStoryId = "story:" + UUID.randomUUID();
             StateTransition committedTransition = turnProcessor.attachNarrative(resolution, nextTurn.storyText());
             List<GameChoice> choices = choiceCodec.issue(nextTurn.choices(), request.expectedTurn() + 1);
+
             ImageAssetService.AssetReference imageAsset = null;
             String imageUrl = loadedTurn.imageUrl();
             String imagePrompt = imagePromptComposer.compose(nextTurn.visualAssets());
@@ -127,71 +195,135 @@ public class GameService {
                 log.info("새로운 이미지 asset 발급");
                 imageAsset = imageAssetService.issue(imagePrompt, "16:9");
                 imageUrl = imageAsset.publicUrl();
-            } else log.info("시각적 변화 없음 -> 이전 이미지 asset 재사용");
-            GameTurnCommit commit = new GameTurnCommit(request.expectedTurn(), resolution.gameResult().resolvedAction().legacyChoiceId(), userChoiceText, committedTransition, nextTurn.storyText(), choiceCodec.serialize(choices), canonicalResultId, generatedStoryId, resolution.gameResult().skillCheckResult(), imageAsset);
-            int savedTurn = gamePersistenceService.saveNextTurn(costContext.ownerKey(), loadedTurn.sessionId(), commit, mutation.requestId(), nextTurn.title(), mutation.reservationOwner());
-            return GameResponseProjector.project(loadedTurn.sessionId(), savedTurn, nextTurn.title(), nextTurn.storyText(), choices, imageUrl, committedTransition.nextState(), resolution.gameResult().skillCheckResult());
+            } else {
+                log.info("시각적 변화 없음 -> 이전 이미지 asset 재사용");
+            }
+
+            GameTurnCommit commit = new GameTurnCommit(
+                    request.expectedTurn(), resolution.gameResult().resolvedAction().legacyChoiceId(), userChoiceText,
+                    committedTransition, nextTurn.storyText(), choiceCodec.serialize(choices),
+                    canonicalResultId, generatedStoryId, resolution.gameResult().skillCheckResult(), imageAsset
+            );
+
+            int savedTurn = gamePersistenceService.saveNextTurn(
+                    costContext.ownerKey(), loadedTurn.sessionId(), commit, mutation.requestId(), nextTurn.title(),
+                    mutation.reservationOwner()
+            );
+            return GameResponseProjector.project(
+                    loadedTurn.sessionId(), savedTurn, nextTurn.title(), nextTurn.storyText(), choices, imageUrl,
+                    committedTransition.nextState(), resolution.gameResult().skillCheckResult()
+            );
         } catch (RuntimeException exception) {
             mutationRequestService.markFailed(mutation.requestId(), mutation.reservationOwner());
             throw exception;
         }
     }
 
-    private NarrativeRecoveryExecutor.Result observeOpening(CostRequestContext costContext, GameInitRequest request) {
+    private NarrativeRecoveryExecutor.Result observeOpening(
+            CostRequestContext costContext,
+            GameInitRequest request
+    ) {
         try {
-            return providerCallTelemetry.observe("gemini", "opening", costContext,
+            return providerCallTelemetry.observe(
+                    "gemini", "opening", costContext,
                     () -> narrativeRecoveryExecutor.execute(
-                            () -> narrativeGenerator.createOpening(request.worldSetting(), request.characterSetting()),
-                            reasonCode -> narrativeGenerator.repairOpening(request.worldSetting(), request.characterSetting(), reasonCode),
-                            () -> {}),
+                            () -> narrativeGenerator.createOpening(
+                                    request.worldSetting(), request.characterSetting()
+                            ),
+                            reasonCode -> narrativeGenerator.repairOpening(
+                                    request.worldSetting(), request.characterSetting(), reasonCode
+                            ),
+                            () -> {}
+                    ),
                     NarrativeRecoveryExecutor.Result::retryCount,
-                    this::narrativeRetryCountFromFailure);
-        } catch (NarrativeRecoveryInterruptedException exception) { throw exception.originalCause(); }
+                    this::narrativeRetryCountFromFailure
+            );
+        } catch (NarrativeRecoveryInterruptedException exception) {
+            throw exception.originalCause();
+        }
     }
 
-    private NarrativeRecoveryExecutor.Result observeProgress(CostRequestContext providerContext, GameMutationRequestService.BeginResult mutation, NarrativeContext narrativeContext) {
+    private NarrativeRecoveryExecutor.Result observeProgress(
+            CostRequestContext providerContext,
+            GameMutationRequestService.BeginResult mutation,
+            NarrativeContext narrativeContext
+    ) {
         try {
-            return providerCallTelemetry.observe("gemini", "progress", providerContext,
-                    () -> mutationRequestService.markProviderAttemptStarted(mutation.requestId(), mutation.reservationOwner()),
+            return providerCallTelemetry.observe(
+                    "gemini", "progress", providerContext,
+                    () -> mutationRequestService.markProviderAttemptStarted(
+                            mutation.requestId(), mutation.reservationOwner()
+                    ),
                     () -> narrativeRecoveryExecutor.execute(
                             () -> narrativeGenerator.createNextTurn(narrativeContext),
                             reasonCode -> narrativeGenerator.repairNextTurn(narrativeContext, reasonCode),
-                            () -> mutationRequestService.markProviderAttemptStarted(mutation.requestId(), mutation.reservationOwner())),
+                            () -> mutationRequestService.markProviderAttemptStarted(
+                                    mutation.requestId(), mutation.reservationOwner()
+                            )
+                    ),
                     NarrativeRecoveryExecutor.Result::retryCount,
-                    this::narrativeRetryCountFromFailure);
-        } catch (NarrativeRecoveryInterruptedException exception) { throw exception.originalCause(); }
+                    this::narrativeRetryCountFromFailure
+            );
+        } catch (NarrativeRecoveryInterruptedException exception) {
+            throw exception.originalCause();
+        }
     }
 
     private int narrativeRetryCountFromFailure(RuntimeException exception) {
-        if (exception instanceof NarrativeRecoveryExhaustedException exhausted) return exhausted.retryCount();
-        if (exception instanceof NarrativeRecoveryInterruptedException interrupted) return interrupted.retryCount();
+        if (exception instanceof NarrativeRecoveryExhaustedException exhausted) {
+            return exhausted.retryCount();
+        }
+        if (exception instanceof NarrativeRecoveryInterruptedException interrupted) {
+            return interrupted.retryCount();
+        }
         return 0;
     }
 
     private GameResponse replay(String ownerKey, GameMutationRequestService.BeginResult mutation) {
-        if (mutation.resultSessionId() == null || mutation.resultTurn() == null || mutation.resultTitle() == null) throw new IllegalStateException("완료된 mutation request의 결과 참조가 올바르지 않습니다.");
-        GamePersistenceService.CommittedTurn turn = gamePersistenceService.loadCommittedTurn(ownerKey, mutation.resultSessionId(), mutation.resultTurn());
-        return GameResponseProjector.projectReplay(mutation.resultSessionId(), mutation.resultTurn(), mutation.resultTitle(), turn.storyText(), choiceCodec.deserialize(turn.choicesJson()), turn.imageUrl(), turn.gameState(), turn.skillCheckAudit());
+        if (mutation.resultSessionId() == null || mutation.resultTurn() == null || mutation.resultTitle() == null) {
+            throw new IllegalStateException("완료된 mutation request의 결과 참조가 올바르지 않습니다.");
+        }
+        GamePersistenceService.CommittedTurn turn = gamePersistenceService.loadCommittedTurn(
+                ownerKey, mutation.resultSessionId(), mutation.resultTurn()
+        );
+        return GameResponseProjector.projectReplay(
+                mutation.resultSessionId(), mutation.resultTurn(), mutation.resultTitle(), turn.storyText(),
+                choiceCodec.deserialize(turn.choicesJson()), turn.imageUrl(), turn.gameState(), turn.skillCheckAudit()
+        );
     }
 
     private String canonicalResultId(Long mutationRequestId, Long sessionId, int nextTurn) {
-        if (mutationRequestId == null || sessionId == null || nextTurn < 2) throw new IllegalArgumentException("canonical result link를 만들 수 없습니다.");
+        if (mutationRequestId == null || sessionId == null || nextTurn < 2) {
+            throw new IllegalArgumentException("canonical result link를 만들 수 없습니다.");
+        }
         return "game-result:%d:%d:%d".formatted(sessionId, nextTurn, mutationRequestId);
     }
 
     private void validateNarrativeTurn(NarrativeTurn turn) {
         if (turn == null) throw new InvalidNarrativeResponseException("Narrative 응답이 없습니다.");
-        if (turn.title() == null || turn.title().isBlank() || turn.title().length() > MAX_TITLE_LENGTH) throw new InvalidNarrativeResponseException("Narrative 제목이 올바르지 않습니다.");
-        if (turn.storyText() == null || turn.storyText().isBlank() || turn.storyText().length() > MAX_STORY_LENGTH) throw new InvalidNarrativeResponseException("Narrative 본문이 올바르지 않습니다.");
-        if (turn.choices() == null || turn.choices().isEmpty() || turn.choices().size() > MAX_CHOICES) throw new InvalidNarrativeResponseException("Narrative 선택지 수가 올바르지 않습니다.");
+        if (turn.title() == null || turn.title().isBlank() || turn.title().length() > MAX_TITLE_LENGTH) {
+            throw new InvalidNarrativeResponseException("Narrative 제목이 올바르지 않습니다.");
+        }
+        if (turn.storyText() == null || turn.storyText().isBlank() || turn.storyText().length() > MAX_STORY_LENGTH) {
+            throw new InvalidNarrativeResponseException("Narrative 본문이 올바르지 않습니다.");
+        }
+        if (turn.choices() == null || turn.choices().isEmpty() || turn.choices().size() > MAX_CHOICES) {
+            throw new InvalidNarrativeResponseException("Narrative 선택지 수가 올바르지 않습니다.");
+        }
         Set<Integer> choiceIds = new HashSet<>();
         for (NarrativeTurn.Choice choice : turn.choices()) {
-            if (choice == null || choice.id() <= 0 || !choiceIds.add(choice.id())) throw new InvalidNarrativeResponseException("Narrative 선택지 ID가 올바르지 않습니다.");
-            if (choice.text() == null || choice.text().isBlank() || choice.text().length() > MAX_CHOICE_TEXT_LENGTH) throw new InvalidNarrativeResponseException("Narrative 선택지 문구가 올바르지 않습니다.");
+            if (choice == null || choice.id() <= 0 || !choiceIds.add(choice.id())) {
+                throw new InvalidNarrativeResponseException("Narrative 선택지 ID가 올바르지 않습니다.");
+            }
+            if (choice.text() == null || choice.text().isBlank() || choice.text().length() > MAX_CHOICE_TEXT_LENGTH) {
+                throw new InvalidNarrativeResponseException("Narrative 선택지 문구가 올바르지 않습니다.");
+            }
         }
     }
 
     private void validateImagePrompt(String imagePrompt) {
-        if (imagePrompt != null && imagePrompt.length() > MAX_IMAGE_PROMPT_LENGTH) throw new InvalidNarrativeResponseException("이미지 prompt가 너무 깁니다.");
+        if (imagePrompt != null && imagePrompt.length() > MAX_IMAGE_PROMPT_LENGTH) {
+            throw new InvalidNarrativeResponseException("이미지 prompt가 너무 깁니다.");
+        }
     }
 }

--- a/src/main/java/com/uctale/uctale/service/GameService.java
+++ b/src/main/java/com/uctale/uctale/service/GameService.java
@@ -16,6 +16,9 @@ import com.uctale.uctale.application.image.ImageAssetService;
 import com.uctale.uctale.application.narrative.InvalidNarrativeResponseException;
 import com.uctale.uctale.application.narrative.NarrativeContext;
 import com.uctale.uctale.application.narrative.NarrativeGenerator;
+import com.uctale.uctale.application.narrative.NarrativeRecoveryExhaustedException;
+import com.uctale.uctale.application.narrative.NarrativeRecoveryExecutor;
+import com.uctale.uctale.application.narrative.NarrativeRecoveryInterruptedException;
 import com.uctale.uctale.application.narrative.NarrativeTurn;
 import com.uctale.uctale.domain.action.PlayerAction;
 import com.uctale.uctale.domain.game.GameState;
@@ -54,20 +57,10 @@ public class GameService {
     private final ProviderCallTelemetry providerCallTelemetry;
     private final GameMutationFingerprint mutationFingerprint;
     private final GameMutationRequestService mutationRequestService;
+    private final NarrativeRecoveryExecutor narrativeRecoveryExecutor = NarrativeRecoveryExecutor.production();
 
     @Autowired
-    public GameService(
-            NarrativeGenerator narrativeGenerator,
-            ImageAssetService imageAssetService,
-            GamePersistenceService gamePersistenceService,
-            ChoiceCodec choiceCodec,
-            TurnProcessor turnProcessor,
-            ImagePromptComposer imagePromptComposer,
-            CostRateLimiter costRateLimiter,
-            ProviderCallTelemetry providerCallTelemetry,
-            GameMutationFingerprint mutationFingerprint,
-            GameMutationRequestService mutationRequestService
-    ) {
+    public GameService(NarrativeGenerator narrativeGenerator, ImageAssetService imageAssetService, GamePersistenceService gamePersistenceService, ChoiceCodec choiceCodec, TurnProcessor turnProcessor, ImagePromptComposer imagePromptComposer, CostRateLimiter costRateLimiter, ProviderCallTelemetry providerCallTelemetry, GameMutationFingerprint mutationFingerprint, GameMutationRequestService mutationRequestService) {
         this.narrativeGenerator = narrativeGenerator;
         this.imageAssetService = imageAssetService;
         this.gamePersistenceService = gamePersistenceService;
@@ -80,118 +73,52 @@ public class GameService {
         this.mutationRequestService = mutationRequestService;
     }
 
-    public GameService(
-            NarrativeGenerator narrativeGenerator,
-            ImageAssetService imageAssetService,
-            GamePersistenceService gamePersistenceService,
-            ChoiceCodec choiceCodec,
-            ImagePromptComposer imagePromptComposer,
-            CostRateLimiter costRateLimiter,
-            ProviderCallTelemetry providerCallTelemetry,
-            GameMutationFingerprint mutationFingerprint,
-            GameMutationRequestService mutationRequestService
-    ) {
-        this(
-                narrativeGenerator,
-                imageAssetService,
-                gamePersistenceService,
-                choiceCodec,
-                new TurnProcessor(),
-                imagePromptComposer,
-                costRateLimiter,
-                providerCallTelemetry,
-                mutationFingerprint,
-                mutationRequestService
-        );
+    public GameService(NarrativeGenerator narrativeGenerator, ImageAssetService imageAssetService, GamePersistenceService gamePersistenceService, ChoiceCodec choiceCodec, ImagePromptComposer imagePromptComposer, CostRateLimiter costRateLimiter, ProviderCallTelemetry providerCallTelemetry, GameMutationFingerprint mutationFingerprint, GameMutationRequestService mutationRequestService) {
+        this(narrativeGenerator, imageAssetService, gamePersistenceService, choiceCodec, new TurnProcessor(), imagePromptComposer, costRateLimiter, providerCallTelemetry, mutationFingerprint, mutationRequestService);
     }
 
-    public GameResponse initGame(String ownerKey, GameInitRequest request) {
-        return initGame(CostRequestContext.internal(ownerKey, null, 1), request);
-    }
+    public GameResponse initGame(String ownerKey, GameInitRequest request) { return initGame(CostRequestContext.internal(ownerKey, null, 1), request); }
 
     public GameResponse initGame(CostRequestContext costContext, GameInitRequest request) {
-        GameMutationRequestService.BeginResult mutation = mutationRequestService.begin(
-                costContext.ownerKey(), GameMutationRequestService.INIT, costContext.idempotencyKey(), null, null,
-                mutationFingerprint.init(request)
-        );
-        if (mutation.replay()) {
-            return replay(costContext.ownerKey(), mutation);
-        }
-
+        GameMutationRequestService.BeginResult mutation = mutationRequestService.begin(costContext.ownerKey(), GameMutationRequestService.INIT, costContext.idempotencyKey(), null, null, mutationFingerprint.init(request));
+        if (mutation.replay()) return replay(costContext.ownerKey(), mutation);
         try {
             costRateLimiter.check(CostOperation.NARRATIVE, costContext);
-            NarrativeTurn opening = providerCallTelemetry.observe(
-                    "gemini", "opening", costContext, 0,
-                    () -> narrativeGenerator.createOpening(request.worldSetting(), request.characterSetting())
-            );
+            NarrativeTurn opening = observeOpening(costContext, request).turn();
             validateNarrativeTurn(opening);
             List<GameChoice> choices = choiceCodec.issue(opening.choices(), 1);
-
             String imagePrompt = imagePromptComposer.compose(opening.visualAssets());
-            if (imagePrompt == null || imagePrompt.isBlank()) {
-                imagePrompt = imagePromptComposer.composeFallback(request.worldSetting());
-            }
+            if (imagePrompt == null || imagePrompt.isBlank()) imagePrompt = imagePromptComposer.composeFallback(request.worldSetting());
             validateImagePrompt(imagePrompt);
             ImageAssetService.AssetReference imageAsset = imageAssetService.issue(imagePrompt, "16:9");
-
-            var session = gamePersistenceService.saveOpening(
-                    costContext.ownerKey(), request.worldSetting(), request.characterSetting(), opening.storyText(),
-                    choiceCodec.serialize(choices), imageAsset, mutation.requestId(), opening.title()
-            );
+            var session = gamePersistenceService.saveOpening(costContext.ownerKey(), request.worldSetting(), request.characterSetting(), opening.storyText(), choiceCodec.serialize(choices), imageAsset, mutation.requestId(), opening.title());
             GameState initialState = GameState.initial(request.worldSetting(), request.characterSetting(), opening.storyText());
-            return GameResponseProjector.project(
-                    session.getId(), session.getCurrentTurn(), opening.title(), opening.storyText(), choices,
-                    imageAsset.publicUrl(), initialState, null
-            );
+            return GameResponseProjector.project(session.getId(), session.getCurrentTurn(), opening.title(), opening.storyText(), choices, imageAsset.publicUrl(), initialState, null);
         } catch (RuntimeException exception) {
             mutationRequestService.markFailed(mutation.requestId());
             throw exception;
         }
     }
 
-    public GameResponse progressGame(String ownerKey, GameProgressRequest request) {
-        return progressGame(CostRequestContext.internal(ownerKey, request.sessionId(), request.expectedTurn() + 1), request);
-    }
+    public GameResponse progressGame(String ownerKey, GameProgressRequest request) { return progressGame(CostRequestContext.internal(ownerKey, request.sessionId(), request.expectedTurn() + 1), request); }
 
     public GameResponse progressGame(CostRequestContext costContext, GameProgressRequest request) {
-        GameMutationRequestService.BeginResult mutation = mutationRequestService.begin(
-                costContext.ownerKey(), GameMutationRequestService.PROGRESS, costContext.idempotencyKey(),
-                request.sessionId(), request.expectedTurn(), mutationFingerprint.progress(request)
-        );
-        if (mutation.replay()) {
-            return replay(costContext.ownerKey(), mutation);
-        }
-
+        GameMutationRequestService.BeginResult mutation = mutationRequestService.begin(costContext.ownerKey(), GameMutationRequestService.PROGRESS, costContext.idempotencyKey(), request.sessionId(), request.expectedTurn(), mutationFingerprint.progress(request));
+        if (mutation.replay()) return replay(costContext.ownerKey(), mutation);
         try {
-            GamePersistenceService.LoadedTurn loadedTurn = gamePersistenceService.loadLatestTurn(
-                    costContext.ownerKey(), request.sessionId(), request.expectedTurn()
-            );
-            CostRequestContext providerContext = new CostRequestContext(
-                    costContext.requestId(), costContext.ownerKey(), costContext.clientIp(), loadedTurn.sessionId(),
-                    request.expectedTurn() + 1, costContext.idempotencyKey()
-            );
-
+            GamePersistenceService.LoadedTurn loadedTurn = gamePersistenceService.loadLatestTurn(costContext.ownerKey(), request.sessionId(), request.expectedTurn());
+            CostRequestContext providerContext = new CostRequestContext(costContext.requestId(), costContext.ownerKey(), costContext.clientIp(), loadedTurn.sessionId(), request.expectedTurn() + 1, costContext.idempotencyKey());
             PlayerAction playerAction = choiceCodec.resolve(loadedTurn.choicesJson(), request);
-            TurnResolution resolution = turnProcessor.resolve(
-                    loadedTurn.gameState(), playerAction, mutation.requestId(), mutation.reservationOwner()
-            );
+            TurnResolution resolution = turnProcessor.resolve(loadedTurn.gameState(), playerAction, mutation.requestId(), mutation.reservationOwner());
             String userChoiceText = resolution.gameResult().resolvedAction().displayText();
-            String canonicalResultId = canonicalResultId(mutation.requestId(), loadedTurn.sessionId(),
-                    resolution.stateTransition().nextState().turnNumber());
+            String canonicalResultId = canonicalResultId(mutation.requestId(), loadedTurn.sessionId(), resolution.stateTransition().nextState().turnNumber());
             NarrativeContext narrativeContext = NarrativeContext.from(canonicalResultId, resolution);
             costRateLimiter.check(CostOperation.NARRATIVE, providerContext);
-            NarrativeTurn nextTurn = providerCallTelemetry.observe(
-                    "gemini", "progress", providerContext, 0,
-                    () -> mutationRequestService.markProviderAttemptStarted(
-                            mutation.requestId(), mutation.reservationOwner()
-                    ),
-                    () -> narrativeGenerator.createNextTurn(narrativeContext)
-            );
+            NarrativeTurn nextTurn = observeProgress(providerContext, mutation, narrativeContext).turn();
             validateNarrativeTurn(nextTurn);
             String generatedStoryId = "story:" + UUID.randomUUID();
             StateTransition committedTransition = turnProcessor.attachNarrative(resolution, nextTurn.storyText());
             List<GameChoice> choices = choiceCodec.issue(nextTurn.choices(), request.expectedTurn() + 1);
-
             ImageAssetService.AssetReference imageAsset = null;
             String imageUrl = loadedTurn.imageUrl();
             String imagePrompt = imagePromptComposer.compose(nextTurn.visualAssets());
@@ -200,75 +127,71 @@ public class GameService {
                 log.info("새로운 이미지 asset 발급");
                 imageAsset = imageAssetService.issue(imagePrompt, "16:9");
                 imageUrl = imageAsset.publicUrl();
-            } else {
-                log.info("시각적 변화 없음 -> 이전 이미지 asset 재사용");
-            }
-
-            GameTurnCommit commit = new GameTurnCommit(
-                    request.expectedTurn(), resolution.gameResult().resolvedAction().legacyChoiceId(), userChoiceText,
-                    committedTransition, nextTurn.storyText(), choiceCodec.serialize(choices),
-                    canonicalResultId, generatedStoryId, resolution.gameResult().skillCheckResult(), imageAsset
-            );
-
-            int savedTurn = gamePersistenceService.saveNextTurn(
-                    costContext.ownerKey(), loadedTurn.sessionId(), commit, mutation.requestId(), nextTurn.title(),
-                    mutation.reservationOwner()
-            );
-            return GameResponseProjector.project(
-                    loadedTurn.sessionId(), savedTurn, nextTurn.title(), nextTurn.storyText(), choices, imageUrl,
-                    committedTransition.nextState(), resolution.gameResult().skillCheckResult()
-            );
+            } else log.info("시각적 변화 없음 -> 이전 이미지 asset 재사용");
+            GameTurnCommit commit = new GameTurnCommit(request.expectedTurn(), resolution.gameResult().resolvedAction().legacyChoiceId(), userChoiceText, committedTransition, nextTurn.storyText(), choiceCodec.serialize(choices), canonicalResultId, generatedStoryId, resolution.gameResult().skillCheckResult(), imageAsset);
+            int savedTurn = gamePersistenceService.saveNextTurn(costContext.ownerKey(), loadedTurn.sessionId(), commit, mutation.requestId(), nextTurn.title(), mutation.reservationOwner());
+            return GameResponseProjector.project(loadedTurn.sessionId(), savedTurn, nextTurn.title(), nextTurn.storyText(), choices, imageUrl, committedTransition.nextState(), resolution.gameResult().skillCheckResult());
         } catch (RuntimeException exception) {
             mutationRequestService.markFailed(mutation.requestId(), mutation.reservationOwner());
             throw exception;
         }
     }
 
+    private NarrativeRecoveryExecutor.Result observeOpening(CostRequestContext costContext, GameInitRequest request) {
+        try {
+            return providerCallTelemetry.observe("gemini", "opening", costContext,
+                    () -> narrativeRecoveryExecutor.execute(
+                            () -> narrativeGenerator.createOpening(request.worldSetting(), request.characterSetting()),
+                            reasonCode -> narrativeGenerator.repairOpening(request.worldSetting(), request.characterSetting(), reasonCode),
+                            () -> {}),
+                    NarrativeRecoveryExecutor.Result::retryCount,
+                    this::narrativeRetryCountFromFailure);
+        } catch (NarrativeRecoveryInterruptedException exception) { throw exception.originalCause(); }
+    }
+
+    private NarrativeRecoveryExecutor.Result observeProgress(CostRequestContext providerContext, GameMutationRequestService.BeginResult mutation, NarrativeContext narrativeContext) {
+        try {
+            return providerCallTelemetry.observe("gemini", "progress", providerContext,
+                    () -> mutationRequestService.markProviderAttemptStarted(mutation.requestId(), mutation.reservationOwner()),
+                    () -> narrativeRecoveryExecutor.execute(
+                            () -> narrativeGenerator.createNextTurn(narrativeContext),
+                            reasonCode -> narrativeGenerator.repairNextTurn(narrativeContext, reasonCode),
+                            () -> mutationRequestService.markProviderAttemptStarted(mutation.requestId(), mutation.reservationOwner())),
+                    NarrativeRecoveryExecutor.Result::retryCount,
+                    this::narrativeRetryCountFromFailure);
+        } catch (NarrativeRecoveryInterruptedException exception) { throw exception.originalCause(); }
+    }
+
+    private int narrativeRetryCountFromFailure(RuntimeException exception) {
+        if (exception instanceof NarrativeRecoveryExhaustedException exhausted) return exhausted.retryCount();
+        if (exception instanceof NarrativeRecoveryInterruptedException interrupted) return interrupted.retryCount();
+        return 0;
+    }
+
     private GameResponse replay(String ownerKey, GameMutationRequestService.BeginResult mutation) {
-        if (mutation.resultSessionId() == null || mutation.resultTurn() == null || mutation.resultTitle() == null) {
-            throw new IllegalStateException("완료된 mutation request의 결과 참조가 올바르지 않습니다.");
-        }
-        GamePersistenceService.CommittedTurn turn = gamePersistenceService.loadCommittedTurn(
-                ownerKey, mutation.resultSessionId(), mutation.resultTurn()
-        );
-        return GameResponseProjector.projectReplay(
-                mutation.resultSessionId(), mutation.resultTurn(), mutation.resultTitle(), turn.storyText(),
-                choiceCodec.deserialize(turn.choicesJson()), turn.imageUrl(), turn.gameState(), turn.skillCheckAudit()
-        );
+        if (mutation.resultSessionId() == null || mutation.resultTurn() == null || mutation.resultTitle() == null) throw new IllegalStateException("완료된 mutation request의 결과 참조가 올바르지 않습니다.");
+        GamePersistenceService.CommittedTurn turn = gamePersistenceService.loadCommittedTurn(ownerKey, mutation.resultSessionId(), mutation.resultTurn());
+        return GameResponseProjector.projectReplay(mutation.resultSessionId(), mutation.resultTurn(), mutation.resultTitle(), turn.storyText(), choiceCodec.deserialize(turn.choicesJson()), turn.imageUrl(), turn.gameState(), turn.skillCheckAudit());
     }
 
     private String canonicalResultId(Long mutationRequestId, Long sessionId, int nextTurn) {
-        if (mutationRequestId == null || sessionId == null || nextTurn < 2) {
-            throw new IllegalArgumentException("canonical result link를 만들 수 없습니다.");
-        }
+        if (mutationRequestId == null || sessionId == null || nextTurn < 2) throw new IllegalArgumentException("canonical result link를 만들 수 없습니다.");
         return "game-result:%d:%d:%d".formatted(sessionId, nextTurn, mutationRequestId);
     }
 
     private void validateNarrativeTurn(NarrativeTurn turn) {
         if (turn == null) throw new InvalidNarrativeResponseException("Narrative 응답이 없습니다.");
-        if (turn.title() == null || turn.title().isBlank() || turn.title().length() > MAX_TITLE_LENGTH) {
-            throw new InvalidNarrativeResponseException("Narrative 제목이 올바르지 않습니다.");
-        }
-        if (turn.storyText() == null || turn.storyText().isBlank() || turn.storyText().length() > MAX_STORY_LENGTH) {
-            throw new InvalidNarrativeResponseException("Narrative 본문이 올바르지 않습니다.");
-        }
-        if (turn.choices() == null || turn.choices().isEmpty() || turn.choices().size() > MAX_CHOICES) {
-            throw new InvalidNarrativeResponseException("Narrative 선택지 수가 올바르지 않습니다.");
-        }
+        if (turn.title() == null || turn.title().isBlank() || turn.title().length() > MAX_TITLE_LENGTH) throw new InvalidNarrativeResponseException("Narrative 제목이 올바르지 않습니다.");
+        if (turn.storyText() == null || turn.storyText().isBlank() || turn.storyText().length() > MAX_STORY_LENGTH) throw new InvalidNarrativeResponseException("Narrative 본문이 올바르지 않습니다.");
+        if (turn.choices() == null || turn.choices().isEmpty() || turn.choices().size() > MAX_CHOICES) throw new InvalidNarrativeResponseException("Narrative 선택지 수가 올바르지 않습니다.");
         Set<Integer> choiceIds = new HashSet<>();
         for (NarrativeTurn.Choice choice : turn.choices()) {
-            if (choice == null || choice.id() <= 0 || !choiceIds.add(choice.id())) {
-                throw new InvalidNarrativeResponseException("Narrative 선택지 ID가 올바르지 않습니다.");
-            }
-            if (choice.text() == null || choice.text().isBlank() || choice.text().length() > MAX_CHOICE_TEXT_LENGTH) {
-                throw new InvalidNarrativeResponseException("Narrative 선택지 문구가 올바르지 않습니다.");
-            }
+            if (choice == null || choice.id() <= 0 || !choiceIds.add(choice.id())) throw new InvalidNarrativeResponseException("Narrative 선택지 ID가 올바르지 않습니다.");
+            if (choice.text() == null || choice.text().isBlank() || choice.text().length() > MAX_CHOICE_TEXT_LENGTH) throw new InvalidNarrativeResponseException("Narrative 선택지 문구가 올바르지 않습니다.");
         }
     }
 
     private void validateImagePrompt(String imagePrompt) {
-        if (imagePrompt != null && imagePrompt.length() > MAX_IMAGE_PROMPT_LENGTH) {
-            throw new InvalidNarrativeResponseException("이미지 prompt가 너무 깁니다.");
-        }
+        if (imagePrompt != null && imagePrompt.length() > MAX_IMAGE_PROMPT_LENGTH) throw new InvalidNarrativeResponseException("이미지 prompt가 너무 깁니다.");
     }
 }

--- a/src/test/java/com/uctale/uctale/application/narrative/NarrativeRecoveryExecutorTest.java
+++ b/src/test/java/com/uctale/uctale/application/narrative/NarrativeRecoveryExecutorTest.java
@@ -1,0 +1,126 @@
+package com.uctale.uctale.application.narrative;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class NarrativeRecoveryExecutorTest {
+
+    @Test
+    @DisplayName("정상 응답은 retry 없이 그대로 반환한다")
+    void normalResponse_DoesNotRetry() {
+        List<Long> backoffs = new ArrayList<>();
+        AtomicInteger retryGuards = new AtomicInteger();
+        NarrativeRecoveryExecutor executor = new NarrativeRecoveryExecutor(3, backoffs::add);
+
+        NarrativeRecoveryExecutor.Result result = executor.execute(
+                () -> validTurn("정상"),
+                reason -> { throw new AssertionError("repair는 호출되면 안 됩니다."); },
+                retryGuards::incrementAndGet
+        );
+
+        assertThat(result.turn().title()).isEqualTo("정상");
+        assertThat(result.retryCount()).isZero();
+        assertThat(backoffs).isEmpty();
+        assertThat(retryGuards).hasValue(0);
+    }
+
+    @Test
+    @DisplayName("repair 가능한 응답 오류는 reason code를 전달하고 bounded retry 후 성공한다")
+    void recoverableResponse_RetriesWithReasonCode() {
+        List<Long> backoffs = new ArrayList<>();
+        List<String> repairReasons = new ArrayList<>();
+        AtomicInteger retryGuards = new AtomicInteger();
+        NarrativeRecoveryExecutor executor = new NarrativeRecoveryExecutor(3, backoffs::add);
+
+        NarrativeRecoveryExecutor.Result result = executor.execute(
+                () -> { throw new RecoverableNarrativeResponseException("INVALID_CHOICE_ID", "중복 선택지"); },
+                reason -> { repairReasons.add(reason); return validTurn("복구"); },
+                retryGuards::incrementAndGet
+        );
+
+        assertThat(result.turn().title()).isEqualTo("복구");
+        assertThat(result.retryCount()).isEqualTo(1);
+        assertThat(repairReasons).containsExactly("INVALID_CHOICE_ID");
+        assertThat(backoffs).containsExactly(50L);
+        assertThat(retryGuards).hasValue(1);
+    }
+
+    @Test
+    @DisplayName("repair가 계속 실패하면 최대 3 provider attempt 뒤 종료한다")
+    void retryExhausted_IsBounded() {
+        List<Long> backoffs = new ArrayList<>();
+        AtomicInteger providerCalls = new AtomicInteger();
+        AtomicInteger retryGuards = new AtomicInteger();
+        NarrativeRecoveryExecutor executor = new NarrativeRecoveryExecutor(3, backoffs::add);
+
+        assertThatThrownBy(() -> executor.execute(
+                () -> fail(providerCalls),
+                reason -> fail(providerCalls),
+                retryGuards::incrementAndGet
+        )).isInstanceOfSatisfying(NarrativeRecoveryExhaustedException.class, exception -> {
+            assertThat(exception.retryCount()).isEqualTo(2);
+            assertThat(exception.reasonCode()).isEqualTo("MALFORMED_JSON");
+        });
+
+        assertThat(providerCalls).hasValue(3);
+        assertThat(retryGuards).hasValue(2);
+        assertThat(backoffs).containsExactly(50L, 150L);
+    }
+
+    @Test
+    @DisplayName("retry 직전 guard 실패는 새 provider attempt로 계산하지 않는다")
+    void retryGuardFailure_DoesNotCountBlockedAttempt() {
+        NarrativeRecoveryExecutor executor = new NarrativeRecoveryExecutor(3, ignored -> {});
+        AtomicInteger providerCalls = new AtomicInteger();
+
+        assertThatThrownBy(() -> executor.execute(
+                () -> fail(providerCalls),
+                reason -> { providerCalls.incrementAndGet(); return validTurn("unexpected"); },
+                () -> { throw new IllegalStateException("stale owner"); }
+        )).isInstanceOfSatisfying(NarrativeRecoveryInterruptedException.class, exception -> {
+            assertThat(exception.retryCount()).isZero();
+            assertThat(exception.originalCause()).hasMessage("stale owner");
+        });
+
+        assertThat(providerCalls).hasValue(1);
+    }
+
+    @Test
+    @DisplayName("repair attempt에서 transport failure가 나면 실제 호출 횟수를 보존한다")
+    void hardFailureDuringRepair_PreservesAttemptCount() {
+        NarrativeRecoveryExecutor executor = new NarrativeRecoveryExecutor(3, ignored -> {});
+        Queue<RuntimeException> failures = new ArrayDeque<>();
+        failures.add(new RecoverableNarrativeResponseException("INVALID_STORY", "invalid"));
+        failures.add(new IllegalStateException("provider down"));
+        AtomicInteger providerCalls = new AtomicInteger();
+
+        assertThatThrownBy(() -> executor.execute(
+                () -> { providerCalls.incrementAndGet(); throw failures.remove(); },
+                reason -> { providerCalls.incrementAndGet(); throw failures.remove(); },
+                () -> {}
+        )).isInstanceOfSatisfying(NarrativeRecoveryInterruptedException.class, exception -> {
+            assertThat(exception.retryCount()).isEqualTo(1);
+            assertThat(exception.originalCause()).hasMessage("provider down");
+        });
+
+        assertThat(providerCalls).hasValue(2);
+    }
+
+    private NarrativeTurn fail(AtomicInteger providerCalls) {
+        providerCalls.incrementAndGet();
+        throw new RecoverableNarrativeResponseException("MALFORMED_JSON", "invalid");
+    }
+
+    private NarrativeTurn validTurn(String title) {
+        return new NarrativeTurn(title, "본문", List.of(new NarrativeTurn.Choice(1, "진행한다")), new NarrativeTurn.VisualAssets("", List.of(), List.of()));
+    }
+}

--- a/src/test/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapterTest.java
+++ b/src/test/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapterTest.java
@@ -2,6 +2,7 @@ package com.uctale.uctale.provider.gemini;
 
 import tools.jackson.databind.ObjectMapper;
 import com.uctale.uctale.application.narrative.NarrativeTurn;
+import com.uctale.uctale.application.narrative.RecoverableNarrativeResponseException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,11 +12,13 @@ import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 class GeminiNarrativeAdapterTest {
-
     private GeminiNarrativeAdapter adapter;
     private MockRestServiceServer mockServer;
 
@@ -28,33 +31,61 @@ class GeminiNarrativeAdapterTest {
     }
 
     @Test
-    @DisplayName("Gemini 오프닝 응답을 내부 내러티브 모델로 변환한다")
-    void createOpening_MapsProviderResponse() {
-        String mockApiResponse = """
-                {
-                  "candidates": [
-                    {
-                      "content": {
-                        "parts": [
-                          {
-                            "text": "{ \\"title\\": \\"첫날 밤\\", \\"story_text\\": \\"좀비가 나타났다!\\", \\"choices\\": [{\\"id\\":1,\\"text\\":\\"도망간다\\"}], \\"visual_assets\\": { \\"background\\": \\"dark subway\\", \\"characters\\": [], \\"assets\\": [] } }"
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                }
-                """;
-
-        mockServer.expect(requestTo("https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=TEST_API_KEY"))
-                .andRespond(withSuccess(mockApiResponse, MediaType.APPLICATION_JSON));
-
+    @DisplayName("Gemini 요청은 JSON MIME과 response schema를 함께 전달한다")
+    void createOpening_UsesStructuredOutputSchema() {
+        mockServer.expect(requestTo(geminiUrl()))
+                .andExpect(content().string(containsString("\"response_mime_type\":\"application/json\"")))
+                .andExpect(content().string(containsString("\"response_schema\"")))
+                .andRespond(withSuccess(apiResponse(validNarrativeJson()), MediaType.APPLICATION_JSON));
         NarrativeTurn response = adapter.createOpening("좀비 아포칼립스", "김대리");
-
         assertThat(response.title()).isEqualTo("첫날 밤");
-        assertThat(response.storyText()).isEqualTo("좀비가 나타났다!");
         assertThat(response.choices()).extracting(NarrativeTurn.Choice::text).containsExactly("도망간다");
-        assertThat(response.visualAssets().background()).isEqualTo("dark subway");
         mockServer.verify();
+    }
+
+    @Test
+    @DisplayName("누락 choice text를 기본값으로 보정하지 않고 recoverable 오류로 거부한다")
+    void parseResponse_DoesNotDefaultMissingChoiceText() {
+        String narrative = """{"title":"첫날 밤","story_text":"좀비가 나타났다!","choices":[{"id":1}]}""";
+        assertThatThrownBy(() -> adapter.parseResponse(apiResponse(narrative)))
+                .isInstanceOfSatisfying(RecoverableNarrativeResponseException.class, exception -> assertThat(exception.reasonCode()).isEqualTo("INVALID_CHOICE_TEXT"));
+    }
+
+    @Test
+    @DisplayName("중복 choice id를 recoverable 오류로 거부한다")
+    void parseResponse_RejectsDuplicateChoiceIds() {
+        String narrative = """{"title":"첫날 밤","story_text":"좀비가 나타났다!","choices":[{"id":1,"text":"도망간다"},{"id":1,"text":"숨는다"}]}""";
+        assertThatThrownBy(() -> adapter.parseResponse(apiResponse(narrative)))
+                .isInstanceOfSatisfying(RecoverableNarrativeResponseException.class, exception -> assertThat(exception.reasonCode()).isEqualTo("INVALID_CHOICE_ID"));
+    }
+
+    @Test
+    @DisplayName("깨진 nested JSON은 raw 응답을 노출하지 않는 분류 코드로 거부한다")
+    void parseResponse_ClassifiesMalformedJson() {
+        assertThatThrownBy(() -> adapter.parseResponse(apiResponse("{not-json}")))
+                .isInstanceOfSatisfying(RecoverableNarrativeResponseException.class, exception -> {
+                    assertThat(exception.reasonCode()).isEqualTo("MALFORMED_JSON");
+                    assertThat(exception.getMessage()).doesNotContain("{not-json}");
+                });
+    }
+
+    @Test
+    @DisplayName("repair 요청은 raw 응답 없이 실패 분류만 prompt에 전달한다")
+    void repairOpening_UsesSafeReasonCode() {
+        mockServer.expect(requestTo(geminiUrl()))
+                .andExpect(content().string(containsString("[응답 수정 요청]")))
+                .andExpect(content().string(containsString("INVALID_CHOICE_ID")))
+                .andRespond(withSuccess(apiResponse(validNarrativeJson()), MediaType.APPLICATION_JSON));
+        assertThat(adapter.repairOpening("세계", "캐릭터", "INVALID_CHOICE_ID").title()).isEqualTo("첫날 밤");
+        mockServer.verify();
+    }
+
+    private String geminiUrl() { return "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=TEST_API_KEY"; }
+    private String validNarrativeJson() { return """{"title":"첫날 밤","story_text":"좀비가 나타났다!","choices":[{"id":1,"text":"도망간다"}],"visual_assets":{"background":"dark subway","characters":[],"assets":[]}}"""; }
+    private String apiResponse(String narrativeJson) {
+        try {
+            String escaped = new ObjectMapper().writeValueAsString(narrativeJson);
+            return """{"candidates":[{"content":{"parts":[{"text":%s}]}}]}""".formatted(escaped);
+        } catch (Exception exception) { throw new AssertionError(exception); }
     }
 }

--- a/src/test/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapterTest.java
+++ b/src/test/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapterTest.java
@@ -51,7 +51,7 @@ class GeminiNarrativeAdapterTest {
     @Test
     @DisplayName("누락 choice text를 기본값으로 보정하지 않고 recoverable 오류로 거부한다")
     void parseResponse_DoesNotDefaultMissingChoiceText() {
-        String narrative = """{"title":"첫날 밤","story_text":"좀비가 나타났다!","choices":[{"id":1}]}""";
+        String narrative = "{\"title\":\"첫날 밤\",\"story_text\":\"좀비가 나타났다!\",\"choices\":[{\"id\":1}]}";
 
         assertThatThrownBy(() -> adapter.parseResponse(apiResponse(narrative)))
                 .isInstanceOfSatisfying(RecoverableNarrativeResponseException.class, exception ->
@@ -61,7 +61,7 @@ class GeminiNarrativeAdapterTest {
     @Test
     @DisplayName("중복 choice id를 recoverable 오류로 거부한다")
     void parseResponse_RejectsDuplicateChoiceIds() {
-        String narrative = """{"title":"첫날 밤","story_text":"좀비가 나타났다!","choices":[{"id":1,"text":"도망간다"},{"id":1,"text":"숨는다"}]}""";
+        String narrative = "{\"title\":\"첫날 밤\",\"story_text\":\"좀비가 나타났다!\",\"choices\":[{\"id\":1,\"text\":\"도망간다\"},{\"id\":1,\"text\":\"숨는다\"}]}";
 
         assertThatThrownBy(() -> adapter.parseResponse(apiResponse(narrative)))
                 .isInstanceOfSatisfying(RecoverableNarrativeResponseException.class, exception ->
@@ -96,13 +96,13 @@ class GeminiNarrativeAdapterTest {
     }
 
     private String validNarrativeJson() {
-        return """{"title":"첫날 밤","story_text":"좀비가 나타났다!","choices":[{"id":1,"text":"도망간다"}],"visual_assets":{"background":"dark subway","characters":[],"assets":[]}}""";
+        return "{\"title\":\"첫날 밤\",\"story_text\":\"좀비가 나타났다!\",\"choices\":[{\"id\":1,\"text\":\"도망간다\"}],\"visual_assets\":{\"background\":\"dark subway\",\"characters\":[],\"assets\":[]}}";
     }
 
     private String apiResponse(String narrativeJson) {
         try {
             String escaped = new ObjectMapper().writeValueAsString(narrativeJson);
-            return """{"candidates":[{"content":{"parts":[{"text":%s}]}}]}""".formatted(escaped);
+            return "{\"candidates\":[{\"content\":{\"parts\":[{\"text\":" + escaped + "}]}}]}";
         } catch (Exception exception) {
             throw new AssertionError(exception);
         }

--- a/src/test/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapterTest.java
+++ b/src/test/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapterTest.java
@@ -15,10 +15,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 class GeminiNarrativeAdapterTest {
+
     private GeminiNarrativeAdapter adapter;
     private MockRestServiceServer mockServer;
 
@@ -31,13 +33,16 @@ class GeminiNarrativeAdapterTest {
     }
 
     @Test
-    @DisplayName("Gemini 요청은 JSON MIME과 response schema를 함께 전달한다")
+    @DisplayName("Gemini 요청은 공식 REST structured output 계약과 API key header를 사용한다")
     void createOpening_UsesStructuredOutputSchema() {
         mockServer.expect(requestTo(geminiUrl()))
-                .andExpect(content().string(containsString("\"response_mime_type\":\"application/json\"")))
-                .andExpect(content().string(containsString("\"response_schema\"")))
+                .andExpect(header("x-goog-api-key", "TEST_API_KEY"))
+                .andExpect(content().string(containsString("\"responseMimeType\":\"application/json\"")))
+                .andExpect(content().string(containsString("\"responseSchema\"")))
                 .andRespond(withSuccess(apiResponse(validNarrativeJson()), MediaType.APPLICATION_JSON));
+
         NarrativeTurn response = adapter.createOpening("좀비 아포칼립스", "김대리");
+
         assertThat(response.title()).isEqualTo("첫날 밤");
         assertThat(response.choices()).extracting(NarrativeTurn.Choice::text).containsExactly("도망간다");
         mockServer.verify();
@@ -47,16 +52,20 @@ class GeminiNarrativeAdapterTest {
     @DisplayName("누락 choice text를 기본값으로 보정하지 않고 recoverable 오류로 거부한다")
     void parseResponse_DoesNotDefaultMissingChoiceText() {
         String narrative = """{"title":"첫날 밤","story_text":"좀비가 나타났다!","choices":[{"id":1}]}""";
+
         assertThatThrownBy(() -> adapter.parseResponse(apiResponse(narrative)))
-                .isInstanceOfSatisfying(RecoverableNarrativeResponseException.class, exception -> assertThat(exception.reasonCode()).isEqualTo("INVALID_CHOICE_TEXT"));
+                .isInstanceOfSatisfying(RecoverableNarrativeResponseException.class, exception ->
+                        assertThat(exception.reasonCode()).isEqualTo("INVALID_CHOICE_TEXT"));
     }
 
     @Test
     @DisplayName("중복 choice id를 recoverable 오류로 거부한다")
     void parseResponse_RejectsDuplicateChoiceIds() {
         String narrative = """{"title":"첫날 밤","story_text":"좀비가 나타났다!","choices":[{"id":1,"text":"도망간다"},{"id":1,"text":"숨는다"}]}""";
+
         assertThatThrownBy(() -> adapter.parseResponse(apiResponse(narrative)))
-                .isInstanceOfSatisfying(RecoverableNarrativeResponseException.class, exception -> assertThat(exception.reasonCode()).isEqualTo("INVALID_CHOICE_ID"));
+                .isInstanceOfSatisfying(RecoverableNarrativeResponseException.class, exception ->
+                        assertThat(exception.reasonCode()).isEqualTo("INVALID_CHOICE_ID"));
     }
 
     @Test
@@ -73,19 +82,29 @@ class GeminiNarrativeAdapterTest {
     @DisplayName("repair 요청은 raw 응답 없이 실패 분류만 prompt에 전달한다")
     void repairOpening_UsesSafeReasonCode() {
         mockServer.expect(requestTo(geminiUrl()))
+                .andExpect(header("x-goog-api-key", "TEST_API_KEY"))
                 .andExpect(content().string(containsString("[응답 수정 요청]")))
                 .andExpect(content().string(containsString("INVALID_CHOICE_ID")))
                 .andRespond(withSuccess(apiResponse(validNarrativeJson()), MediaType.APPLICATION_JSON));
+
         assertThat(adapter.repairOpening("세계", "캐릭터", "INVALID_CHOICE_ID").title()).isEqualTo("첫날 밤");
         mockServer.verify();
     }
 
-    private String geminiUrl() { return "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=TEST_API_KEY"; }
-    private String validNarrativeJson() { return """{"title":"첫날 밤","story_text":"좀비가 나타났다!","choices":[{"id":1,"text":"도망간다"}],"visual_assets":{"background":"dark subway","characters":[],"assets":[]}}"""; }
+    private String geminiUrl() {
+        return "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent";
+    }
+
+    private String validNarrativeJson() {
+        return """{"title":"첫날 밤","story_text":"좀비가 나타났다!","choices":[{"id":1,"text":"도망간다"}],"visual_assets":{"background":"dark subway","characters":[],"assets":[]}}""";
+    }
+
     private String apiResponse(String narrativeJson) {
         try {
             String escaped = new ObjectMapper().writeValueAsString(narrativeJson);
             return """{"candidates":[{"content":{"parts":[{"text":%s}]}}]}""".formatted(escaped);
-        } catch (Exception exception) { throw new AssertionError(exception); }
+        } catch (Exception exception) {
+            throw new AssertionError(exception);
+        }
     }
 }

--- a/src/test/java/com/uctale/uctale/service/GameServiceNarrativeRecoveryTest.java
+++ b/src/test/java/com/uctale/uctale/service/GameServiceNarrativeRecoveryTest.java
@@ -1,0 +1,75 @@
+package com.uctale.uctale.service;
+
+import tools.jackson.databind.ObjectMapper;
+import com.uctale.uctale.application.cost.CostRateLimitPolicy;
+import com.uctale.uctale.application.cost.CostRateLimiter;
+import com.uctale.uctale.application.cost.ProviderCallEvent;
+import com.uctale.uctale.application.cost.ProviderCallTelemetry;
+import com.uctale.uctale.application.game.ChoiceCodec;
+import com.uctale.uctale.application.game.GameMutationFingerprint;
+import com.uctale.uctale.application.game.GameMutationRequestService;
+import com.uctale.uctale.application.game.GamePersistenceService;
+import com.uctale.uctale.application.game.ImagePromptComposer;
+import com.uctale.uctale.application.game.TurnProcessor;
+import com.uctale.uctale.application.image.ImageAssetService;
+import com.uctale.uctale.application.narrative.NarrativeGenerator;
+import com.uctale.uctale.application.narrative.NarrativeRecoveryExhaustedException;
+import com.uctale.uctale.application.narrative.RecoverableNarrativeResponseException;
+import com.uctale.uctale.dto.GameInitRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class GameServiceNarrativeRecoveryTest {
+    private static final String OWNER_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    @Mock private NarrativeGenerator narrativeGenerator;
+    @Mock private ImageAssetService imageAssetService;
+    @Mock private GamePersistenceService gamePersistenceService;
+    @Mock private GameMutationRequestService mutationRequestService;
+    private final List<ProviderCallEvent> events = new ArrayList<>();
+    private GameService gameService;
+
+    @BeforeEach
+    void setUp() {
+        Clock clock = Clock.systemUTC();
+        given(mutationRequestService.begin(anyString(), anyString(), anyString(), any(), any(), anyString())).willReturn(new GameMutationRequestService.BeginResult(100L, false, null, null, null));
+        gameService = new GameService(narrativeGenerator, imageAssetService, gamePersistenceService, new ChoiceCodec(new ObjectMapper()), new TurnProcessor(), new ImagePromptComposer(), new CostRateLimiter(new CostRateLimitPolicy(1_000, 1_000, 60), clock), new ProviderCallTelemetry(clock, events::add), new GameMutationFingerprint(), mutationRequestService);
+    }
+
+    @Test
+    @DisplayName("Gemini response recovery 소진 시 3회 attempt를 기록하고 canonical opening을 저장하지 않는다")
+    void initGame_RecoveryExhausted_DoesNotCommit() {
+        GameInitRequest request = new GameInitRequest("세계관", "캐릭터");
+        given(narrativeGenerator.createOpening("세계관", "캐릭터")).willThrow(new RecoverableNarrativeResponseException("MALFORMED_JSON", "invalid"));
+        given(narrativeGenerator.repairOpening("세계관", "캐릭터", "MALFORMED_JSON")).willThrow(new RecoverableNarrativeResponseException("MALFORMED_JSON", "invalid"));
+        assertThatThrownBy(() -> gameService.initGame(OWNER_KEY, request)).isInstanceOfSatisfying(NarrativeRecoveryExhaustedException.class, exception -> assertThat(exception.retryCount()).isEqualTo(2));
+        verify(narrativeGenerator).createOpening("세계관", "캐릭터");
+        verify(narrativeGenerator, times(2)).repairOpening("세계관", "캐릭터", "MALFORMED_JSON");
+        verify(imageAssetService, never()).issue(any(), any());
+        verify(gamePersistenceService, never()).saveOpening(any(), any(), any(), any(), any(), any(), any(), any());
+        verify(mutationRequestService).markFailed(100L);
+        assertThat(events).singleElement().satisfies(event -> {
+            assertThat(event.provider()).isEqualTo("gemini");
+            assertThat(event.outcome()).isEqualTo("FAILURE");
+            assertThat(event.retryCount()).isEqualTo(2);
+            assertThat(event.attemptCount()).isEqualTo(3);
+        });
+    }
+}


### PR DESCRIPTION
## 왜 필요한가요?

Gemini 응답이 누락/잘못된 필드를 포함해도 adapter가 `제목 없음`, `스토리가 없습니다.`, 임의 choice ID, `내용 없음` 같은 기본값으로 보정할 수 있어 provider 오류가 정상 narrative처럼 다음 단계로 전달될 수 있었습니다. provider output을 신뢰하지 않는 외부 입력으로 취급하고, 복구 가능한 구조 오류만 제한적으로 재시도하되 모든 실패에서 canonical turn이 진행되지 않도록 경계를 강화합니다.

- Closes #35

## 무엇이 바뀌나요?

- 게임 규칙·상태: canonical 게임 규칙과 `GameResult` 판정은 변경하지 않습니다. Narrative recovery가 소진되면 기존 canonical commit 이전 실패 경계를 유지합니다.
- Backend / API / DB: API/DB schema 변경은 없습니다. `GameService`가 logical narrative operation 단위의 bounded recovery 결과를 기존 provider telemetry에 연결하고, progress의 각 실제 recovery attempt 전에 현재 reservation owner와 provider attempt 상한을 다시 검증합니다.
- AI narrative / prompt: Gemini `generateContent` 요청에 `responseMimeType=application/json`과 `responseSchema`를 추가합니다. adapter가 title/story/choice/visual field의 타입·필수값·길이·choice 수·양의 unique ID·제어문자를 검증하며 누락값을 기본값으로 보정하지 않습니다. malformed/missing/duplicate 같은 구조 오류만 bounded reason code로 분류해 최대 3 provider attempt, 50ms/150ms backoff로 repair합니다. transport/provider hard failure는 response repair 대상으로 바꾸지 않습니다. raw response 전문은 recovery prompt나 로그에 넣지 않습니다.
- Image generation: 변경 없음. invalid narrative는 image asset 발급 전에 실패합니다.
- Frontend / UX: 변경 없음. 기존 `PROVIDER_RESPONSE_INVALID` API 오류 계약을 유지합니다.
- Build / deploy / docs: README와 `docs/architecture/narrative-context.md`를 현재 structured output/recovery 정책에 맞게 갱신했습니다. Gemini API key는 query string 대신 `x-goog-api-key` header로 전달합니다.

## 책임 경계

- **서버가 결정하는 사실:** action resolution, Skill Check, canonical state transition, provider 응답의 구조 유효성, recovery 상한과 provider attempt 경계
- **LLM이 서술하는 내용:** 서버가 확정한 결과를 반영하는 story prose, 다음 choice 후보, 선택적 visual assets
- **LLM이 변경하면 안 되는 사실:** outcome/roll/성공·실패, HP·능력치·아이템·레벨·위치·생사 등 서버가 state change로 확정하지 않은 canonical 사실

## 어떻게 검증했나요?

- [x] PR 작성 전 변경 diff를 비판적으로 검토하고 타당한 지적을 반영했습니다.
- [x] `./gradlew clean test`
- [x] `./gradlew postgresIntegrationTest`
- [ ] `./gradlew build`
- [x] `cd frontend && npm ci && npm test && npm run lint && npm run build`
- [ ] 정상 흐름을 직접 확인했습니다.
- [x] 잘못된 입력/실패 흐름을 확인했습니다.
- [x] 중복 요청 또는 상태 전이가 관련되면 이를 검증했습니다.

GitHub Actions CI #189에서 `./gradlew clean test`, `./gradlew postgresIntegrationTest`, `./gradlew build -x test`, frontend `npm ci`/`npm test`/`npm run lint`/`npm run build`가 모두 성공했습니다. CI의 backend build 명령은 정확히 `./gradlew build -x test`이므로 `./gradlew build` 체크박스는 실행 근거 부족으로 남겨둡니다. 직접 수동 정상 흐름 smoke는 수행하지 않았습니다.

PR 전 추가한 deterministic test는 structured schema 요청, 정상 parse, missing/duplicate/malformed 거부, repair reason 전달, recovery 정상/1회 repair/3회 소진, retry guard 실패와 hard failure attempt count, recovery 소진 시 opening 미저장을 검증합니다.

비판적 자체 리뷰에서 다음 지적을 발견하고 PR 작성 전에 반영했습니다.

1. 최초 초안이 SDK-style snake_case 필드를 REST body에 사용하고 있었습니다. Google 공식 `generateContent` REST 예시를 대조해 `responseMimeType` / `responseSchema` wire contract로 정정했습니다.
2. 기존 adapter는 API key를 query string에 포함했습니다. provider 경계를 수정하는 이번 작업에서 공식 `x-goog-api-key` header 방식으로 이동해 URL/진단 경로 노출 가능성을 줄였습니다.
3. 최초 구현에서 `GameService`가 기능 변경보다 크게 재포맷되어 review noise가 발생했습니다. 기존 formatting을 복원하고 recovery orchestration 변경만 남겼습니다.
4. README와 architecture 문서가 #35를 미래 작업으로 설명하고 있었습니다. 실제 구현 정책, max attempt/backoff, stale-owner fencing, raw-response 비기록 경계를 문서와 동기화했습니다.
5. CI 검증 중 recovery backoff index가 첫 retry에서 0ms를 반환하는 off-by-one을 발견했습니다. 테스트 기대값을 낮추지 않고 production 구현을 수정해 첫 retry 50ms, 두 번째 retry 150ms가 되도록 반영했습니다.

## 게임 상태·AI 안전성

- [x] 게임의 결정적 상태는 서버에서 검증·저장됩니다.
- [x] LLM 출력만으로 HP, 보상, 성공/실패 등 결정적 상태가 임의 변경되지 않습니다.
- [x] AI 요청에 필요한 최소 문맥만 전달합니다.
- [x] AI 응답 파싱 실패와 provider 오류가 게임 상태를 오염시키지 않습니다.
- [x] 기존 저장 데이터 또는 GameState 호환성 영향을 확인했습니다.

DB/GameState schema 변경은 없고 provider JSON은 `provider/gemini` 내부에서만 해석합니다. recovery failure가 persistence 전에 종료되는 회귀 테스트가 CI에서 통과했습니다.

## 보안·비용

- [x] API Key, 토큰, 비밀번호가 코드·로그·URL·클라이언트 응답에 노출되지 않습니다.
- [x] 외부 AI/Image 호출 횟수와 실패 시 동작을 검토했습니다.
- [x] 사용자 입력 길이와 외부 API 비용 증가 가능성을 검토했습니다.
- [x] CORS 또는 공개 endpoint 변경이 있다면 의도된 변경입니다.

Gemini recovery는 최대 3 provider attempt로 제한되고 telemetry의 `retryCount` / `attemptCount` 및 기존 usage ledger에 반영됩니다. progress recovery마다 reservation의 `provider_attempt_count` 상한과 owner를 다시 확인합니다. CORS/public endpoint 변경은 없습니다.

## API·DB·운영 영향

- [x] API 계약 변경 시 Frontend 호출부와 문서를 함께 갱신했습니다.
- [x] DB schema 변경 시 migration 전략을 포함했습니다.
- [x] 환경변수는 이름과 용도만 문서화했고 실제 Secret은 포함하지 않았습니다.
- [x] 배포 후 확인할 smoke test가 있습니다.

외부 UCTale API/DB schema 변경이 없어 migration은 필요하지 않습니다. 기존 production smoke를 그대로 사용합니다.

## 화면 / 응답 예시

UI/API wire response 변경은 없습니다. invalid Gemini payload는 더 이상 placeholder narrative로 보정되지 않고 bounded recovery 후 기존 `PROVIDER_RESPONSE_INVALID` 실패 경계로 종료됩니다.
