### PR TITLE
fix(ai): Narrative 출력 언어 계약 보강

### DIFF
--- a/docs/architecture/gemini-narrative-provider.md
+++ b/docs/architecture/gemini-narrative-provider.md
@@ -48,7 +48,18 @@ Gemini request는 다음을 유지합니다.
 - opening과 progress의 thinking level 독립 적용
 - repair 요청은 원 요청과 동일한 operation thinking level 사용
 
-Narrative prompt 내용과 출력 언어 계약은 #97의 별도 범위이며 이 버전 마이그레이션에서 변경하지 않습니다.
+### Narrative 출력 언어 계약
+
+사용자에게 노출되는 Narrative 필드와 image provider용 시각 묘사의 언어 책임을 분리합니다.
+
+- `title`, `story_text`, `choices[].text`는 세계관/캐릭터 설정과 현재 narrative context에서 확립된 주 언어를 유지합니다.
+- 세계관/캐릭터 설정의 주 언어가 한국어이면 opening의 `title`, `story_text`, `choices[].text`를 한국어로 작성하도록 명시합니다.
+- progress는 `worldPremise`, `playerDescription`, Story Memory와 최근 narrative context의 주 언어를 계속 사용하도록 명시합니다.
+- repair는 원 요청에서 확립된 Narrative 주 언어를 그대로 유지하며 번역하거나 다른 언어로 전환하지 않습니다.
+- `visual_assets.background`, `visual_assets.characters`, `visual_assets.assets`는 기존 image prompt pipeline과의 호환성을 위해 항상 영어 설명을 사용합니다.
+- JSON field 이름과 `visual_assets`의 영어 계약은 사용자 노출 Narrative를 영어로 전환할 근거가 아닙니다.
+
+이 계약은 prompt 지침이며 별도 외부 언어 감지/번역 서비스를 도입하지 않습니다. 또한 언어 선택은 canonical game state나 Skill Check/GameResult 판정 권한을 LLM에 부여하지 않습니다.
 
 ## 관측성
 
@@ -66,7 +77,7 @@ Narrative prompt 내용과 출력 언어 계약은 #97의 별도 범위이며 �
 
 토큰 수는 Gemini `usageMetadata`가 제공될 때만 기록됩니다. prompt/story 전문과 API key는 기록하지 않습니다.
 
-bounded recovery와 canonical commit 경계는 #35에서 확립한 정책을 그대로 유지합니다. 모델 설정 변경은 provider attempt 횟수나 게임 상태 저장 의미를 변경하지 않습니다.
+bounded recovery와 canonical commit 경계는 #35에서 확립한 정책을 그대로 유지합니다. 모델 설정이나 Narrative 출력 언어 계약은 provider attempt 횟수나 게임 상태 저장 의미를 변경하지 않습니다.
 
 ## rollback
 
@@ -74,8 +85,9 @@ production에서 문제가 발생하면 코드 변경 없이 `GOOGLE_AI_MODEL`�
 
 rollback 후에는 최소한 다음을 확인합니다.
 
-- opening 정상 생성
-- progress 정상 생성
+- 한국어 설정의 opening title/story/choices가 한국어로 유지되는지
+- progress와 repair에서 Narrative 언어가 유지되는지
+- `visual_assets` 영어 설명 계약
 - structured output validation
 - invalid response bounded recovery
 - provider telemetry의 model/thinking 값

--- a/src/main/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapter.java
+++ b/src/main/java/com/uctale/uctale/provider/gemini/GeminiNarrativeAdapter.java
@@ -41,6 +41,13 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
             4. **메모리 우선순위:** 확정 게임 결과/상태 > 캐논 사실 > 누적 요약 > 최근 턴 순으로 충돌을 해결하십시오.
             5. **출력 책임:** story_text와 다음 choices를 제안하고, 선택적으로 visual_assets를 묘사하십시오. canonical state 변경값을 출력 계약으로 만들지 마십시오.
 
+            [내러티브 출력 언어 계약 - 매우 중요]
+            1. 사용자에게 노출되는 `title`, `story_text`, `choices[].text`는 세계관/캐릭터 설정과 현재 narrative context에서 확립된 **주 언어**를 따르세요.
+            2. 세계관과 캐릭터 설정의 주 언어가 한국어라면 `title`, `story_text`, `choices[].text`를 모두 한국어로 작성하세요.
+            3. JSON field 이름이나 아래 `visual_assets` 영어 계약 때문에 사용자 내러티브 언어를 영어로 바꾸거나 번역하지 마세요.
+            4. opening, progress, repair 사이에서 사용자 내러티브의 주 언어를 임의로 전환하지 마세요.
+            5. `visual_assets`는 이미지 provider용 별도 계약이며 사용자 내러티브 언어와 무관하게 영어로 작성합니다.
+
             [시각적 요소(visual_assets) 작성 규칙 - 매우 중요]
             1. **이미지 생성 판단:** 직전 턴과 비교하여 **시각적으로 명확한 변화**가 있을 때만 작성하세요.
                - (O) 장소 이동, 새로운 적/NPC 등장, 중요한 아이템 등장
