### PR TITLE
refactor(ai): Gemini 모델 설정과 버전 호환 경계 정리

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ snapshot JSON은 schema/ruleset version을 가지며 legacy production snapshot�
 - `game_log`는 progress turn의 `canonical_result_id` / `generated_story_id`와 선택적 Skill Check audit 필드를 기록합니다. legacy/opening 행은 Skill Check 필드가 모두 비어 있을 수 있습니다.
 - provider failure 시 canonical turn은 진행하지 않으며 같은 idempotent 요청은 reservation에 저장된 Skill Check 판정과 동일 canonical result link를 재사용합니다.
 - Gemini `generateContent`는 JSON response schema를 사용하고 adapter가 필수 필드, 길이, choice 수/ID를 다시 검증합니다. 구조 오류는 최대 3 provider attempt의 bounded recovery를 거치며 raw 응답 전문은 진단 로그에 남기지 않습니다.
+- Narrative model은 설정 기반 stable Flash ID를 사용하며 기본값은 `gemini-3.7-flash`입니다. opening/progress thinking level과 2.5 rollback compatibility는 provider adapter 내부에서 처리합니다.
 
 Story Memory projection/token budget 전면 개선은 #46 범위입니다.
 
@@ -153,6 +154,7 @@ M2의 턴 무결성·복구 구현 범위와 완료 조건은 main에 반영되�
 - PostgreSQL `provider_usage_event` ledger로 일/월 provider 사용량을 누적합니다.
 - warning/critical budget threshold와 선택적 `FAIL_CLOSED` 정책을 지원합니다.
 - provider 호출마다 provider, model, operation, session, turn, request ID, latency, outcome, retry/attempt 수를 구조화 로그로 기록합니다.
+- Gemini provider attempt는 model/thinking level과 prompt/candidate/thought/total token usage를 별도 구조화 로그로 기록합니다.
 - prompt/응답 전문, 비밀번호, API key, access/owner token은 관측 로그에 남기지 않습니다.
 
 ### 프론트엔드 UX
@@ -176,7 +178,7 @@ M2의 턴 무결성·복구 구현 범위와 완료 조건은 main에 반영되�
 | Backend | Java 21, Spring Boot 4.1, Spring Web MVC, Spring Data JPA |
 | Database | PostgreSQL, Flyway |
 | Test Database | H2 + Testcontainers PostgreSQL 17.6 |
-| Narrative AI | Google Gemini 2.5 Flash |
+| Narrative AI | Google Gemini 3.7 Flash |
 | Image AI | Pollinations |
 | Deployment | Vercel, Render |
 
@@ -204,6 +206,7 @@ uctale/
 - [Action Resolution](./docs/architecture/action-resolution.md)
 - [Skill Check turn integration](./docs/architecture/skill-check-turn.md)
 - [GameResult 기반 NarrativeContext](./docs/architecture/narrative-context.md)
+- [Gemini Narrative provider](./docs/architecture/gemini-narrative-provider.md)
 - [GameState / Story Memory](./docs/architecture/game-state-story-memory.md)
 - [Game mutation idempotency](./docs/architecture/game-mutation-idempotency.md)
 - [Turn reservation lease](./docs/architecture/game-turn-reservation.md)
@@ -231,6 +234,9 @@ uctale/
 
 ```env
 GOOGLE_AI_API_KEY=...
+GOOGLE_AI_MODEL=gemini-3.7-flash
+GOOGLE_AI_THINKING_OPENING=medium
+GOOGLE_AI_THINKING_PROGRESS=low
 POLLINATIONS_TOKEN=...
 GAME_ACCESS_PASSWORD=...
 GAME_ACCESS_SESSION_SECRET=32자 이상의 충분히 긴 임의 문자열
@@ -331,6 +337,6 @@ GitHub Actions CI도 backend unit test → PostgreSQL integration test → backe
 
 진행 중.
 
-현재 #33 `AvailableAction` / `PlayerAction`, #34 `ActionResolver` / `GameResult`, #36 확정 결과 기반 `NarrativeContext`, #7 typed `CharacterStats` / pure Skill Check 규칙에 더해 #37 Skill Check turn 통합·감사 저장과 #38 능력치·Skill Check 결과 frontend projection, #35 Gemini structured output 검증과 bounded recovery가 반영됩니다.
+현재 #33 `AvailableAction` / `PlayerAction`, #34 `ActionResolver` / `GameResult`, #36 확정 결과 기반 `NarrativeContext`, #7 typed `CharacterStats` / pure Skill Check 규칙에 더해 #37 Skill Check turn 통합·감사 저장과 #38 능력치·Skill Check 결과 frontend projection, #35 Gemini structured output 검증과 bounded recovery, #49 Gemini 3.7 Flash 설정 기반 마이그레이션이 반영됩니다.
 
 아직 구현되지 않은 전투·인벤토리·퀘스트·NPC 관계 기능은 현재 기능처럼 문서에 표시하지 않습니다.

--- a/docs/architecture/cost-controls.md
+++ b/docs/architecture/cost-controls.md
@@ -109,7 +109,9 @@ provider 호출마다 다음 항목을 구조화 로그로 기록합니다.
 
 사용자 world/character/action, provider prompt/응답 전문, access/owner token, API key는 로그에 기록하지 않습니다.
 
-Narrative는 현재 provider 내부 retry가 없어 `retryCount=0`입니다. Image는 Pollinations bounded retry의 실제 횟수를 성공 결과 또는 최종 실패에서 추출해 같은 `provider_call` event에 기록합니다. 이미지별 model/size/seed/status 등 상세 진단은 `image_provider_result` event를 사용합니다.
+Narrative bounded recovery는 같은 logical call 안의 실제 Gemini provider attempt 수를 `retryCount`/`attemptCount`에 반영합니다. `provider_call.model`은 `GOOGLE_AI_MODEL` 설정과 동일한 model ID를 기록합니다. Gemini adapter는 각 provider attempt의 별도 `gemini_provider_result` 로그에 model, thinking level, latency, outcome과 provider가 반환한 prompt/candidate/thought/total token usage를 기록합니다. 토큰 메타데이터가 없거나 provider 호출 자체가 실패한 경우 해당 token 값은 비어 있을 수 있습니다. prompt/story 전문은 기록하지 않습니다.
+
+Image는 Pollinations bounded retry의 실제 횟수를 성공 결과 또는 최종 실패에서 추출해 같은 `provider_call` event에 기록합니다. 이미지별 model/size/seed/status 등 상세 진단은 `image_provider_result` event를 사용합니다.
 
 ## 책임 경계
 
@@ -118,5 +120,6 @@ Narrative는 현재 provider 내부 retry가 없어 `retryCount=0`입니다. Ima
 - Global budget guard: PostgreSQL usage ledger를 기준으로 UTC 일/월 provider 사용량과 warning/critical 정책을 관리합니다.
 - Turn provider attempt: `game_turn_reservation.provider_attempt_count`가 같은 canonical turn의 실제 Narrative provider 시작을 최대 3회로 제한합니다. 이는 전역 budget ledger와 별개의 무결성 경계입니다.
 - Narrative: `GameService`가 소유권/turn/action/rate limit을 확인하고 budget guard와 provider attempt 시작 경계를 통과한 호출만 Gemini telemetry로 감쌉니다.
+- Gemini adapter: model/thinking compatibility와 provider usage metadata 관측만 소유하며 canonical game state를 변경하지 않습니다.
 - Image: `ImageAssetService`가 asset 소유권과 기존 생성 결과를 먼저 확인하고 미생성 asset에 대해서만 rate limit과 provider 호출을 수행합니다.
 - DB에 저장된 이미지 재조회는 provider를 호출하지 않으므로 Image quota와 global budget unit을 소비하지 않습니다.

--- a/docs/architecture/gemini-narrative-provider.md
+++ b/docs/architecture/gemini-narrative-provider.md
@@ -23,10 +23,11 @@ UCTale의 Narrative provider 모델 버전을 game domain이나 `NarrativeGenera
 
 `GeminiProviderSettings`가 모델 버전과 REST request 차이를 adapter 내부에서 흡수합니다.
 