@@ -153,6 +160,11 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
                 [세계관 설정]: %s
                 [캐릭터 설정]: %s
 
+                [내러티브 출력 언어]
+                `title`, `story_text`, `choices[].text`는 위 세계관/캐릭터 설정의 주 언어로 작성하세요.
+                주 언어가 한국어라면 해당 사용자 노출 필드를 모두 한국어로 작성하세요.
+                `visual_assets`만 이미지 provider 계약에 따라 영어로 작성하세요.
+
                 위 설정을 바탕으로 게임의 오프닝을 생성하세요.
                 첫 장면이므로 visual_assets(배경, 분위기 등)를 반드시 상세하게 채워주세요.
                 """, worldSetting, characterSetting);
@@ -165,6 +177,8 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
                 직전 provider 응답이 구조 계약을 만족하지 않았습니다.
                 실패 분류: %s
                 원래 게임 결과나 사실을 바꾸지 말고, 동일 요청을 response schema에 맞는 JSON으로 다시 작성하세요.
+                원래 요청에서 확립된 `title`, `story_text`, `choices[].text`의 주 언어를 그대로 유지하고 번역하거나 다른 언어로 전환하지 마세요.
+                `visual_assets`는 기존과 동일하게 영어로 작성하세요.
                 """.formatted(safeReasonCode(reasonCode));
     }
 
@@ -200,6 +214,11 @@ public class GeminiNarrativeAdapter implements NarrativeGenerator {
 
                 [금지 canonical mutation]
                 %s
+
+                [내러티브 출력 언어]
+                `title`, `story_text`, `choices[].text`는 worldPremise, playerDescription과 누적/최근 narrative context에서 확립된 주 언어를 계속 사용하세요.
+                해당 주 언어가 한국어라면 사용자 노출 내러티브 필드를 모두 한국어로 작성하세요.
+                `visual_assets`만 이미지 provider 계약에 따라 영어로 작성하고, 그 영어 계약 때문에 사용자 내러티브 언어를 바꾸지 마세요.
 
                 위 확정 결과를 변경하거나 재판정하지 말고 그 결과가 드러나는 장면을 서술하세요.
                 Skill Check가 있으면 raw roll, modifier, DC, total, success/failure를 서버가 확정한 그대로 따르세요.

--- a/src/test/java/com/uctale/uctale/provider/gemini/GeminiPromptContractTest.java
+++ b/src/test/java/com/uctale/uctale/provider/gemini/GeminiPromptContractTest.java
@@ -10,6 +10,7 @@ import com.uctale.uctale.domain.game.SkillCheckResult;
 import com.uctale.uctale.domain.game.TurnResolution;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestClient;
 
 import java.util.Map;
@@ -17,6 +18,42 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class GeminiPromptContractTest {
+
+    @Test
+    @DisplayName("opening prompt는 한국어 narrative 필드와 영어 visual_assets 언어 계약을 분리한다")
+    void openingPrompt_SeparatesNarrativeAndVisualAssetLanguageContracts() {
+        GeminiNarrativeAdapter adapter = adapter();
+
+        String prompt = ReflectionTestUtils.invokeMethod(
+                adapter,
+                "openingPrompt",
+                "폐허가 된 서울에서 살아남는 이야기",
+                "한국인 정찰자 김하늘"
+        );
+
+        assertThat(prompt)
+                .contains("[내러티브 출력 언어]")
+                .contains("`title`, `story_text`, `choices[].text`")
+                .contains("주 언어가 한국어라면 해당 사용자 노출 필드를 모두 한국어로 작성하세요")
+                .contains("`visual_assets`만 이미지 provider 계약에 따라 영어로 작성하세요");
+    }
+
+    @Test
+    @DisplayName("system instruction은 사용자 narrative 언어와 visual_assets 영어 계약을 분리한다")
+    void requestBody_SeparatesNarrativeAndVisualAssetLanguageContracts() throws Exception {
+        GeminiNarrativeAdapter adapter = adapter();
+
+        String requestBody = adapter.createRequestBody("진행", new GeminiProviderSettings("TEST_API_KEY", "gemini-3.7-flash", "medium", "low").progressThinkingLevel());
+
+        assertThat(requestBody)
+                .contains("내러티브 출력 언어 계약")
+                .contains("title")
+                .contains("story_text")
+                .contains("choices[].text")
+                .contains("주 언어가 한국어라면")
+                .contains("visual_assets")
+                .contains("영어(English)");
+    }
 
     @Test
     @DisplayName("progress prompt는 확정 결과/상태/금지 mutation/cues를 분리하고 action token을 노출하지 않는다")
@@ -43,6 +80,10 @@ class GeminiPromptContractTest {
                 .contains("[확정 상태 projection]", "\"turnNumber\":2")
                 .contains("[narrative cues]", "문을 잠근다")
                 .contains("[금지 canonical mutation]", "HP", "roll")
+                .contains("[내러티브 출력 언어]")
+                .contains("worldPremise, playerDescription과 누적/최근 narrative context에서 확립된 주 언어")
+                .contains("해당 주 언어가 한국어라면 사용자 노출 내러티브 필드를 모두 한국어로 작성하세요")
+                .contains("`visual_assets`만 이미지 provider 계약에 따라 영어로 작성")
                 .doesNotContain("SERVER_ONLY_SECRET_TOKEN");
     }
 
@@ -83,6 +124,20 @@ class GeminiPromptContractTest {
                 .contains("\"total\":10")
                 .contains("\"outcome\":\"SUCCESS\"")
                 .doesNotContain("SERVER_ONLY_SKILL_TOKEN");
+    }
+
+    @Test
+    @DisplayName("repair instruction은 원 요청 narrative 언어를 유지하고 visual_assets만 영어로 유지한다")
+    void recoveryInstruction_PreservesOriginalNarrativeLanguage() {
+        GeminiNarrativeAdapter adapter = adapter();
+
+        String instruction = ReflectionTestUtils.invokeMethod(adapter, "recoveryInstruction", "INVALID_CHOICE_ID");
+
+        assertThat(instruction)
+                .contains("INVALID_CHOICE_ID")
+                .contains("원래 요청에서 확립된 `title`, `story_text`, `choices[].text`의 주 언어를 그대로 유지")
+                .contains("번역하거나 다른 언어로 전환하지 마세요")
+                .contains("`visual_assets`는 기존과 동일하게 영어로 작성하세요");
     }
 
     private GeminiNarrativeAdapter adapter() {


### PR DESCRIPTION
## 왜 필요한가요?

한국어 세계관/캐릭터 설정으로 시작한 게임에서도 Gemini가 `title`, `story_text`, `choices`를 영어로 생성할 수 있었습니다. 기존 prompt는 `visual_assets`만 영어로 고정하고 사용자 노출 Narrative 언어는 명시하지 않아 provider의 우연한 언어 선택에 의존했습니다.

- Closes #97

## 무엇이 바뀌나요?

- 게임 규칙·상태: 변경 없음. canonical state, Skill Check, GameResult 판정 경계는 그대로 유지합니다.
- Backend / API / DB: public API와 DB schema 변경 없음.
- AI narrative / prompt: system/opening/progress/repair prompt에 사용자 노출 `title`, `story_text`, `choices[].text`가 세계관/캐릭터와 기존 narrative context의 주 언어를 유지하도록 명시했습니다. 한국어 설정에서는 해당 필드를 한국어로 작성하도록 고정합니다. `visual_assets`는 기존 image provider 호환성을 위해 영어 계약을 유지합니다.
- Image generation: style/model/prompt composition 변경 없음. Gemini가 반환하는 `visual_assets` 영어 설명 계약만 기존대로 유지합니다.
- Frontend / UX: 변경 없음.
- Build / deploy / docs: Gemini Narrative provider 문서에 opening/progress/repair 언어 계약과 visual asset 경계를 추가했습니다.

## 책임 경계

- **서버가 결정하는 사실:** action 유효성, Skill Check roll/modifier/DC/outcome, canonical state transition, commit 여부와 structured-output validation/recovery 상한은 기존 서버 규칙이 결정합니다.
- **LLM이 서술하는 내용:** 서버가 확정한 결과를 사용자의 narrative 주 언어로 표현하고 다음 choice 후보를 제안하며, 선택적 `visual_assets`만 영어로 묘사합니다.
- **LLM이 변경하면 안 되는 사실:** HP/능력치/아이템/위치/생사/Skill Check/GameResult 등 서버가 확정한 canonical 사실과 성공/실패를 변경하거나 재판정할 수 없습니다.

## 어떻게 검증했나요?

- [x] PR 작성 전 변경 diff를 비판적으로 검토하고 타당한 지적을 반영했습니다.
- [x] `./gradlew clean test`
- [x] `./gradlew postgresIntegrationTest`
- [ ] `./gradlew build`
- [x] `cd frontend && npm ci && npm test && npm run lint && npm run build`
- [ ] 정상 흐름을 직접 확인했습니다.
- [ ] 잘못된 입력/실패 흐름을 직접 확인했습니다.
- [x] 중복 요청 또는 상태 전이 관련 기존 회귀 테스트가 통과했습니다.

GitHub Actions CI #195 (`33981994055`)에서 다음이 모두 성공했습니다.
- backend `./gradlew clean test`
- backend `./gradlew postgresIntegrationTest`
- backend `./gradlew build -x test`
- frontend `npm ci`, `npm test`, `npm run lint`, `npm run build`
- production smoke script Bash syntax validation

CI의 backend build 명령은 정확히 `./gradlew build -x test`이므로 템플릿의 `./gradlew build` 항목은 실행 근거 부족으로 체크하지 않았습니다. live Gemini provider를 사용한 수동 smoke는 수행하지 않았으므로 정상/실패 직접 확인 항목도 체크하지 않았습니다.

추가한 prompt contract test는 다음을 검증합니다.
- 한국어 opening에서 `title`/`story_text`/`choices[].text`의 한국어 계약
- system instruction에서 사용자 Narrative와 `visual_assets` 영어 계약 분리
- progress가 state/memory context의 주 언어를 유지
- repair가 원 요청 언어를 유지하고 번역/언어 전환을 금지
- 기존 canonical result/state/Skill Check guardrail과 action token 비노출 회귀

PR 전 비판적 자체 리뷰에서 실제 반영한 내용:
- 언어를 canonical `GameState` 필드로 새로 저장하거나 외부 언어 감지 서비스를 도입하는 것은 #97 범위를 넘고 legacy/schema 책임을 불필요하게 키우므로 도입하지 않았습니다.
- provider 응답의 문자 비율로 한국어 여부를 서버에서 거부하는 방식은 고유명사/혼합 언어에서 false positive가 발생할 수 있고 structured-output validation 책임과도 다르므로 추가하지 않았습니다. 이 Issue의 완료 조건인 prompt contract를 opening/progress/repair에 명시적으로 고정했습니다.
- `visual_assets` 영어 지침이 전체 응답 언어를 영어로 끌고 갈 수 있는 점을 별도 경계로 명시해 사용자 Narrative 언어와 분리했습니다.
- #49 모델 설정, #35 structured-output bounded recovery, #98 이미지 스타일 변경이 섞이지 않았는지 main 대비 diff를 확인했습니다.

## 게임 상태·AI 안전성

- [x] 게임의 결정적 상태는 서버에서 검증·저장됩니다.
- [x] LLM 출력만으로 HP, 보상, 성공/실패 등 결정적 상태가 임의 변경되지 않습니다.
- [x] AI 요청에 필요한 최소 문맥만 전달합니다.
- [x] AI 응답 파싱 실패와 provider 오류가 게임 상태를 오염시키지 않습니다.
- [x] 기존 저장 데이터 또는 GameState 호환성 영향을 확인했습니다.

GameState/DB/API schema를 변경하지 않으며 기존 `NarrativeContext`, strict structured-output validation, bounded recovery, stale-owner/canonical commit 경계를 그대로 사용합니다.

## 보안·비용

- [x] API Key, 토큰, 비밀번호가 코드·로그·URL·클라이언트 응답에 노출되지 않습니다.
- [x] 외부 AI/Image 호출 횟수와 실패 시 동작을 검토했습니다.
- [x] 사용자 입력 길이와 외부 API 비용 증가 가능성을 검토했습니다.
- [x] CORS 또는 공개 endpoint 변경이 없음을 확인했습니다.

provider 호출 횟수/retry 상한/모델/thinking 설정은 변경하지 않습니다. Prompt에 짧은 언어 지침만 추가되어 token 사용량은 소폭 증가할 수 있으나 새 provider 호출이나 별도 번역/감지 호출은 없습니다.

## API·DB·운영 영향

- [x] public API 계약 변경이 없음을 확인했습니다.
- [x] DB schema 변경이 없어 migration이 불필요함을 확인했습니다.
- [x] 환경변수 변경이 없음을 확인했습니다.
- [x] 배포 후 확인할 smoke 항목을 문서화했습니다.

배포 후에는 한국어 설정 opening, progress, invalid-response repair에서 사용자 Narrative 언어가 한국어로 유지되고 `visual_assets`만 영어 설명으로 유지되는지 확인합니다.

## 화면 / 응답 예시

API response shape와 UI 구조 변경은 없습니다. 한국어 입력 세션의 `title`, `storyText`, choice text가 한국어로 유지되도록 provider prompt 계약만 보강합니다.