-- Gemini 3 이상 stable Flash: `generationConfig.thinkingConfig.thinkingLevel` 사용
+- 검증된 Gemini 3.x stable Flash: `generationConfig.thinkingConfig.thinkingLevel` 사용
 - Gemini 2.5 Flash rollback: legacy `thinkingBudget` 사용
-- 향후 stable Flash major version이 동일 generateContent 계약을 유지하면 설정 변경만으로 전환 가능
-- 계약이 바뀌는 모델은 `GeminiProviderSettings` / `GeminiNarrativeAdapter` 내부에서만 호환 처리를 추가하며 game domain과 `NarrativeGenerator` port는 변경하지 않음
+- 같은 Gemini 3.x 계약 안의 stable Flash 교체는 설정 변경만으로 가능
+- 아직 검증하지 않은 새 major version은 동일 계약이라고 추측하지 않고 startup에서 거부하며, 공식 계약을 확인한 뒤 provider compatibility boundary만 갱신함
+- 계약이 바뀌는 모델도 `GeminiProviderSettings` / `GeminiNarrativeAdapter` 내부에서만 호환 처리를 추가하며 game domain과 `NarrativeGenerator` port는 변경하지 않음
 
 Gemini 2.5 rollback의 `low` / `medium` / `high`는 Google이 제공하는 동일 이름의 직접 매핑이 아닙니다. UCTALE compatibility policy로 다음 budget을 사용합니다.
 

--- a/docs/architecture/gemini-narrative-provider.md
+++ b/docs/architecture/gemini-narrative-provider.md
@@ -1,0 +1,88 @@
+# Gemini Narrative provider 설정과 버전 호환 경계
+
+## 목적
+
+UCTale의 Narrative provider 모델 버전을 game domain이나 `NarrativeGenerator` port에 노출하지 않고 provider adapter 설정으로 관리합니다.
+
+현재 production 기본 모델은 `gemini-3.7-flash`입니다. 2026-09-01 기준 Google 공식 문서에서 GA stable이며 production-ready Flash로 안내되고, structured outputs와 `low` / `medium` / `high` thinking level을 지원합니다.
+
+모델 선택 근거와 당시 가격은 구현 PR에 기록합니다. 이 문서는 현재 runtime 계약을 설명하며 별도 자체 benchmark 결과를 주장하지 않습니다.
+
+## 설정
+
+`application.properties`의 기본값은 다음 환경변수로 override할 수 있습니다.
+
+- `GOOGLE_AI_MODEL`: 명시적인 stable Flash model ID. 기본 `gemini-3.7-flash`
+- `GOOGLE_AI_THINKING_OPENING`: opening thinking level. 기본 `medium`
+- `GOOGLE_AI_THINKING_PROGRESS`: progress thinking level. 기본 `low`
+- `GOOGLE_AI_API_KEY`: Gemini API key
+
+`latest`, preview, experimental alias는 production 설정으로 허용하지 않습니다. 모델 ID는 `gemini-{major}.{minor}-flash` 형태의 명시적인 stable Flash ID만 허용합니다.
+
+## compatibility boundary
+
+`GeminiProviderSettings`가 모델 버전과 REST request 차이를 adapter 내부에서 흡수합니다.
+
+- Gemini 3 이상 stable Flash: `generationConfig.thinkingConfig.thinkingLevel` 사용
+- Gemini 2.5 Flash rollback: legacy `thinkingBudget` 사용
+- 향후 stable Flash major version이 동일 generateContent 계약을 유지하면 설정 변경만으로 전환 가능
+- 계약이 바뀌는 모델은 `GeminiProviderSettings` / `GeminiNarrativeAdapter` 내부에서만 호환 처리를 추가하며 game domain과 `NarrativeGenerator` port는 변경하지 않음
+
+Gemini 2.5 rollback의 `low` / `medium` / `high`는 Google이 제공하는 동일 이름의 직접 매핑이 아닙니다. UCTALE compatibility policy로 다음 budget을 사용합니다.
+
+- `low`: 1,024 tokens
+- `medium`: `-1` dynamic thinking
+- `high`: 24,576 tokens
+
+이 정책은 rollback 시 설정 인터페이스를 유지하기 위한 provider-local 변환이며 게임 규칙에는 영향을 주지 않습니다.
+
+## 요청 계약
+
+Gemini request는 다음을 유지합니다.
+
+- `generateContent` REST endpoint
+- API key는 `x-goog-api-key` header로 전달
+- `responseMimeType=application/json`
+- response schema 기반 structured output
+- opening과 progress의 thinking level 독립 적용
+- repair 요청은 원 요청과 동일한 operation thinking level 사용
+
+Narrative prompt 내용과 출력 언어 계약은 #97의 별도 범위이며 이 버전 마이그레이션에서 변경하지 않습니다.
+
+## 관측성
+
+기존 `provider_call` event는 설정된 Narrative model ID를 기록합니다. Gemini adapter는 provider attempt별 `gemini_provider_result` 구조화 로그에 다음을 추가로 기록합니다.
+
+- model
+- thinkingLevel
+- context (`opening`, `opening_repair`, `progress`, `progress_repair`)
+- latencyMs
+- outcome
+- promptTokens
+- candidatesTokens
+- thoughtsTokens
+- totalTokens
+
+토큰 수는 Gemini `usageMetadata`가 제공될 때만 기록됩니다. prompt/story 전문과 API key는 기록하지 않습니다.
+
+bounded recovery와 canonical commit 경계는 #35에서 확립한 정책을 그대로 유지합니다. 모델 설정 변경은 provider attempt 횟수나 게임 상태 저장 의미를 변경하지 않습니다.
+
+## rollback
+
+production에서 문제가 발생하면 코드 변경 없이 `GOOGLE_AI_MODEL`과 필요한 thinking 설정을 이전 stable Flash로 변경해 rollback할 수 있습니다.
+
+rollback 후에는 최소한 다음을 확인합니다.
+
+- opening 정상 생성
+- progress 정상 생성
+- structured output validation
+- invalid response bounded recovery
+- provider telemetry의 model/thinking 값
+
+## 공식 참고
+
+- Google Gemini models: https://ai.google.dev/gemini-api/docs/models
+- Gemini 3.7 Flash: https://ai.google.dev/gemini-api/docs/models/gemini-3.7-flash
+- Gemini 3.7 migration guide: https://ai.google.dev/gemini-api/docs/latest-model
+- Thinking: https://ai.google.dev/gemini-api/docs/generate-content/thinking
+- Pricing: https://ai.google.dev/gemini-api/docs/pricing

--- a/src/main/java/com/uctale/uctale/application/cost/ProviderCallTelemetry.java
+++ b/src/main/java/com/uctale/uctale/application/cost/ProviderCallTelemetry.java
@@ -14,6 +14,7 @@ public class ProviderCallTelemetry {
     private final Clock clock;
     private final ProviderCallEventSink sink;
     private final ProviderBudgetGuard budgetGuard;
+    private final String narrativeModel;
     private final String imageModel;
 
     @Autowired
@@ -21,19 +22,27 @@ public class ProviderCallTelemetry {
             Clock clock,
             ProviderCallEventSink sink,
             ProviderBudgetGuard budgetGuard,
+            @Value("${google.ai.model}") String narrativeModel,
             @Value("${game.image.model:flux}") String imageModel
     ) {
         this.clock = clock;
         this.sink = sink;
         this.budgetGuard = budgetGuard;
+        this.narrativeModel = narrativeModel;
         this.imageModel = imageModel;
     }
 
     public ProviderCallTelemetry(Clock clock, ProviderCallEventSink sink) {
-        this.clock = clock;
-        this.sink = sink;
-        this.budgetGuard = null;
-        this.imageModel = "configured";
+        this(clock, sink, null, "configured", "configured");
+    }
+
+    public ProviderCallTelemetry(
+            Clock clock,
+            ProviderCallEventSink sink,
+            ProviderBudgetGuard budgetGuard,
+            String imageModel
+    ) {
+        this(clock, sink, budgetGuard, "configured", imageModel);
     }
 
     public <T> T observe(
@@ -200,6 +209,6 @@ public class ProviderCallTelemetry {
     }
 
     private String defaultModel(String provider) {
-        return "gemini".equals(provider) ? "gemini-2.5-flash" : imageModel;
+        return "gemini".equals(provider) ? narrativeModel : imageModel;
     }
 }

--- a/src/main/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapter.java
+++ b/src/main/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapter.java
@@ -8,7 +8,7 @@ import com.uctale.uctale.application.narrative.NarrativeGenerator;
 import com.uctale.uctale.application.narrative.NarrativeTurn;
 import com.uctale.uctale.application.narrative.RecoverableNarrativeResponseException;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
@@ -23,7 +23,6 @@ import java.util.Set;
 @Component
 public class GeminiNarrativeAdapter implements NarrativeGenerator {
 
-    private static final String GEMINI_API_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent";
     private static final int MAX_TITLE_LENGTH = 200;
     private static final int MAX_STORY_LENGTH = 50_000;
     private static final int MAX_CHOICE_TEXT_LENGTH = 255;
@@ -94,31 +93,43 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
             )
     );
 
-    @Value("${google.ai.api-key}")
-    private String apiKey;
-
     private final RestClient restClient;
     private final ObjectMapper objectMapper;
+    private final GeminiProviderSettings settings;
 
-    public GeminiNarrativeAdapter(ObjectMapper objectMapper, RestClient.Builder builder) {
+    @Autowired
+    public GeminiNarrativeAdapter(
+            ObjectMapper objectMapper,
+            RestClient.Builder builder,
+            GeminiProviderSettings settings
+    ) {
         this.objectMapper = objectMapper;
         this.restClient = builder.build();
+        this.settings = settings;
     }
 
     @Override
     public NarrativeTurn createOpening(String worldSetting, String characterSetting) {
-        return generate(openingPrompt(worldSetting, characterSetting), "opening");
+        return generate(
+                openingPrompt(worldSetting, characterSetting),
+                "opening",
+                settings.openingThinkingLevel()
+        );
     }
 
     @Override
     public NarrativeTurn repairOpening(String worldSetting, String characterSetting, String reasonCode) {
-        return generate(openingPrompt(worldSetting, characterSetting) + recoveryInstruction(reasonCode), "opening_repair");
+        return generate(
+                openingPrompt(worldSetting, characterSetting) + recoveryInstruction(reasonCode),
+                "opening_repair",
+                settings.openingThinkingLevel()
+        );
     }
 
     @Override
     public NarrativeTurn createNextTurn(NarrativeContext context) {
         try {
-            return generate(buildProgressPrompt(context), "progress");
+            return generate(buildProgressPrompt(context), "progress", settings.progressThinkingLevel());
         } catch (JacksonException exception) {
             throw new IllegalStateException("Narrative progress prompt 직렬화에 실패했습니다.", exception);
         }
@@ -127,7 +138,11 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
     @Override
     public NarrativeTurn repairNextTurn(NarrativeContext context, String reasonCode) {
         try {
-            return generate(buildProgressPrompt(context) + recoveryInstruction(reasonCode), "progress_repair");
+            return generate(
+                    buildProgressPrompt(context) + recoveryInstruction(reasonCode),
+                    "progress_repair",
+                    settings.progressThinkingLevel()
+            );
         } catch (JacksonException exception) {
             throw new IllegalStateException("Narrative recovery prompt 직렬화에 실패했습니다.", exception);
         }
@@ -208,12 +223,18 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
         );
     }
 
-    private NarrativeTurn generate(String prompt, String errorContext) {
+    private NarrativeTurn generate(
+            String prompt,
+            String errorContext,
+            GeminiProviderSettings.ThinkingLevel thinkingLevel
+    ) {
+        long startedAt = System.nanoTime();
+        TokenUsage tokenUsage = TokenUsage.empty();
         try {
-            String requestBody = createRequestBody(prompt);
+            String requestBody = createRequestBody(prompt, thinkingLevel);
             String response = restClient.post()
-                    .uri(GEMINI_API_URL)
-                    .header("x-goog-api-key", apiKey)
+                    .uri(settings.generateContentUrl())
+                    .header("x-goog-api-key", settings.apiKey())
                     .contentType(MediaType.APPLICATION_JSON)
                     .body(requestBody)
                     .retrieve()
@@ -221,24 +242,34 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
             if (response == null || response.isBlank()) {
                 throw recoverable("EMPTY_RESPONSE", "Gemini 응답 body가 비어 있습니다.", null);
             }
-            return parseResponse(response);
+            tokenUsage = readTokenUsage(response);
+            NarrativeTurn turn = parseResponse(response);
+            logProviderResult(errorContext, thinkingLevel, tokenUsage, startedAt, "SUCCESS");
+            return turn;
         } catch (RecoverableNarrativeResponseException exception) {
+            logProviderResult(errorContext, thinkingLevel, tokenUsage, startedAt, "INVALID_RESPONSE");
             log.warn("gemini_response_invalid context={} reason={}", errorContext, exception.reasonCode());
             throw exception;
         } catch (JacksonException exception) {
+            logProviderResult(errorContext, thinkingLevel, tokenUsage, startedAt, "REQUEST_SERIALIZATION_FAILURE");
             throw new IllegalStateException("Gemini 요청 직렬화에 실패했습니다.", exception);
         } catch (RuntimeException exception) {
+            logProviderResult(errorContext, thinkingLevel, tokenUsage, startedAt, "PROVIDER_FAILURE");
             log.error("Gemini provider 호출 실패 context={} error={}", errorContext, exception.getClass().getSimpleName());
             throw exception;
         }
     }
 
-    String createRequestBody(String userPrompt) throws JacksonException {
+    String createRequestBody(
+            String userPrompt,
+            GeminiProviderSettings.ThinkingLevel thinkingLevel
+    ) throws JacksonException {
         Map<String, Object> requestMap = Map.of(
                 "contents", List.of(Map.of("parts", List.of(Map.of("text", SYSTEM_INSTRUCTION + "\n\n" + userPrompt)))),
                 "generationConfig", Map.of(
                         "responseMimeType", "application/json",
-                        "responseSchema", RESPONSE_SCHEMA
+                        "responseSchema", RESPONSE_SCHEMA,
+                        "thinkingConfig", settings.thinkingConfig(thinkingLevel)
                 )
         );
         return objectMapper.writeValueAsString(requestMap);
@@ -266,6 +297,54 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
         } catch (JacksonException exception) {
             throw recoverable("MALFORMED_JSON", "Gemini JSON을 파싱할 수 없습니다.", exception);
         }
+    }
+
+    private TokenUsage readTokenUsage(String rawResponse) {
+        try {
+            JsonNode root = objectMapper.readTree(rawResponse);
+            JsonNode usage = root == null ? null : root.get("usageMetadata");
+            if (usage == null || !usage.isObject()) {
+                return TokenUsage.empty();
+            }
+            return new TokenUsage(
+                    optionalNonNegativeInt(usage.get("promptTokenCount")),
+                    optionalNonNegativeInt(usage.get("candidatesTokenCount")),
+                    optionalNonNegativeInt(usage.get("thoughtsTokenCount")),
+                    optionalNonNegativeInt(usage.get("totalTokenCount"))
+            );
+        } catch (JacksonException ignored) {
+            return TokenUsage.empty();
+        }
+    }
+
+    private Integer optionalNonNegativeInt(JsonNode node) {
+        if (node == null || !node.isIntegralNumber() || !node.canConvertToInt()) {
+            return null;
+        }
+        int value = node.intValue();
+        return value < 0 ? null : value;
+    }
+
+    private void logProviderResult(
+            String context,
+            GeminiProviderSettings.ThinkingLevel thinkingLevel,
+            TokenUsage usage,
+            long startedAt,
+            String outcome
+    ) {
+        long latencyMs = Math.max(0L, (System.nanoTime() - startedAt) / 1_000_000L);
+        log.info(
+                "gemini_provider_result model={} thinkingLevel={} context={} latencyMs={} outcome={} promptTokens={} candidatesTokens={} thoughtsTokens={} totalTokens={}",
+                settings.modelId(),
+                thinkingLevel.apiValue(),
+                context,
+                latencyMs,
+                outcome,
+                usage.promptTokenCount(),
+                usage.candidatesTokenCount(),
+                usage.thoughtsTokenCount(),
+                usage.totalTokenCount()
+        );
     }
 
     private NarrativeTurn mapNarrative(JsonNode rootNode) {
@@ -387,4 +466,15 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
     private record Candidate(Content content) {}
     private record Content(List<Part> parts) {}
     private record Part(String text) {}
+
+    private record TokenUsage(
+            Integer promptTokenCount,
+            Integer candidatesTokenCount,
+            Integer thoughtsTokenCount,
+            Integer totalTokenCount
+    ) {
+        private static TokenUsage empty() {
+            return new TokenUsage(null, null, null, null);
+        }
+    }
 }

--- a/src/main/java/com/uctale/uctale/provider/gemini/GeminiProviderSettings.java
+++ b/src/main/java/com/uctale/uctale/provider/gemini/GeminiProviderSettings.java
@@ -75,7 +75,7 @@ public final class GeminiProviderSettings {
     }
 
     private boolean supportsConfiguredThinkingContract() {
-        return (modelMajor == 2 && modelMinor == 5) || modelMajor >= 3;
+        return (modelMajor == 2 && modelMinor == 5) || modelMajor == 3;
     }
 
     private String requireNonBlank(String value, String label) {

--- a/src/main/java/com/uctale/uctale/provider/gemini/GeminiProviderSettings.java
+++ b/src/main/java/com/uctale/uctale/provider/gemini/GeminiProviderSettings.java
@@ -1,0 +1,123 @@
+package com.uctale.uctale.provider.gemini;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+public final class GeminiProviderSettings {
+
+    private static final Pattern STABLE_FLASH_MODEL = Pattern.compile("^gemini-(\\d+)\\.(\\d+)-flash$");
+    private static final String GENERATE_CONTENT_URL =
+            "https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent";
+
+    private final String apiKey;
+    private final String modelId;
+    private final int modelMajor;
+    private final int modelMinor;
+    private final ThinkingLevel openingThinkingLevel;
+    private final ThinkingLevel progressThinkingLevel;
+
+    public GeminiProviderSettings(
+            @Value("${google.ai.api-key}") String apiKey,
+            @Value("${google.ai.model}") String modelId,
+            @Value("${google.ai.thinking.opening}") String openingThinkingLevel,
+            @Value("${google.ai.thinking.progress}") String progressThinkingLevel
+    ) {
+        this.apiKey = requireNonBlank(apiKey, "Gemini API key");
+        this.modelId = requireNonBlank(modelId, "Gemini model ID");
+
+        Matcher matcher = STABLE_FLASH_MODEL.matcher(this.modelId);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException(
+                    "Gemini Narrative 모델은 명시적인 stable Flash model ID여야 합니다: " + this.modelId
+            );
+        }
+        this.modelMajor = Integer.parseInt(matcher.group(1));
+        this.modelMinor = Integer.parseInt(matcher.group(2));
+        if (!supportsConfiguredThinkingContract()) {
+            throw new IllegalArgumentException("지원하지 않는 Gemini Narrative model family입니다: " + this.modelId);
+        }
+
+        this.openingThinkingLevel = ThinkingLevel.parse(openingThinkingLevel, "opening");
+        this.progressThinkingLevel = ThinkingLevel.parse(progressThinkingLevel, "progress");
+    }
+
+    String apiKey() {
+        return apiKey;
+    }
+
+    public String modelId() {
+        return modelId;
+    }
+
+    String generateContentUrl() {
+        return GENERATE_CONTENT_URL.formatted(modelId);
+    }
+
+    ThinkingLevel openingThinkingLevel() {
+        return openingThinkingLevel;
+    }
+
+    ThinkingLevel progressThinkingLevel() {
+        return progressThinkingLevel;
+    }
+
+    Map<String, Object> thinkingConfig(ThinkingLevel level) {
+        if (modelMajor == 2 && modelMinor == 5) {
+            return Map.of("thinkingBudget", level.legacyThinkingBudget());
+        }
+        return Map.of("thinkingLevel", level.apiValue());
+    }
+
+    private boolean supportsConfiguredThinkingContract() {
+        return (modelMajor == 2 && modelMinor == 5) || modelMajor == 3;
+    }
+
+    private String requireNonBlank(String value, String label) {
+        String normalized = value == null ? "" : value.trim();
+        if (normalized.isBlank()) {
+            throw new IllegalArgumentException(label + "가 비어 있습니다.");
+        }
+        return normalized;
+    }
+
+    enum ThinkingLevel {
+        LOW("low", 1_024),
+        MEDIUM("medium", 8_192),
+        HIGH("high", 24_576);
+
+        private final String apiValue;
+        private final int legacyThinkingBudget;
+
+        ThinkingLevel(String apiValue, int legacyThinkingBudget) {
+            this.apiValue = apiValue;
+            this.legacyThinkingBudget = legacyThinkingBudget;
+        }
+
+        String apiValue() {
+            return apiValue;
+        }
+
+        int legacyThinkingBudget() {
+            return legacyThinkingBudget;
+        }
+
+        static ThinkingLevel parse(String value, String operation) {
+            String normalized = value == null ? "" : value.trim().toLowerCase(Locale.ROOT);
+            for (ThinkingLevel level : values()) {
+                if (level.apiValue.equals(normalized)) {
+                    return level;
+                }
+            }
+            throw new IllegalArgumentException(
+                    "지원하지 않는 Gemini " + operation + " thinking level입니다: " + normalized
+                            + " (allowed: low, medium, high)"
+            );
+        }
+    }
+}

--- a/src/main/java/com/uctale/uctale/provider/gemini/GeminiProviderSettings.java
+++ b/src/main/java/com/uctale/uctale/provider/gemini/GeminiProviderSettings.java
@@ -75,7 +75,7 @@ public final class GeminiProviderSettings {
     }
 
     private boolean supportsConfiguredThinkingContract() {
-        return (modelMajor == 2 && modelMinor == 5) || modelMajor == 3;
+        return (modelMajor == 2 && modelMinor == 5) || modelMajor >= 3;
     }
 
     private String requireNonBlank(String value, String label) {
@@ -88,7 +88,7 @@ public final class GeminiProviderSettings {
 
     enum ThinkingLevel {
         LOW("low", 1_024),
-        MEDIUM("medium", 8_192),
+        MEDIUM("medium", -1),
         HIGH("high", 24_576);
 
         private final String apiValue;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,9 @@
 spring.application.name=uctale
 
 google.ai.api-key=${GOOGLE_AI_API_KEY}
+google.ai.model=${GOOGLE_AI_MODEL:gemini-3.7-flash}
+google.ai.thinking.opening=${GOOGLE_AI_THINKING_OPENING:medium}
+google.ai.thinking.progress=${GOOGLE_AI_THINKING_PROGRESS:low}
 pollinations.token=${POLLINATIONS_TOKEN}
 game.access.password=${GAME_ACCESS_PASSWORD}
 game.access.session-secret=${GAME_ACCESS_SESSION_SECRET}

--- a/src/test/java/com/uctale/uctale/application/cost/ProviderCallTelemetryTest.java
+++ b/src/test/java/com/uctale/uctale/application/cost/ProviderCallTelemetryTest.java
@@ -49,6 +49,28 @@ class ProviderCallTelemetryTest {
     }
 
     @Test
+    @DisplayName("Gemini telemetry는 application 설정의 Narrative model ID를 기록한다")
+    void geminiModel_ComesFromApplicationConfiguration() {
+        MutableClock clock = new MutableClock(Instant.parse("2026-08-30T06:00:00Z"));
+        List<ProviderCallEvent> events = new ArrayList<>();
+        ProviderCallTelemetry telemetry = new ProviderCallTelemetry(
+                clock, events::add, null, "gemini-3.7-flash", "flux"
+        );
+
+        telemetry.observe(
+                "gemini",
+                "opening",
+                CostRequestContext.internal("owner-a", null, 1),
+                0,
+                () -> "ok"
+        );
+
+        assertThat(events).singleElement().satisfies(event ->
+                assertThat(event.model()).isEqualTo("gemini-3.7-flash")
+        );
+    }
+
+    @Test
     @DisplayName("provider 예외도 실패 event를 남기고 원래 예외를 전달한다")
     void failure_IsRecorded() {
         MutableClock clock = new MutableClock(Instant.parse("2026-08-30T06:00:00Z"));

--- a/src/test/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapterTest.java
+++ b/src/test/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapterTest.java
@@ -67,12 +67,16 @@ class GeminiNarrativeAdapterTest {
     @DisplayName("Gemini usageMetadata의 prompt candidate thought total token을 관측값으로 읽는다")
     void readTokenUsage_UsesProviderUsageMetadata() {
         Object usage = ReflectionTestUtils.invokeMethod(adapter, "readTokenUsage", apiResponse(validNarrativeJson()));
+        Integer promptTokens = ReflectionTestUtils.invokeMethod(usage, "promptTokenCount");
+        Integer candidateTokens = ReflectionTestUtils.invokeMethod(usage, "candidatesTokenCount");
+        Integer thoughtTokens = ReflectionTestUtils.invokeMethod(usage, "thoughtsTokenCount");
+        Integer totalTokens = ReflectionTestUtils.invokeMethod(usage, "totalTokenCount");
 
         assertThat(usage).isNotNull();
-        assertThat(ReflectionTestUtils.invokeMethod(usage, "promptTokenCount")).isEqualTo(100);
-        assertThat(ReflectionTestUtils.invokeMethod(usage, "candidatesTokenCount")).isEqualTo(50);
-        assertThat(ReflectionTestUtils.invokeMethod(usage, "thoughtsTokenCount")).isEqualTo(25);
-        assertThat(ReflectionTestUtils.invokeMethod(usage, "totalTokenCount")).isEqualTo(175);
+        assertThat(promptTokens).isEqualTo(100);
+        assertThat(candidateTokens).isEqualTo(50);
+        assertThat(thoughtTokens).isEqualTo(25);
+        assertThat(totalTokens).isEqualTo(175);
     }
 
     @Test

--- a/src/test/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapterTest.java
+++ b/src/test/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapterTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestClient;
 
@@ -21,24 +20,28 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 
 class GeminiNarrativeAdapterTest {
 
+    private static final String TEST_MODEL = "gemini-3.7-flash";
+
     private GeminiNarrativeAdapter adapter;
+    private GeminiProviderSettings settings;
     private MockRestServiceServer mockServer;
 
     @BeforeEach
     void setUp() {
         RestClient.Builder builder = RestClient.builder();
         mockServer = MockRestServiceServer.bindTo(builder).build();
-        adapter = new GeminiNarrativeAdapter(new ObjectMapper(), builder);
-        ReflectionTestUtils.setField(adapter, "apiKey", "TEST_API_KEY");
+        settings = new GeminiProviderSettings("TEST_API_KEY", TEST_MODEL, "medium", "low");
+        adapter = new GeminiNarrativeAdapter(new ObjectMapper(), builder, settings);
     }
 
     @Test
-    @DisplayName("Gemini 요청은 공식 REST structured output 계약과 API key header를 사용한다")
-    void createOpening_UsesStructuredOutputSchema() {
-        mockServer.expect(requestTo(geminiUrl()))
+    @DisplayName("Gemini opening 요청은 설정 모델과 structured output, opening thinking level을 사용한다")
+    void createOpening_UsesConfiguredModelStructuredOutputAndThinkingLevel() {
+        mockServer.expect(requestTo(settings.generateContentUrl()))
                 .andExpect(header("x-goog-api-key", "TEST_API_KEY"))
                 .andExpect(content().string(containsString("\"responseMimeType\":\"application/json\"")))
                 .andExpect(content().string(containsString("\"responseSchema\"")))
+                .andExpect(content().string(containsString("\"thinkingLevel\":\"medium\"")))
                 .andRespond(withSuccess(apiResponse(validNarrativeJson()), MediaType.APPLICATION_JSON));
 
         NarrativeTurn response = adapter.createOpening("좀비 아포칼립스", "김대리");
@@ -46,6 +49,17 @@ class GeminiNarrativeAdapterTest {
         assertThat(response.title()).isEqualTo("첫날 밤");
         assertThat(response.choices()).extracting(NarrativeTurn.Choice::text).containsExactly("도망간다");
         mockServer.verify();
+    }
+
+    @Test
+    @DisplayName("progress 설정은 opening과 독립적인 thinking level을 request contract에 반영한다")
+    void createRequestBody_UsesProgressThinkingLevel() throws Exception {
+        String requestBody = adapter.createRequestBody("진행", settings.progressThinkingLevel());
+
+        assertThat(requestBody)
+                .contains("\"thinkingConfig\"")
+                .contains("\"thinkingLevel\":\"low\"")
+                .doesNotContain("thinkingBudget");
     }
 
     @Test
@@ -79,20 +93,17 @@ class GeminiNarrativeAdapterTest {
     }
 
     @Test
-    @DisplayName("repair 요청은 raw 응답 없이 실패 분류만 prompt에 전달한다")
-    void repairOpening_UsesSafeReasonCode() {
-        mockServer.expect(requestTo(geminiUrl()))
+    @DisplayName("repair 요청은 raw 응답 없이 실패 분류와 동일 opening thinking level만 전달한다")
+    void repairOpening_UsesSafeReasonCodeAndOpeningThinkingLevel() {
+        mockServer.expect(requestTo(settings.generateContentUrl()))
                 .andExpect(header("x-goog-api-key", "TEST_API_KEY"))
                 .andExpect(content().string(containsString("[응답 수정 요청]")))
                 .andExpect(content().string(containsString("INVALID_CHOICE_ID")))
+                .andExpect(content().string(containsString("\"thinkingLevel\":\"medium\"")))
                 .andRespond(withSuccess(apiResponse(validNarrativeJson()), MediaType.APPLICATION_JSON));
 
         assertThat(adapter.repairOpening("세계", "캐릭터", "INVALID_CHOICE_ID").title()).isEqualTo("첫날 밤");
         mockServer.verify();
-    }
-
-    private String geminiUrl() {
-        return "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent";
     }
 
     private String validNarrativeJson() {
@@ -102,7 +113,8 @@ class GeminiNarrativeAdapterTest {
     private String apiResponse(String narrativeJson) {
         try {
             String escaped = new ObjectMapper().writeValueAsString(narrativeJson);
-            return "{\"candidates\":[{\"content\":{\"parts\":[{\"text\":" + escaped + "}]}}]}";
+            return "{\"candidates\":[{\"content\":{\"parts\":[{\"text\":" + escaped + "}]}}],"
+                    + "\"usageMetadata\":{\"promptTokenCount\":100,\"candidatesTokenCount\":50,\"thoughtsTokenCount\":25,\"totalTokenCount\":175}}";
         } catch (Exception exception) {
             throw new AssertionError(exception);
         }

--- a/src/test/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapterTest.java
+++ b/src/test/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapterTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestClient;
 
@@ -60,6 +61,18 @@ class GeminiNarrativeAdapterTest {
                 .contains("\"thinkingConfig\"")
                 .contains("\"thinkingLevel\":\"low\"")
                 .doesNotContain("thinkingBudget");
+    }
+
+    @Test
+    @DisplayName("Gemini usageMetadata의 prompt candidate thought total token을 관측값으로 읽는다")
+    void readTokenUsage_UsesProviderUsageMetadata() {
+        Object usage = ReflectionTestUtils.invokeMethod(adapter, "readTokenUsage", apiResponse(validNarrativeJson()));
+
+        assertThat(usage).isNotNull();
+        assertThat(ReflectionTestUtils.invokeMethod(usage, "promptTokenCount")).isEqualTo(100);
+        assertThat(ReflectionTestUtils.invokeMethod(usage, "candidatesTokenCount")).isEqualTo(50);
+        assertThat(ReflectionTestUtils.invokeMethod(usage, "thoughtsTokenCount")).isEqualTo(25);
+        assertThat(ReflectionTestUtils.invokeMethod(usage, "totalTokenCount")).isEqualTo(175);
     }
 
     @Test

--- a/src/test/java/com/uctale/uctale/provider/gemini/GeminiPromptContractTest.java
+++ b/src/test/java/com/uctale/uctale/provider/gemini/GeminiPromptContractTest.java
@@ -21,7 +21,7 @@ class GeminiPromptContractTest {
     @Test
     @DisplayName("progress prompt는 확정 결과/상태/금지 mutation/cues를 분리하고 action token을 노출하지 않는다")
     void buildProgressPrompt_UsesCanonicalContractWithoutActionToken() throws Exception {
-        GeminiNarrativeAdapter adapter = new GeminiNarrativeAdapter(new ObjectMapper(), RestClient.builder());
+        GeminiNarrativeAdapter adapter = adapter();
         GameState state = GameState.initial("폐허 도시", "정찰자", "오프닝");
         PlayerAction action = new PlayerAction(
                 7,
@@ -49,7 +49,7 @@ class GeminiPromptContractTest {
     @Test
     @DisplayName("Skill Check prompt는 서버가 확정한 roll modifier DC total outcome을 그대로 전달한다")
     void buildProgressPrompt_IncludesCanonicalSkillCheckResult() throws Exception {
-        GeminiNarrativeAdapter adapter = new GeminiNarrativeAdapter(new ObjectMapper(), RestClient.builder());
+        GeminiNarrativeAdapter adapter = adapter();
         GameState state = GameState.initial("폐허 도시", "정찰자", "오프닝");
         PlayerAction action = new PlayerAction(
                 7,
@@ -83,5 +83,13 @@ class GeminiPromptContractTest {
                 .contains("\"total\":10")
                 .contains("\"outcome\":\"SUCCESS\"")
                 .doesNotContain("SERVER_ONLY_SKILL_TOKEN");
+    }
+
+    private GeminiNarrativeAdapter adapter() {
+        return new GeminiNarrativeAdapter(
+                new ObjectMapper(),
+                RestClient.builder(),
+                new GeminiProviderSettings("TEST_API_KEY", "gemini-3.7-flash", "medium", "low")
+        );
     }
 }

--- a/src/test/java/com/uctale/uctale/provider/gemini/GeminiProviderSettingsTest.java
+++ b/src/test/java/com/uctale/uctale/provider/gemini/GeminiProviderSettingsTest.java
@@ -1,0 +1,70 @@
+package com.uctale.uctale.provider.gemini;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GeminiProviderSettingsTest {
+
+    @Test
+    @DisplayName("Gemini 3 stable Flash는 model URL과 thinkingLevel 계약을 설정에서 만든다")
+    void gemini3Stable_UsesThinkingLevel() {
+        GeminiProviderSettings settings = new GeminiProviderSettings(
+                "key", "gemini-3.7-flash", "medium", "low"
+        );
+
+        assertThat(settings.modelId()).isEqualTo("gemini-3.7-flash");
+        assertThat(settings.generateContentUrl()).endsWith("/models/gemini-3.7-flash:generateContent");
+        assertThat(settings.thinkingConfig(settings.openingThinkingLevel()))
+                .containsEntry("thinkingLevel", "medium")
+                .doesNotContainKey("thinkingBudget");
+        assertThat(settings.thinkingConfig(settings.progressThinkingLevel()))
+                .containsEntry("thinkingLevel", "low");
+    }
+
+    @Test
+    @DisplayName("Gemini 2.5 rollback은 legacy thinkingBudget 경계에서 호환한다")
+    void gemini25Stable_UsesLegacyThinkingBudget() {
+        GeminiProviderSettings settings = new GeminiProviderSettings(
+                "key", "gemini-2.5-flash", "medium", "low"
+        );
+
+        assertThat(settings.thinkingConfig(settings.openingThinkingLevel()))
+                .containsEntry("thinkingBudget", -1)
+                .doesNotContainKey("thinkingLevel");
+        assertThat(settings.thinkingConfig(settings.progressThinkingLevel()))
+                .containsEntry("thinkingBudget", 1_024);
+    }
+
+    @Test
+    @DisplayName("향후 stable Flash major version도 동일 compatibility boundary에서 thinkingLevel을 사용한다")
+    void futureStableFlash_UsesThinkingLevelBoundary() {
+        GeminiProviderSettings settings = new GeminiProviderSettings(
+                "key", "gemini-4.0-flash", "high", "medium"
+        );
+
+        assertThat(settings.thinkingConfig(settings.openingThinkingLevel()))
+                .containsEntry("thinkingLevel", "high");
+    }
+
+    @Test
+    @DisplayName("latest preview experimental alias는 production model 설정으로 거부한다")
+    void unstableAliases_AreRejected() {
+        assertThatThrownBy(() -> new GeminiProviderSettings("key", "gemini-flash-latest", "medium", "low"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("stable Flash model ID");
+        assertThatThrownBy(() -> new GeminiProviderSettings("key", "gemini-3.7-flash-preview", "medium", "low"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("stable Flash model ID");
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 thinking level은 시작 시 fail-fast 한다")
+    void unsupportedThinkingLevel_IsRejected() {
+        assertThatThrownBy(() -> new GeminiProviderSettings("key", "gemini-3.7-flash", "minimal", "low"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("allowed: low, medium, high");
+    }
+}

--- a/src/test/java/com/uctale/uctale/provider/gemini/GeminiProviderSettingsTest.java
+++ b/src/test/java/com/uctale/uctale/provider/gemini/GeminiProviderSettingsTest.java
@@ -39,14 +39,11 @@ class GeminiProviderSettingsTest {
     }
 
     @Test
-    @DisplayName("향후 stable Flash major version도 동일 compatibility boundary에서 thinkingLevel을 사용한다")
-    void futureStableFlash_UsesThinkingLevelBoundary() {
-        GeminiProviderSettings settings = new GeminiProviderSettings(
-                "key", "gemini-4.0-flash", "high", "medium"
-        );
-
-        assertThat(settings.thinkingConfig(settings.openingThinkingLevel()))
-                .containsEntry("thinkingLevel", "high");
+    @DisplayName("검증하지 않은 future major Flash는 자동 호환한다고 가정하지 않는다")
+    void unreviewedFutureMajor_IsRejected() {
+        assertThatThrownBy(() -> new GeminiProviderSettings("key", "gemini-4.0-flash", "high", "medium"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("지원하지 않는 Gemini Narrative model family");
     }
 
     @Test

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,4 +1,7 @@
 google.ai.api-key=TEST_API_KEY
+google.ai.model=gemini-3.7-flash
+google.ai.thinking.opening=medium
+google.ai.thinking.progress=low
 pollinations.token=TEST_TOKEN
 game.access.password=TEST_PASSWORD
 game.access.session-secret=TEST_SESSION_SECRET_0123456789_0123456789


### PR DESCRIPTION
## 왜 필요한가요?

현재 `GeminiNarrativeAdapter`와 provider telemetry에 `gemini-2.5-flash`가 하드코딩되어 있어 모델 업그레이드와 rollback이 코드 변경에 의존합니다. #49의 범위를 자체 benchmark release gate가 아니라 공식 지원 상태·기능·가격을 근거로 한 stable 모델 마이그레이션과 유지보수 가능한 provider compatibility boundary 구축으로 정리했습니다.

이번 PR의 migration target은 `gemini-3.7-flash`입니다.

- Google 공식 Models 문서에서 3.7 Flash는 현재 latest/most capable Flash stable, 3.6 Flash는 previous-generation stable로 안내됩니다.
- 3.7 Flash는 GA production-ready이며 structured outputs와 `low` / `medium` / `high` thinking level을 지원합니다.
- 2026-12-31까지 Standard paid tier는 3.7/3.6 모두 input `$0.75 / 1M`, output including thinking `$3.75 / 1M`이고, 2027-01-01부터 `$1.50 / $7.50`입니다.
- 별도 자체 blind benchmark는 수행하지 않았으며 #49의 완료 조건으로 두지 않습니다.

공식 근거:
- https://ai.google.dev/gemini-api/docs/models
- https://ai.google.dev/gemini-api/docs/latest-model
- https://ai.google.dev/gemini-api/docs/pricing
- https://ai.google.dev/gemini-api/docs/generate-content/thinking

Closes #49

## 무엇이 바뀌나요?

- 게임 규칙·상태: 변경 없음. canonical game state와 Skill Check 판정 경계는 그대로 유지합니다.
- Backend / API / DB: public API/DB schema 변경 없음. `GOOGLE_AI_MODEL`, opening/progress thinking 설정을 추가하고 `GeminiProviderSettings`에서 stable Flash ID와 버전별 request 차이를 검증합니다.
- AI narrative / prompt: 기본 모델을 `gemini-3.7-flash`로 전환하고 Gemini 3.x는 `thinkingLevel`, 2.5 rollback은 adapter 내부 `thinkingBudget` compatibility policy를 사용합니다. Narrative prompt 내용과 출력 언어 계약은 변경하지 않았으며 #97에서 별도 처리합니다.
- Image generation: 변경 없음.
- Frontend / UX: 변경 없음.
- Build / deploy / docs: README와 Gemini provider/cost observability 문서를 현재 runtime 설정에 맞게 갱신했습니다. production은 환경변수만으로 이전 stable Flash로 rollback할 수 있습니다.

추가 관측성:
- 기존 `provider_call.model`이 하드코딩 값이 아니라 `GOOGLE_AI_MODEL`을 기록합니다.
- Gemini provider attempt별 `gemini_provider_result` 로그에 model, thinking level, latency, outcome, prompt/candidate/thought/total token usage를 기록합니다.
- prompt/story 전문과 API key는 기록하지 않습니다.

## 책임 경계

게임 기능이나 AI 변경이 있다면 아래를 명확히 적어 주세요.

- **서버가 결정하는 사실:** 기존과 동일하게 action 유효성, canonical state, Skill Check 결과, state transition, commit 여부를 서버가 결정합니다.
- **LLM이 서술하는 내용:** 서버가 전달한 확정 결과를 바탕으로 story, choice 후보, 선택적 visual assets를 생성합니다.
- **LLM이 변경하면 안 되는 사실:** HP/능력치/아이템/위치/생사/Skill Check roll·modifier·DC·total·outcome 등 서버가 확정한 canonical fact를 변경하거나 재판정할 수 없습니다.

## 어떻게 검증했나요?

- [x] PR 작성 전 변경 diff를 비판적으로 검토하고 타당한 지적을 반영했습니다.
- [x] `./gradlew clean test`
- [x] `./gradlew postgresIntegrationTest`
- [x] `./gradlew build -x test`
- [x] `cd frontend && npm ci && npm test && npm run lint && npm run build`
- [ ] 정상 흐름을 직접 확인했습니다.
- [ ] 잘못된 입력/실패 흐름을 직접 확인했습니다.
- [x] 중복 요청 또는 상태 전이 관련 기존 회귀 테스트가 통과했습니다.

GitHub Actions CI #192에서 backend unit/H2, PostgreSQL integration, backend build와 frontend test/lint/build가 모두 성공했습니다. live Gemini provider smoke는 수행하지 않았으므로 수동 확인 항목은 체크하지 않았습니다.

자동 테스트 변경:
- 3.7 configured URL / API key header / structured output / opening `medium` thinking contract
- progress `low` thinking contract
- 2.5 rollback `thinkingBudget` compatibility
- latest/preview alias 및 미지원 thinking level fail-fast
- 검증하지 않은 future major를 자동 호환으로 가정하지 않는 경계
- provider telemetry의 configured Narrative model 기록
- Gemini `usageMetadata` token 추출
- 기존 strict structured-output validation과 prompt canonical contract 회귀

비판적 자체 리뷰에서 실제 반영한 내용:
- 처음에는 `major >= 3`을 모두 동일 API라고 가정했으나, 미래 major의 request contract를 보장할 근거가 없어 과도한 호환성이라고 판단했습니다. 검증된 3.x와 2.5 rollback만 허용하고 미확인 major는 fail-fast하도록 수정했습니다.
- token usage 관측성을 구현했지만 직접 검증이 부족한 점을 발견해 `usageMetadata`의 prompt/candidate/thought/total token 추출 테스트를 추가했습니다.
- #97 범위인 Narrative 출력 언어/prompt 보강과 #98 이미지 스타일 변경이 이 PR에 섞이지 않았는지 재확인했습니다.
- 첫 CI에서 token usage reflection assertion의 generic type 추론 때문에 test compile이 실패했습니다. 반환값을 `Integer`로 명시해 수정했고 CI #192에서 전체 검증을 다시 통과했습니다.

## 게임 상태·AI 안전성

해당하지 않는 항목은 이유를 적어 주세요.

- [x] 게임의 결정적 상태는 서버에서 검증·저장됩니다.
- [x] LLM 출력만으로 HP, 보상, 성공/실패 등 결정적 상태가 임의 변경되지 않습니다.
- [x] AI 요청에 필요한 최소 문맥만 전달합니다.
- [x] AI 응답 파싱 실패와 provider 오류가 게임 상태를 오염시키지 않습니다.
- [x] 기존 저장 데이터 또는 GameState 호환성 영향을 확인했습니다.

GameState/DB schema는 변경하지 않았고 #35의 structured output validation 및 bounded recovery, stale-owner/canonical commit 경계를 수정하지 않습니다.

## 보안·비용

- [x] API Key, 토큰, 비밀번호가 코드·로그·URL·클라이언트 응답에 노출되지 않습니다.
- [x] 외부 AI/Image 호출 횟수와 실패 시 동작을 검토했습니다.
- [x] 사용자 입력 길이와 외부 API 비용 증가 가능성을 검토했습니다.
- [x] CORS 또는 공개 endpoint 변경이 없음을 확인했습니다.

Gemini 3.7 전환은 2.5 대비 유료 token 단가 상승 가능성이 있습니다. provider attempt 상한과 budget unit 정책은 유지하며 실제 token usage를 구조화 로그에 추가했습니다. CORS/public endpoint 변경은 없습니다.

## API·DB·운영 영향

- [x] public API 계약 변경이 없음을 확인했습니다.
- [x] DB schema 변경이 없어 migration이 불필요함을 확인했습니다.
- [x] 환경변수는 이름과 용도만 문서화했고 실제 Secret은 포함하지 않았습니다.
- [x] 배포 후 확인할 smoke 항목을 문서화했습니다.

Public API와 DB schema는 변경하지 않아 frontend 수정과 migration은 필요하지 않습니다. 운영 설정은 `GOOGLE_AI_MODEL`, `GOOGLE_AI_THINKING_OPENING`, `GOOGLE_AI_THINKING_PROGRESS`이며 Secret 값은 문서화하지 않았습니다. 배포 후 opening/progress, structured output recovery, provider model/thinking telemetry를 확인합니다.

## 화면 / 응답 예시

UI와 public API response shape 변경은 없습니다. live Gemini provider smoke는 PR CI 범위가 아니므로 아직 수행하지 않았습니다.
