### PR TITLE
feat(game): Inventory와 Equipment 상태 전이 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ UCTale은 사용자가 직접 입력한 세계관과 주인공 설정을 바탕�
 
 UCTale의 핵심 원칙은 **게임의 결정적 사실과 규칙은 서버가 소유하고, LLM은 확정된 결과를 서술한다**는 것입니다.
 
-현재 main은 공유 베타 운영 안전망과 신뢰 가능한 턴 저장 기반에 더해 `ActionResolver` / `GameResult` / provider-safe `NarrativeContext` 경계와 첫 실제 Skill Check turn vertical slice까지 갖추는 단계입니다.
+현재 main은 공유 베타 운영 안전망과 신뢰 가능한 턴 저장 기반에 더해 `ActionResolver` / `GameResult` / provider-safe `NarrativeContext`, Skill Check vertical slice, 서버 소유 Inventory/Equipment aggregate를 갖추는 단계입니다.
 
-- 서버: 세션 소유권, 현재 턴, idempotency, reservation lease, canonical state, Skill Check 판정, `GameResult`, GameLog, provider attempt 상한을 검증합니다.
+- 서버: 세션 소유권, 현재 턴, idempotency, reservation lease, canonical state, Skill Check 판정, Inventory/Equipment 상태 전이, `GameResult`, GameLog, provider attempt 상한을 검증합니다.
 - Narrative AI: 서버가 확정한 결과와 제한된 state/memory projection을 바탕으로 이야기와 다음 선택지 표현을 생성합니다.
 - Image AI: 브라우저의 임의 prompt가 아니라 서버가 발급한 image asset 계약만 실행합니다.
 - Frontend: 서버가 반환한 선택 행동, 캐릭터 능력치, Skill Check 결과를 표시하고 규칙을 재계산하지 않습니다.
@@ -49,7 +49,7 @@ UCTale의 핵심 원칙은 **게임의 결정적 사실과 규칙은 서버가 �
 4. 플레이어가 현재 턴에 유효한 행동을 선택합니다.
 5. 서버가 소유권, expected turn, idempotency, action payload를 검증합니다.
 6. Skill Check action이면 reservation 소유 요청이 서버 난수와 modifier/DC/outcome을 한 번 확정·보존합니다.
-7. 서버가 action을 `GameResult` / canonical next state로 resolve하고 provider-safe `NarrativeContext`를 구성한 뒤 Narrative provider를 호출합니다.
+7. 서버가 action과 필요한 결정적 effect를 `GameResult` / canonical next state로 resolve하고 provider-safe `NarrativeContext`를 구성한 뒤 Narrative provider를 호출합니다.
 8. 검증된 story는 확정 rule state를 변경하지 않고 transcript를 완성하며 canonical state와 committed-turn log를 원자적으로 저장합니다.
 9. 시각적으로 표현할 장면이 있으면 서버가 발급한 image asset을 통해 삽화를 제공합니다.
 
@@ -94,16 +94,31 @@ UCTale의 핵심 원칙은 **게임의 결정적 사실과 규칙은 서버가 �
 - canonical commit은 Skill Check 결과와 state transition을 같은 transaction에서 `GameLog`에 기록합니다.
 - frontend는 서버가 반환한 능력치와 Skill Check projection을 한국어로 표시하며 modifier/outcome을 재계산하지 않습니다.
 
+### Inventory와 Equipment
+
+#39 이후 `GameState`는 서버 소유 `Inventory`와 `Equipment` 상태를 포함합니다.
+
+- stable item definition ID와 player-owned stack/instance ID를 분리합니다.
+- `STACK`은 동일 owned ID와 동일 definition에 한해 수량을 합칠 수 있고 overflow를 거절합니다.
+- 장착 가능한 item은 개별 `INSTANCE`로만 표현하며 quantity는 항상 1입니다.
+- 최소 slot은 `MAIN_HAND`, `OFF_HAND`, `BODY`, `ACCESSORY`입니다.
+- acquire/remove/quantity/consume/equip/unequip은 `InventoryCommand`와 순수 `InventoryRules`에서만 canonical transition을 만듭니다.
+- 음수/0 수량, 없는 item, 보유량 초과 소비, 잘못된 slot, 중복 장착, 장착 중 item의 암묵적 삭제를 거절합니다.
+- Inventory 변화는 typed `GameResult.StateChange`와 `game_log.inventory_changes_json` audit으로 남고 snapshotless recovery에서도 순서대로 replay됩니다.
+- Narrative provider 응답은 inventory command 입력이 아니므로 story prose만으로 item을 생성·소비·장착할 수 없습니다.
+- 상점/거래, 랜덤 loot table, 강화/내구도, 전투 modifier, frontend 전체 inventory UI는 이 단계의 범위가 아닙니다.
+
 ### GameState와 Story Memory
 
 서버는 세션별 canonical `GameState`를 JSON snapshot으로 저장하고 Narrative Engine에는 필요한 projection만 전달합니다.
 
 - `PlayerCharacter`는 typed `CharacterStats`를 소유합니다.
+- `Inventory`는 owned item과 equipment slot의 canonical state를 소유합니다.
 - `canonicalFacts`: 서버가 유지하는 장기 사실
 - `rollingSummary`: 오래된 진행 내용을 제한된 크기로 압축한 기록
 - `recentTurns`: 최근 진행 기록
 
-snapshot JSON은 schema/ruleset version을 가지며 legacy production snapshot을 deterministic upgrader로 읽을 수 있습니다. typed stats 도입으로 현재 snapshot schema는 v2이며, v0/v1 stats는 읽을 때 순수 변환합니다. read-time upgrade는 in-memory에서만 수행하고 다음 정상 canonical write에서 최신 형식으로 저장합니다.
+snapshot JSON은 schema/ruleset version을 가지며 legacy production snapshot을 deterministic upgrader로 읽을 수 있습니다. Inventory 도입으로 현재 snapshot schema는 v3이며, v0/v1/v2는 읽을 때 typed stats와 빈 inventory를 순수 변환합니다. read-time upgrade는 in-memory에서만 수행하고 다음 정상 canonical write에서 최신 형식으로 저장합니다.
 
 ### GameResult 기반 NarrativeContext
 
@@ -111,11 +126,12 @@ snapshot JSON은 schema/ruleset version을 가지며 legacy production snapshot�
 
 - `NarrativeContext`는 canonical result ID, resolved action projection, outcome, optional Skill Check projection, canonical facts/events/state changes, canonical next-state projection, memory projection, narrative cues를 포함합니다.
 - Skill Check projection은 raw roll, stat/situational modifier, DC, total, success/failure, ruleset version을 포함합니다.
+- Inventory/Equipment effect가 있으면 서버가 확정한 typed state change만 provider에 전달되며 provider가 이를 추가하거나 재판정할 수 없습니다.
 - 서버 발급 `PlayerAction.token`은 provider context에 포함하지 않습니다.
 - prompt는 확정 결과/state, narrative cues, 금지 canonical mutation을 분리합니다.
 - provider는 story prose와 다음 choice 후보를 만들 수 있지만 서버가 확정한 outcome/roll/state change를 재판정할 수 없습니다.
 - provider story는 canonical state를 직접 변경하지 않고 기존 StoryMemory transcript만 완성합니다.
-- `game_log`는 progress turn의 `canonical_result_id` / `generated_story_id`와 선택적 Skill Check audit 필드를 기록합니다. legacy/opening 행은 Skill Check 필드가 모두 비어 있을 수 있습니다.
+- `game_log`는 progress turn의 `canonical_result_id` / `generated_story_id`, 선택적 Skill Check audit, Inventory/Equipment audit을 기록합니다. legacy/opening 행은 해당 audit 필드가 비어 있을 수 있습니다.
 - provider failure 시 canonical turn은 진행하지 않으며 같은 idempotent 요청은 reservation에 저장된 Skill Check 판정과 동일 canonical result link를 재사용합니다.
 - Gemini `generateContent`는 JSON response schema를 사용하고 adapter가 필수 필드, 길이, choice 수/ID를 다시 검증합니다. 구조 오류는 최대 3 provider attempt의 bounded recovery를 거치며 raw 응답 전문은 진단 로그에 남기지 않습니다.
 - Narrative model은 설정 기반 stable Flash ID를 사용하며 기본값은 `gemini-3.7-flash`입니다. opening/progress thinking level과 2.5 rollback compatibility는 provider adapter 내부에서 처리합니다.
@@ -205,6 +221,7 @@ uctale/
 - [개발 원칙](./CONTRIBUTING.md)
 - [Action Resolution](./docs/architecture/action-resolution.md)
 - [Skill Check turn integration](./docs/architecture/skill-check-turn.md)
+- [Inventory / Equipment](./docs/architecture/inventory-equipment.md)
 - [GameResult 기반 NarrativeContext](./docs/architecture/narrative-context.md)
 - [Gemini Narrative provider](./docs/architecture/gemini-narrative-provider.md)
 - [GameState / Story Memory](./docs/architecture/game-state-story-memory.md)
@@ -337,6 +354,6 @@ GitHub Actions CI도 backend unit test → PostgreSQL integration test → backe
 
 진행 중.
 
-현재 #33 `AvailableAction` / `PlayerAction`, #34 `ActionResolver` / `GameResult`, #36 확정 결과 기반 `NarrativeContext`, #7 typed `CharacterStats` / pure Skill Check 규칙에 더해 #37 Skill Check turn 통합·감사 저장과 #38 능력치·Skill Check 결과 frontend projection, #35 Gemini structured output 검증과 bounded recovery, #49 Gemini 3.7 Flash 설정 기반 마이그레이션이 반영됩니다.
+현재 #33 `AvailableAction` / `PlayerAction`, #34 `ActionResolver` / `GameResult`, #36 확정 결과 기반 `NarrativeContext`, #7 typed `CharacterStats` / pure Skill Check 규칙, #37 Skill Check turn 통합·감사 저장, #38 능력치·Skill Check 결과 frontend projection, #39 Inventory/Equipment canonical aggregate와 audit/recovery, #35 Gemini structured output 검증과 bounded recovery, #49 Gemini 3.7 Flash 설정 기반 마이그레이션이 반영됩니다.
 
-아직 구현되지 않은 전투·인벤토리·퀘스트·NPC 관계 기능은 현재 기능처럼 문서에 표시하지 않습니다.
+아직 구현되지 않은 전투·퀘스트·NPC 관계와 Inventory 상점/거래·loot·강화 기능은 현재 기능처럼 문서에 표시하지 않습니다.

--- a/docs/architecture/action-resolution.md
+++ b/docs/architecture/action-resolution.md
@@ -4,7 +4,7 @@
 
 UCTale의 결정적 게임 규칙은 Narrative provider가 아니라 서버가 소유한다. `/progress`는 서버가 발급한 `PlayerAction`을 먼저 규칙으로 해석하고, 그 결과와 canonical state transition을 확정한 뒤 Narrative provider를 호출한다.
 
-현재 실제 action type은 `NARRATIVE_CHOICE` 하나이므로 resolver registry나 범용 Rule Engine은 만들지 않는다.
+현재 실제 action type은 `NARRATIVE_CHOICE`, `SKILL_CHECK`이며 규칙 규모가 작으므로 범용 Rule Engine은 만들지 않는다. Inventory/equipment effect는 provider 출력이 아니라 서버가 명시적으로 만든 `InventoryCommand` 목록이 있을 때만 같은 resolution 단계에서 적용한다.
 
 ## 책임
 
@@ -16,6 +16,8 @@ UCTale의 결정적 게임 규칙은 Narrative provider가 아니라 서버가 �
 
 - 현재 `GameState`
 - 검증된 `PlayerAction`
+- Skill Check action이면 서버가 reservation 경계에서 확정한 `SkillCheckResult`
+- 필요할 경우 서버가 확정한 `InventoryCommand`
 
 출력:
 
@@ -27,16 +29,17 @@ UCTale의 결정적 게임 규칙은 Narrative provider가 아니라 서버가 �
 
 - 서버가 resolve한 `PlayerAction`
 - `Outcome.RESOLVED`
+- optional `SkillCheckResult`
 - 이번 action이 만든 canonical facts
 - domain events
 - typed state changes
 - Narrative Engine이 활용할 수 있는 narrative cues
 
-`NARRATIVE_CHOICE`는 아직 성공/실패·HP·아이템 같은 규칙을 만들지 않으므로 새 canonical fact는 없고, `ACTION_RESOLVED` event와 `TurnAdvanced` state change만 생성한다.
+`NARRATIVE_CHOICE` 자체는 별도 성공/실패를 만들지 않는다. inventory command가 없으면 `ACTION_RESOLVED` event와 `TurnAdvanced`만 생성한다. `SKILL_CHECK`는 보존된 판정 결과를 검증해 `SKILL_CHECK_RESOLVED`를 추가한다. 서버가 inventory command를 함께 제공하면 item 획득/제거/수량/소비/장착/해제 결과를 typed state change로 먼저 확정한다.
 
 ### `TurnProcessor`
 
-application 단계에서 `ActionResolver` 호출과 resolved transition의 narrative transcript 완성을 연결한다. 현재 resolver가 하나뿐이고 상태가 없으므로 registry나 Spring bean graph를 추가하지 않는다.
+application 단계에서 `ActionResolver` 호출과 resolved transition의 narrative transcript 완성을 연결한다. Skill Check 난수/decision persistence는 reservation owner 경계에서 수행하고, 일반 Narrative provider는 규칙 공식을 소유하지 않는다.
 
 ### `GameService`
 
@@ -53,20 +56,21 @@ application 단계에서 `ActionResolver` 호출과 resolved transition의 narra
 9. 확정된 transition에 narrative transcript를 부착하고 다음 server-issued actions 구성
 10. `GameTurnCommit`으로 원자적 persistence 호출
 
-`GameService`는 action type별 규칙 공식이나 상태 변경 세부 구현을 알지 않는다.
+`GameService`는 action type별 규칙 공식이나 inventory 상태 변경 세부 구현을 알지 않는다.
 
 ### Persistence
 
-`GameTurnCommit`은 문자열에서 상태를 계산하지 않고 `StateTransition`을 소유한다. `GamePersistenceService.saveNextTurn()`은 저장 직전에 다음을 재검증한 뒤 한 transaction에서 commit한다.
+`GameTurnCommit`은 문자열에서 상태를 계산하지 않고 `StateTransition`을 소유한다. inventory가 변경된 commit은 함께 전달된 `GameResult.stateChanges`를 previous inventory에 replay한 결과가 next inventory와 정확히 일치해야 한다. `GamePersistenceService.saveNextTurn()`은 저장 직전에 다음을 재검증한 뒤 한 transaction에서 commit한다.
 
 - reservation owner
 - expected turn
 - previous/next state version
 - DB의 canonical previous state와 transition의 previous state equality
+- inventory audit과 next inventory equality
 - optimistic lock / unique turn constraint
 - canonical result / generated story linkage pair
 
-Persistence는 user choice text나 story prose를 파싱해 규칙 결과를 계산하지 않는다.
+Persistence는 user choice text나 story prose를 파싱해 규칙 결과를 계산하지 않는다. Inventory/equipment typed change는 `game_log.inventory_changes_json`에도 audit으로 남겨 snapshotless recovery에 사용한다.
 
 ## Narrative provider 전후 경계
 
@@ -74,8 +78,10 @@ Persistence는 user choice text나 story prose를 파싱해 규칙 결과를 계
 
 - resolved `PlayerAction`
 - `GameResult.outcome`
+- optional Skill Check roll/outcome
 - canonical facts/events
 - 규칙이 만드는 state changes
+- inventory/equipment 변화
 - canonical next turn/state transition
 - narrative cues
 - provider-safe `NarrativeContext`
@@ -84,11 +90,11 @@ Persistence는 user choice text나 story prose를 파싱해 규칙 결과를 계
 
 ### Provider 호출 뒤 허용되는 것
 
-현재 `StoryMemory.recentTurns`는 기존 장기 narrative 호환을 위해 provider가 만든 story prose를 transcript로 보관한다. 이 단계는 이미 확정된 turn number, player/world state, canonical facts, `GameResult`를 변경하지 않는다.
+현재 `StoryMemory.recentTurns`는 기존 장기 narrative 호환을 위해 provider가 만든 story prose를 transcript로 보관한다. 이 단계는 이미 확정된 turn number, player/world/inventory state, canonical facts, `GameResult`를 변경하지 않는다.
 
-`game_log`에는 새 progress turn부터 `canonical_result_id`와 `generated_story_id`를 함께 기록해 서버 결과와 최종 채택 prose의 연결을 남긴다. legacy/opening 행은 두 값이 모두 비어 있을 수 있다.
+`game_log`에는 progress turn의 `canonical_result_id`와 `generated_story_id`를 함께 기록해 서버 결과와 최종 채택 prose의 연결을 남긴다. legacy/opening 행은 두 값이 모두 비어 있을 수 있다.
 
-Story Memory projection 자체의 전면 재설계와 token budget 개선은 #46 범위다. 세부 NarrativeContext 계약은 [narrative-context.md](./narrative-context.md)를 기준으로 한다.
+Story Memory projection 자체의 전면 재설계와 token budget 개선은 #46 범위다. 세부 NarrativeContext 계약은 [narrative-context.md](./narrative-context.md)를 기준으로 한다. Inventory/equipment 규칙은 [inventory-equipment.md](./inventory-equipment.md)를 기준으로 한다.
 
 ## Transaction boundary
 
@@ -99,11 +105,11 @@ Narrative/Image provider 네트워크 호출 동안 DB transaction을 열지 않
 - Narrative/Image provider: DB transaction 밖
 - final commit: `GameTurnCommit`을 단일 persistence transaction으로 저장
 
-provider 호출 성공 후 commit 전 crash window에서 외부 provider가 재호출될 수 있다는 bounded at-least-once 정책과 stale-owner fencing은 변경하지 않는다. 동일 idempotent mutation retry는 동일 canonical result link를 재구성하고, 완료된 mutation은 provider 없이 committed turn을 replay한다.
+provider 호출 성공 후 commit 전 crash window에서 외부 provider가 재호출될 수 있다는 bounded at-least-once 정책과 stale-owner fencing은 변경하지 않는다. 동일 idempotent mutation retry는 동일 canonical result link와 이미 보존된 결정적 판정을 재사용하고, 완료된 mutation은 provider/규칙/commit 없이 committed turn을 replay한다.
 
 ## 호환성
 
-- API wire contract와 기존 `NARRATIVE_CHOICE` 선택 흐름은 변경하지 않는다.
+- API wire contract와 기존 `NARRATIVE_CHOICE` / `SKILL_CHECK` 선택 흐름은 변경하지 않는다.
+- Inventory/equipment command는 이번 Issue에서 새 public API나 LLM 출력 필드로 노출하지 않는다.
 - `GameState.advance(playerAction, storyText)`는 legacy log recovery와 기존 테스트 호환을 위해 남기되, 내부적으로 `advanceTurn()` + `recordNarrativeTurn()`을 사용한다.
-- 기존 `game_log` 행은 신규 narrative linkage 컬럼이 `NULL`이어도 읽을 수 있다.
-- Skill Check 실제 turn 연결과 roll 감사 저장은 #37 범위다.
+- 기존 `game_log` 행은 narrative linkage, Skill Check audit, inventory audit 컬럼이 `NULL`이어도 읽을 수 있다.

--- a/docs/architecture/game-state-snapshot-evolution.md
+++ b/docs/architecture/game-state-snapshot-evolution.md
@@ -4,15 +4,15 @@
 
 `game_state_snapshot.state_json`은 최신 canonical `GameState`를 빠르게 복구하기 위한 snapshot입니다. 도메인 구조가 확장되어도 기존 세션을 Jackson 기본값에 암묵적으로 의존해 읽지 않도록 JSON envelope에 명시적인 schema/ruleset version을 둡니다.
 
-DB 컬럼을 추가하지 않고 `state_json` 내부 형식만 진화시키므로 기존 PostgreSQL/Flyway schema는 그대로 유지합니다.
+snapshot 구조는 `state_json` 내부에서 진화하고, 별도의 audit이 필요한 canonical 변화는 append-only `GameLog` migration으로 보강합니다.
 
 ## 현재 snapshot 형식
 
-새 write는 schema `2`, ruleset `1`을 사용합니다.
+새 write는 schema `3`, ruleset `1`을 사용합니다.
 
 ```json
 {
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "rulesetVersion": 1,
   "state": {
     "turnNumber": 1,
@@ -27,7 +27,11 @@ DB 컬럼을 추가하지 않고 `state_json` 내부 형식만 진화시키므�
       }
     },
     "worldState": {},
-    "storyMemory": {}
+    "storyMemory": {},
+    "inventory": {
+      "items": {},
+      "equipment": {"slots": {}}
+    }
   }
 }
 ```
@@ -36,7 +40,7 @@ DB 컬럼을 추가하지 않고 `state_json` 내부 형식만 진화시키므�
 - `rulesetVersion`: 저장 상태를 해석하는 결정적 게임 규칙 계약 version
 - `state`: canonical `GameState`
 
-schema와 ruleset version은 서로 다른 축입니다. #7의 typed stats 추가는 저장 JSON 구조 변경이므로 schema를 2로 올렸지만, 과거 Skill Check 결과를 새로운 규칙으로 재판정하는 변경은 아니므로 ruleset은 1을 유지합니다.
+schema와 ruleset version은 서로 다른 축입니다. typed stats와 inventory aggregate 추가는 저장 JSON 구조 변경이므로 schema를 각각 2, 3으로 올렸지만 과거 결과를 새로운 규칙으로 재판정하지 않으므로 ruleset은 1을 유지합니다.
 
 ## 지원 경로
 
@@ -44,7 +48,7 @@ schema와 ruleset version은 서로 다른 축입니다. #7의 typed stats 추�
 
 #31 이전 production 형식은 envelope 없이 `GameState` 자체를 저장했습니다. logical schema v0, legacy ruleset baseline 1로 취급합니다.
 
-v0은 먼저 v1 의미로 승격한 뒤 v2 변환을 적용합니다.
+v0은 v1, v2, v3 순서로 한 단계씩 승격합니다.
 
 ### v1 -> v2 typed stats
 
@@ -58,6 +62,19 @@ v2 upgrade 규칙:
 - 알 수 없는 legacy key를 임의의 현재 stat으로 추정 매핑하지 않음
 - provider, 랜덤, 시간, LLM 호출 없이 순수 JSON 변환만 수행
 
+### v2 -> v3 inventory / equipment
+
+v2에는 inventory 의미가 존재하지 않았으므로 안전하게 복구 가능한 값은 빈 inventory뿐입니다.
+
+v3 upgrade 규칙:
+
+- `inventory`가 없으면 `items: {}`와 `equipment.slots: {}`를 명시적으로 추가
+- v2 문서에 이미 `inventory` 필드가 존재하지만 object가 아니면 손상 데이터로 실패
+- 과거 story prose에서 item 획득·소비·장착을 추론하지 않음
+- read-time upgrade는 DB write나 provider 호출 없이 순수 변환만 수행
+
+현재 schema v3에서 inventory가 누락되거나 손상된 경우는 legacy로 간주하지 않고 역직렬화 실패로 처리합니다.
+
 ## read / write 정책
 
 - **write:** 항상 현재 schema/ruleset version으로 저장
@@ -66,7 +83,7 @@ v2 upgrade 규칙:
 - **미지원 ruleset:** 자동 재판정하지 않고 명시적 실패
 - **손상 snapshot:** legacy raw state로 명확히 식별되지 않으면 명시적 실패
 
-읽기만으로 DB를 즉시 다시 쓰지 않습니다. read-time upgrade는 메모리에서만 수행하고, 다음 정상 canonical turn commit에서 최신 v2 envelope로 자연스럽게 재작성합니다.
+읽기만으로 DB를 즉시 다시 쓰지 않습니다. read-time upgrade는 메모리에서만 수행하고, 다음 정상 canonical turn commit에서 최신 v3 envelope로 자연스럽게 재작성합니다.
 
 ## GameLog state version과의 관계
 
@@ -76,9 +93,11 @@ v2 upgrade 규칙:
 
 서로 비교하거나 대체하지 않습니다.
 
+Inventory/equipment 변화는 snapshot에 최신 상태를 저장하는 것과 별도로 `game_log.inventory_changes_json`에 typed audit을 기록합니다. snapshot이 사라진 session은 이 audit을 turn 순서대로 replay해 동일 inventory/equipment를 복구합니다. legacy/opening log의 audit `NULL`은 변화 없음으로 해석합니다.
+
 ## snapshot 없는 session
 
-snapshot이 없으면 append-only `GameLog`를 통해 `GameStateRecovery`가 현재 상태를 복구합니다. 복구되는 신규 `PlayerCharacter`에는 서버 기본 `CharacterStats`가 적용되고 이후 정상 write에서 schema v2 snapshot이 생성됩니다.
+snapshot이 없으면 append-only `GameLog`를 통해 `GameStateRecovery`가 현재 상태를 복구합니다. legacy log에는 inventory audit이 없으므로 빈 inventory에서 시작하고, 신규 audit이 있는 turn부터 typed state change를 replay합니다. 복구 뒤 다음 정상 write에서 schema v3 snapshot이 생성됩니다.
 
 ## 향후 규칙
 

--- a/docs/architecture/game-state-snapshot-evolution.md
+++ b/docs/architecture/game-state-snapshot-evolution.md
@@ -69,11 +69,11 @@ v2에는 inventory 의미가 존재하지 않았으므로 안전하게 복구 �
 v3 upgrade 규칙:
 
 - `inventory`가 없으면 `items: {}`와 `equipment.slots: {}`를 명시적으로 추가
-- v2 문서에 이미 `inventory` 필드가 존재하지만 object가 아니면 손상 데이터로 실패
+- schema v2 snapshot에 `inventory` 키가 존재하면 object 형태여도 정의되지 않은 의미를 v3 canonical state로 승격하지 않고 명시적으로 실패
 - 과거 story prose에서 item 획득·소비·장착을 추론하지 않음
 - read-time upgrade는 DB write나 provider 호출 없이 순수 변환만 수행
 
-현재 schema v3에서 inventory가 누락되거나 손상된 경우는 legacy로 간주하지 않고 역직렬화 실패로 처리합니다.
+현재 schema v3에서 inventory가 누락되거나 손상된 경우도 legacy로 간주하지 않고 역직렬화 실패로 처리합니다.
 
 ## read / write 정책
 

--- a/docs/architecture/game-state-story-memory.md
+++ b/docs/architecture/game-state-story-memory.md
@@ -12,6 +12,7 @@ UCTale의 결정적 게임 상태는 서버가 소유하고, LLM은 그 상태�
 - `PlayerCharacter`: 설명과 서버 소유 `CharacterStats`
 - `WorldState`: 세계의 서버 소유 상태와 flags 확장 지점
 - `StoryMemory`: 장기 서사를 위한 제한된 내러티브 문맥
+- `Inventory`: 서버 소유 item/Equipment canonical state
 
 운영 DB에는 `game_state_snapshot` JSON snapshot으로 저장합니다. `game_session`과 append-only `game_log`는 세션/턴 무결성과 committed-turn 원장 역할을 담당합니다.
 
@@ -41,9 +42,13 @@ UCTale의 결정적 게임 상태는 서버가 소유하고, LLM은 그 상태�
 
 `SkillCheckResult`에는 stat type, raw roll, stat modifier, situational modifier, DC, total, outcome, ruleset version을 모두 기록해 후속 감사 저장에 필요한 계산 근거를 보존합니다.
 
-랜덤은 `RandomSource` port로 분리합니다. production adapter는 `SecureRandom`을 사용하고 테스트는 fixed/sequence source로 결정적으로 검증합니다. 이 pure domain 판정은 Narrative provider를 호출하지 않습니다.
+랜덤은 `RandomSource` port로 분리합니다. production adapter는 `SecureRandom`을 사용하고 테스트는 fixed/sequence source로 결정적으로 검증합니다. 이 pure domain 판정은 Narrative provider를 호출하지 않습니다. #37/#38 이후 실제 `/progress` vertical slice와 DB/UI projection까지 연결되어 있습니다.
 
-#7 범위에서는 이 규칙을 실제 `/progress` turn pipeline과 DB roll ledger에 아직 연결하지 않습니다. Skill Check의 실제 통합은 #37/#38에서 수행합니다.
+## Inventory / Equipment
+
+#39 이후 `GameState.inventory`는 stable owned item ID와 최소 equipment slot 상태를 소유합니다. acquire/remove/quantity/consume/equip/unequip은 `InventoryCommand`와 순수 `InventoryRules`에서만 canonical transition을 만듭니다.
+
+Narrative provider 응답은 inventory command 입력이 아니므로 story prose만으로 item을 만들거나 소비하거나 장착할 수 없습니다. 상세 invariant, audit, recovery는 [inventory-equipment.md](./inventory-equipment.md)를 기준으로 합니다.
 
 ## Story Memory
 
@@ -52,7 +57,7 @@ Story Memory는 세 계층으로 구분합니다.
 1. `canonicalFacts`
    - 서버가 진실로 승인한 장기 사실
    - 현재는 최초 세계관과 플레이어 설정으로 시작
-   - 향후 Game Engine의 검증된 state transition만 canonical truth를 변경
+   - Game Engine의 검증된 state transition만 canonical truth를 변경
 2. `rollingSummary`
    - 최근 문맥에서 밀려난 오래된 턴의 제한된 압축 기록
    - 현재 별도 AI 호출 없이 서버가 결정적으로 누적
@@ -80,7 +85,7 @@ LLM 응답 자체는 canonical rule state 변경 권한이 없습니다.
 - 만료되거나 변조된 action은 Narrative provider 또는 규칙 실행 전에 거절합니다.
 - 기존 choice ID는 compatibility adapter 경로로 유지합니다.
 
-#34 이후 검증된 `PlayerAction`은 `ActionResolver`에서 `TurnResolution(GameResult, StateTransition)`으로 resolve됩니다. 현재 `ActionType`은 `NARRATIVE_CHOICE` 하나이므로 resolver registry는 두지 않습니다.
+#34 이후 검증된 `PlayerAction`은 `ActionResolver`에서 `TurnResolution(GameResult, StateTransition)`으로 resolve됩니다. 현재 실제 action type은 `NARRATIVE_CHOICE`, `SKILL_CHECK`이며, inventory/equipment effect는 별도의 provider 출력이 아니라 서버 명령이 있을 때 같은 pure resolution에서 적용됩니다.
 
 #36 이후 Narrative provider에는 raw state/action 문자열 조합 대신 확정된 `GameResult`와 canonical next-state에서 만든 provider-safe `NarrativeContext`를 전달합니다. 서버 발급 `PlayerAction.token`은 provider context에 포함하지 않습니다.
 
@@ -89,26 +94,25 @@ LLM 응답 자체는 canonical rule state 변경 권한이 없습니다.
 1. idempotency와 `(session_id, expected_turn)` reservation을 확인합니다.
 2. `expectedTurn`으로 현재 세션과 `GameState.turnNumber`를 검증합니다.
 3. 제출된 `PlayerAction`을 현재 서버 발급 `AvailableAction`과 대조합니다.
-4. `ActionResolver`가 `GameResult`와 canonical next `StateTransition`을 pure domain operation으로 확정합니다.
-5. 확정 결과와 canonical next state에서 provider-safe `NarrativeContext`를 구성합니다.
-6. rate limit과 provider budget/attempt 경계를 확인합니다.
-7. Narrative Engine이 확정 결과를 재판정하지 않고 story와 다음 choice 후보를 생성합니다.
-8. 검증된 story prose는 확정된 rule transition을 변경하지 않고 `StoryMemory` transcript에만 부착합니다.
-9. 서버가 다음 server-issued available actions를 구성합니다.
-10. `GameTurnCommit`이 `StateTransition`, `canonicalResultId`, `generatedStoryId`를 소유한 채 canonical transaction에서 저장됩니다.
+4. 필요한 결정적 판정/effect를 서버에서 확정합니다.
+5. `ActionResolver`가 `GameResult`와 canonical next `StateTransition`을 pure domain operation으로 확정합니다.
+6. 확정 결과와 canonical next state에서 provider-safe `NarrativeContext`를 구성합니다.
+7. rate limit과 provider budget/attempt 경계를 확인합니다.
+8. Narrative Engine이 확정 결과를 재판정하지 않고 story와 다음 choice 후보를 생성합니다.
+9. 검증된 story prose는 확정된 rule transition을 변경하지 않고 `StoryMemory` transcript에만 부착합니다.
+10. 서버가 다음 server-issued available actions를 구성합니다.
+11. `GameTurnCommit`이 `StateTransition`, audit, narrative linkage를 소유한 채 canonical transaction에서 저장됩니다.
 
 세부 책임과 provider/transaction 경계는 [action-resolution.md](./action-resolution.md), prompt 계약과 retry/linkage 정책은 [narrative-context.md](./narrative-context.md)를 기준으로 합니다.
 
-#37은 이 경계 위에 실제 Skill Check vertical slice와 roll 결과를 연결합니다.
-
 ## 기존 세션 호환성
 
-현재 snapshot schema는 v2입니다. #31 이전 raw `GameState`는 logical v0, typed stats 이전 envelope는 v1로 읽어 deterministic upgrader에서 v2로 승격합니다.
+현재 snapshot schema는 v3입니다. #31 이전 raw `GameState`는 logical v0, typed stats 이전 envelope는 v1, inventory 이전 형식은 v2로 읽어 deterministic upgrader에서 v3까지 한 단계씩 승격합니다.
 
-legacy stats가 없으면 기본값 10을 적용하고 canonical legacy stat 값이 있으면 검증 후 보존합니다. read 자체는 DB를 다시 쓰지 않고 다음 정상 canonical commit에서 최신 snapshot 형식으로 저장합니다.
+legacy stats가 없으면 기본값 10을 적용하고 canonical legacy stat 값이 있으면 검증 후 보존합니다. v0/v1/v2는 inventory 의미가 없으므로 빈 inventory를 명시적으로 추가합니다. read 자체는 DB를 다시 쓰지 않고 다음 정상 canonical commit에서 최신 snapshot 형식으로 저장합니다.
 
 `GameState.advance(playerAction, storyText)`는 legacy `GameLog` recovery에서 동일한 StoryMemory를 복원해야 하므로 compatibility method로 유지합니다. 새 turn pipeline은 규칙 단계의 `advanceTurn()`과 provider 이후의 `recordNarrativeTurn()`을 분리해 사용합니다.
 
-#36의 `game_log.canonical_result_id`와 `generated_story_id`는 legacy/opening 행에서 둘 다 `NULL`일 수 있도록 migration했습니다. 새 production progress commit은 두 linkage ID를 함께 기록하며 한쪽만 존재하는 상태는 DB CHECK constraint와 `GameTurnCommit`에서 거부합니다.
+`game_log.canonical_result_id`와 `generated_story_id`는 legacy/opening 행에서 둘 다 `NULL`일 수 있습니다. 신규 inventory/equipment audit도 legacy/opening 행에서 `NULL`이면 변화 없음으로 해석하고, snapshotless recovery는 신규 audit만 순서대로 replay합니다.
 
 세부 snapshot 내용은 [game-state-snapshot-evolution.md](./game-state-snapshot-evolution.md)를 기준으로 합니다.

--- a/docs/architecture/inventory-equipment.md
+++ b/docs/architecture/inventory-equipment.md
@@ -1,0 +1,87 @@
+# Inventory / Equipment canonical state
+
+## 목적
+
+아이템 획득·소비·수량·장착 상태는 story prose가 아니라 서버가 결정하는 canonical game state입니다. #39는 전투/보상 규칙이 이 상태를 사용할 수 있도록 최소한의 타입 안전한 aggregate와 audit/recovery 경계를 정의합니다.
+
+## 도메인 모델
+
+`GameState.inventory`는 다음 두 부분을 소유합니다.
+
+- `Inventory.items`: stable owned item ID -> `OwnedItem`
+- `Equipment.slots`: `EquipmentSlot` -> stable owned item ID
+
+`ItemDefinition`은 stable definition ID, ownership type, optional equipment slot을 가집니다.
+
+- `STACK`: 같은 owned ID + 같은 definition이면 획득 수량을 합칠 수 있습니다.
+- `INSTANCE`: owned ID가 개별 인스턴스를 식별하고 quantity는 항상 1입니다.
+
+최소 equipment slot은 `MAIN_HAND`, `OFF_HAND`, `BODY`, `ACCESSORY`입니다. 한 item은 정의된 slot에만 장착할 수 있고 동일 owned item을 여러 slot이 참조할 수 없습니다.
+
+## 서버 명령과 invariant
+
+`InventoryCommand` / `InventoryRules`는 provider와 무관한 순수 도메인 경계입니다.
+
+지원 명령:
+
+- acquire
+- remove
+- change quantity
+- consume
+- equip
+- unequip
+
+공통 invariant:
+
+- 보유 item quantity는 항상 1 이상입니다.
+- 0/음수 수량, 보유량 초과 소비, 존재하지 않는 item은 거절합니다.
+- `INSTANCE` quantity는 1이고 임의 수량 변경/부분 소비를 허용하지 않습니다.
+- item definition과 맞지 않는 equipment slot은 거절합니다.
+- 사용 중 slot 덮어쓰기와 중복 item 참조를 거절합니다.
+- 장착 중 item은 명시적 unequip 없이 제거하거나 전량 소비할 수 없습니다.
+- stack quantity 합산 overflow는 명시적으로 실패합니다.
+
+`ActionResolver`에 inventory command가 전달된 경우에만 해당 명령을 canonical next state에 적용합니다. 현재 Narrative provider 응답은 inventory command 입력 경로가 아니므로 story text만으로 item을 생성·소비·장착할 수 없습니다.
+
+## GameResult / Narrative 경계
+
+각 inventory 명령은 결과를 `GameResult.StateChange`로 남깁니다.
+
+- `ItemAcquired`
+- `ItemRemoved`
+- `ItemQuantityChanged`
+- `ItemConsumed`
+- `ItemEquipped`
+- `ItemUnequipped`
+
+이 state change는 provider 호출 전에 확정되고 기존 `NarrativeContext`에 전달됩니다. LLM은 이를 서술할 수 있지만 state change를 추가하거나 다시 판정할 수 없습니다.
+
+## persistence / idempotency
+
+`GameTurnCommit`은 전달된 inventory state change를 previous inventory에 replay한 결과가 `StateTransition.nextState.inventory`와 정확히 일치하는지 검증합니다. 누락되거나 변조된 audit으로 inventory가 바뀐 transition은 commit할 수 없습니다.
+
+최종 canonical transaction은 기존과 동일하게 다음을 함께 처리합니다.
+
+- session turn advance
+- append-only `GameLog`
+- 최신 `GameStateSnapshot`
+- mutation completion
+- reservation release
+
+`game_log.inventory_changes_json`에는 inventory state change만 JSON audit으로 저장합니다. `TurnAdvanced` 등 다른 state change는 이 컬럼에 중복 저장하지 않습니다.
+
+같은 completed idempotency mutation은 기존 `game_mutation_request` replay 경계를 사용하므로 provider/규칙/commit을 다시 수행하지 않습니다. stale turn/owner도 기존 session turn, reservation, optimistic lock, unique turn constraint에서 canonical commit을 할 수 없습니다.
+
+## snapshot / legacy recovery
+
+snapshot schema v3부터 `GameState.inventory`가 필수입니다.
+
+- v0/v1/v2 snapshot은 deterministic read-time upgrade에서 빈 inventory를 명시적으로 추가합니다.
+- 현재 v3 snapshot에서 inventory 누락은 손상 데이터로 실패합니다.
+- legacy/opening `GameLog.inventory_changes_json = NULL`은 변화 없음입니다.
+- snapshot이 없으면 `GameStateRecovery`가 빈 inventory에서 시작해 각 committed turn의 inventory audit을 순서대로 replay합니다.
+- story prose에서 과거 item 의미를 추측해 복구하지 않습니다.
+
+## 범위 밖
+
+#39에서는 상점/거래, 랜덤 loot table, 내구도/upgrade, 전투 modifier, frontend inventory UI를 구현하지 않습니다.

--- a/src/main/java/com/uctale/uctale/application/game/GamePersistenceService.java
+++ b/src/main/java/com/uctale/uctale/application/game/GamePersistenceService.java
@@ -12,10 +12,12 @@ import com.uctale.uctale.repository.GameMutationRequestRepository;
 import com.uctale.uctale.repository.GameSessionRepository;
 import com.uctale.uctale.repository.GameStateSnapshotRepository;
 import com.uctale.uctale.repository.ImageAssetRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.ObjectMapper;
 
 @Service
 public class GamePersistenceService {
@@ -31,6 +33,7 @@ public class GamePersistenceService {
     private final GameStateRecovery gameStateRecovery;
     private final InventoryAuditCodec inventoryAuditCodec;
 
+    @Autowired
     public GamePersistenceService(GameSessionRepository gameSessionRepository, GameLogRepository gameLogRepository,
             GameStateSnapshotRepository gameStateSnapshotRepository, ImageAssetRepository imageAssetRepository,
             GameMutationRequestRepository gameMutationRequestRepository, GameStateCodec gameStateCodec,
@@ -43,6 +46,22 @@ public class GamePersistenceService {
         this.gameStateCodec = gameStateCodec;
         this.gameStateRecovery = gameStateRecovery;
         this.inventoryAuditCodec = inventoryAuditCodec;
+    }
+
+    public GamePersistenceService(GameSessionRepository gameSessionRepository, GameLogRepository gameLogRepository,
+            GameStateSnapshotRepository gameStateSnapshotRepository, ImageAssetRepository imageAssetRepository,
+            GameMutationRequestRepository gameMutationRequestRepository, GameStateCodec gameStateCodec,
+            GameStateRecovery gameStateRecovery) {
+        this(
+                gameSessionRepository,
+                gameLogRepository,
+                gameStateSnapshotRepository,
+                imageAssetRepository,
+                gameMutationRequestRepository,
+                gameStateCodec,
+                gameStateRecovery,
+                new InventoryAuditCodec(new ObjectMapper())
+        );
     }
 
     @Transactional

--- a/src/main/java/com/uctale/uctale/application/game/GamePersistenceService.java
+++ b/src/main/java/com/uctale/uctale/application/game/GamePersistenceService.java
@@ -12,17 +12,16 @@ import com.uctale.uctale.repository.GameMutationRequestRepository;
 import com.uctale.uctale.repository.GameSessionRepository;
 import com.uctale.uctale.repository.GameStateSnapshotRepository;
 import com.uctale.uctale.repository.ImageAssetRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import tools.jackson.databind.ObjectMapper;
 
 @Service
 public class GamePersistenceService {
     private static final String GAME_LOG_TURN_UNIQUE_CONSTRAINT = "uk_game_log_session_turn";
     private static final String IMAGE_ASSET_TURN_UNIQUE_CONSTRAINT = "uk_image_asset_session_turn";
+
     private final GameSessionRepository gameSessionRepository;
     private final GameLogRepository gameLogRepository;
     private final GameStateSnapshotRepository gameStateSnapshotRepository;
@@ -32,30 +31,28 @@ public class GamePersistenceService {
     private final GameStateRecovery gameStateRecovery;
     private final InventoryAuditCodec inventoryAuditCodec;
 
-    @Autowired
     public GamePersistenceService(GameSessionRepository gameSessionRepository, GameLogRepository gameLogRepository,
             GameStateSnapshotRepository gameStateSnapshotRepository, ImageAssetRepository imageAssetRepository,
             GameMutationRequestRepository gameMutationRequestRepository, GameStateCodec gameStateCodec,
             GameStateRecovery gameStateRecovery, InventoryAuditCodec inventoryAuditCodec) {
-        this.gameSessionRepository = gameSessionRepository; this.gameLogRepository = gameLogRepository;
-        this.gameStateSnapshotRepository = gameStateSnapshotRepository; this.imageAssetRepository = imageAssetRepository;
-        this.gameMutationRequestRepository = gameMutationRequestRepository; this.gameStateCodec = gameStateCodec;
-        this.gameStateRecovery = gameStateRecovery; this.inventoryAuditCodec = inventoryAuditCodec;
+        this.gameSessionRepository = gameSessionRepository;
+        this.gameLogRepository = gameLogRepository;
+        this.gameStateSnapshotRepository = gameStateSnapshotRepository;
+        this.imageAssetRepository = imageAssetRepository;
+        this.gameMutationRequestRepository = gameMutationRequestRepository;
+        this.gameStateCodec = gameStateCodec;
+        this.gameStateRecovery = gameStateRecovery;
+        this.inventoryAuditCodec = inventoryAuditCodec;
     }
 
-    public GamePersistenceService(GameSessionRepository gameSessionRepository, GameLogRepository gameLogRepository,
-            GameStateSnapshotRepository gameStateSnapshotRepository, ImageAssetRepository imageAssetRepository,
-            GameMutationRequestRepository gameMutationRequestRepository, GameStateCodec gameStateCodec,
-            GameStateRecovery gameStateRecovery) {
-        this(gameSessionRepository, gameLogRepository, gameStateSnapshotRepository, imageAssetRepository,
-                gameMutationRequestRepository, gameStateCodec, gameStateRecovery, new InventoryAuditCodec(new ObjectMapper()));
-    }
-
-    @Transactional public GameSession saveOpening(String ownerKey, String worldSetting, String characterSetting, String storyText,
+    @Transactional
+    public GameSession saveOpening(String ownerKey, String worldSetting, String characterSetting, String storyText,
             String choicesJson, ImageAssetService.AssetReference imageAsset) {
         return saveOpening(ownerKey, worldSetting, characterSetting, storyText, choicesJson, imageAsset, null, null);
     }
-    @Transactional public GameSession saveOpening(String ownerKey, String worldSetting, String characterSetting, String storyText,
+
+    @Transactional
+    public GameSession saveOpening(String ownerKey, String worldSetting, String characterSetting, String storyText,
             String choicesJson, ImageAssetService.AssetReference imageAsset, Long mutationRequestId, String resultTitle) {
         try {
             GameSession session = gameSessionRepository.save(new GameSession(ownerKey, worldSetting, characterSetting));
@@ -63,52 +60,92 @@ public class GamePersistenceService {
             GameState initialState = GameState.initial(worldSetting, characterSetting, storyText);
             gameStateSnapshotRepository.save(new GameStateSnapshot(session, gameStateCodec.serialize(initialState)));
             gameLogRepository.save(GameLog.opening(session, storyText, choicesJson, imageUrl));
-            completeMutationRequest(mutationRequestId, session.getId(), 1, resultTitle); flushAll(); return session;
-        } catch (DataIntegrityViolationException exception) { throw new PersistenceOperationException("게임 시작 상태를 저장할 수 없습니다.", exception); }
+            completeMutationRequest(mutationRequestId, session.getId(), 1, resultTitle);
+            flushAll();
+            return session;
+        } catch (DataIntegrityViolationException exception) {
+            throw new PersistenceOperationException("게임 시작 상태를 저장할 수 없습니다.", exception);
+        }
     }
 
-    @Transactional(readOnly = true) public LoadedTurn loadLatestTurn(String ownerKey, Long sessionId, int expectedTurn) {
+    @Transactional(readOnly = true)
+    public LoadedTurn loadLatestTurn(String ownerKey, Long sessionId, int expectedTurn) {
         GameSession session = findOwnedSession(ownerKey, sessionId);
         if (session.getCurrentTurn() != expectedTurn) throw new TurnConflictException("이미 처리되었거나 오래된 턴 요청입니다.");
-        GameLog lastLog = gameLogRepository.findTopByGameSessionOrderByTurnNumberDesc(session).orElseThrow(() -> new IllegalStateException("게임 로그가 없습니다."));
+        GameLog lastLog = gameLogRepository.findTopByGameSessionOrderByTurnNumberDesc(session)
+                .orElseThrow(() -> new IllegalStateException("게임 로그가 없습니다."));
         if (lastLog.getTurnNumber() != expectedTurn) throw new IllegalStateException("세션 턴과 저장된 로그가 일치하지 않습니다.");
         GameState gameState = loadOrRecoverState(session);
-        if (gameState.turnNumber() != expectedTurn || lastLog.getStateVersion() != expectedTurn) throw new IllegalStateException("세션 턴과 canonical state version이 일치하지 않습니다.");
-        return new LoadedTurn(session.getId(), session.getCurrentTurn(), session.getWorldSetting(), session.getCharacterSetting(), lastLog.getStoryText(), lastLog.getChoicesJson(), lastLog.getImageUrl(), gameState);
+        if (gameState.turnNumber() != expectedTurn || lastLog.getStateVersion() != expectedTurn) {
+            throw new IllegalStateException("세션 턴과 canonical state version이 일치하지 않습니다.");
+        }
+        return new LoadedTurn(session.getId(), session.getCurrentTurn(), session.getWorldSetting(),
+                session.getCharacterSetting(), lastLog.getStoryText(), lastLog.getChoicesJson(), lastLog.getImageUrl(), gameState);
     }
 
-    @Transactional(readOnly = true) public CommittedTurn loadCommittedTurn(String ownerKey, Long sessionId, int turnNumber) {
+    @Transactional(readOnly = true)
+    public CommittedTurn loadCommittedTurn(String ownerKey, Long sessionId, int turnNumber) {
         GameSession session = findOwnedSession(ownerKey, sessionId);
-        GameLog log = gameLogRepository.findByGameSessionAndTurnNumber(session, turnNumber).orElseThrow(() -> new IllegalStateException("완료된 게임 로그를 찾을 수 없습니다."));
-        return new CommittedTurn(log.getStoryText(), log.getChoicesJson(), log.getImageUrl(), loadOrRecoverState(session), SkillCheckAudit.from(log));
+        GameLog log = gameLogRepository.findByGameSessionAndTurnNumber(session, turnNumber)
+                .orElseThrow(() -> new IllegalStateException("완료된 게임 로그를 찾을 수 없습니다."));
+        GameState gameState = loadOrRecoverState(session);
+        return new CommittedTurn(
+                log.getStoryText(),
+                log.getChoicesJson(),
+                log.getImageUrl(),
+                gameState,
+                SkillCheckAudit.from(log)
+        );
     }
 
-    @Transactional public int saveNextTurn(String ownerKey, Long sessionId, GameTurnCommit commit) { return saveNextTurn(ownerKey, sessionId, commit, null, null, null); }
-    @Transactional public int saveNextTurn(String ownerKey, Long sessionId, GameTurnCommit commit, Long mutationRequestId, String resultTitle) { return saveNextTurn(ownerKey, sessionId, commit, mutationRequestId, resultTitle, null); }
-    @Transactional public int saveNextTurn(String ownerKey, Long sessionId, GameTurnCommit commit, Long mutationRequestId, String resultTitle, String reservationOwner) {
+    @Transactional
+    public int saveNextTurn(String ownerKey, Long sessionId, GameTurnCommit commit) {
+        return saveNextTurn(ownerKey, sessionId, commit, null, null, null);
+    }
+
+    @Transactional
+    public int saveNextTurn(String ownerKey, Long sessionId, GameTurnCommit commit, Long mutationRequestId, String resultTitle) {
+        return saveNextTurn(ownerKey, sessionId, commit, mutationRequestId, resultTitle, null);
+    }
+
+    @Transactional
+    public int saveNextTurn(String ownerKey, Long sessionId, GameTurnCommit commit, Long mutationRequestId,
+            String resultTitle, String reservationOwner) {
         try {
             if (reservationOwner != null) verifyReservation(sessionId, commit.expectedTurn(), reservationOwner);
-            GameSession session = findOwnedSession(ownerKey, sessionId); validateCommitAgainstSession(session, commit);
-            GameLog previousLog = gameLogRepository.findTopByGameSessionOrderByTurnNumberDesc(session).orElseThrow(() -> new IllegalStateException("게임 로그가 없습니다."));
-            if (previousLog.getTurnNumber() != commit.expectedTurn() || previousLog.getStateVersion() != commit.previousStateVersion()) throw new IllegalStateException("세션 턴과 저장된 로그의 state version이 일치하지 않습니다.");
+            GameSession session = findOwnedSession(ownerKey, sessionId);
+            validateCommitAgainstSession(session, commit);
+            GameLog previousLog = gameLogRepository.findTopByGameSessionOrderByTurnNumberDesc(session)
+                    .orElseThrow(() -> new IllegalStateException("게임 로그가 없습니다."));
+            if (previousLog.getTurnNumber() != commit.expectedTurn() || previousLog.getStateVersion() != commit.previousStateVersion()) {
+                throw new IllegalStateException("세션 턴과 저장된 로그의 state version이 일치하지 않습니다.");
+            }
             GameState canonicalPreviousState = loadOrRecoverState(session);
-            if (!canonicalPreviousState.equals(commit.previousState())) throw new TurnConflictException("commit의 이전 상태가 현재 canonical state와 일치하지 않습니다.");
+            if (!canonicalPreviousState.equals(commit.previousState())) {
+                throw new TurnConflictException("commit의 이전 상태가 현재 canonical state와 일치하지 않습니다.");
+            }
             session.advanceTurn();
-            String imageUrl = commit.imageAsset() == null ? previousLog.getImageUrl() : persistImageAsset(session, commit.nextStateVersion(), commit.imageAsset());
+            String imageUrl = commit.imageAsset() == null ? previousLog.getImageUrl()
+                    : persistImageAsset(session, commit.nextStateVersion(), commit.imageAsset());
             String inventoryChangesJson = inventoryAuditCodec.serialize(commit.stateChanges());
             gameSessionRepository.save(session);
-            gameLogRepository.save(GameLog.committedTurn(session, commit.nextStateVersion(), commit.inputChoiceId(), commit.inputChoiceText(),
-                    commit.previousStateVersion(), commit.nextStateVersion(), commit.canonicalResultId(), commit.generatedStoryId(),
-                    commit.skillCheckResult(), inventoryChangesJson, commit.storyText(), commit.choicesJson(), imageUrl));
-            GameStateSnapshot snapshot = gameStateSnapshotRepository.findById(sessionId).orElseGet(() -> new GameStateSnapshot(session, gameStateCodec.serialize(commit.previousState())));
-            snapshot.updateStateJson(gameStateCodec.serialize(commit.nextState())); gameStateSnapshotRepository.save(snapshot);
+            gameLogRepository.save(GameLog.committedTurn(session, commit.nextStateVersion(), commit.inputChoiceId(),
+                    commit.inputChoiceText(), commit.previousStateVersion(), commit.nextStateVersion(),
+                    commit.canonicalResultId(), commit.generatedStoryId(), commit.skillCheckResult(), inventoryChangesJson,
+                    commit.storyText(), commit.choicesJson(), imageUrl));
+            GameStateSnapshot snapshot = gameStateSnapshotRepository.findById(sessionId)
+                    .orElseGet(() -> new GameStateSnapshot(session, gameStateCodec.serialize(commit.previousState())));
+            snapshot.updateStateJson(gameStateCodec.serialize(commit.nextState()));
+            gameStateSnapshotRepository.save(snapshot);
             completeMutationRequest(mutationRequestId, session.getId(), session.getCurrentTurn(), resultTitle);
             if (reservationOwner != null) {
                 int released = gameMutationRequestRepository.releaseReservation(sessionId, commit.expectedTurn(), mutationRequestId, reservationOwner);
                 if (released != 1) throw new TurnConflictException("턴 reservation 소유권이 변경되었습니다.");
             }
-            flushAll(); return session.getCurrentTurn();
-        } catch (ObjectOptimisticLockingFailureException exception) { throw new TurnConflictException("동시에 처리된 턴 요청과 충돌했습니다.", exception);
+            flushAll();
+            return session.getCurrentTurn();
+        } catch (ObjectOptimisticLockingFailureException exception) {
+            throw new TurnConflictException("동시에 처리된 턴 요청과 충돌했습니다.", exception);
         } catch (DataIntegrityViolationException exception) {
             if (isTurnUniqueConstraintViolation(exception)) throw new TurnConflictException("동시에 처리된 턴 요청과 충돌했습니다.", exception);
             throw new PersistenceOperationException("게임 진행 상태를 저장할 수 없습니다.", exception);
@@ -116,40 +153,98 @@ public class GamePersistenceService {
     }
 
     private void verifyReservation(Long sessionId, int expectedTurn, String reservationOwner) {
-        String currentOwner = gameMutationRequestRepository.findReservationOwnerForUpdate(sessionId, expectedTurn).orElseThrow(() -> new TurnConflictException("턴 reservation이 만료되었거나 회수되었습니다."));
+        if (reservationOwner == null) throw new TurnConflictException("턴 reservation 소유권이 없습니다.");
+        String currentOwner = gameMutationRequestRepository.findReservationOwnerForUpdate(sessionId, expectedTurn)
+                .orElseThrow(() -> new TurnConflictException("턴 reservation이 만료되었거나 회수되었습니다."));
         if (!reservationOwner.equals(currentOwner)) throw new TurnConflictException("턴 reservation 소유권이 변경되었습니다.");
     }
+
     private void completeMutationRequest(Long mutationRequestId, Long sessionId, int turn, String resultTitle) {
         if (mutationRequestId == null) return;
-        GameMutationRequest request = gameMutationRequestRepository.findById(mutationRequestId).orElseThrow(() -> new IllegalStateException("mutation request를 찾을 수 없습니다."));
-        request.complete(sessionId, turn, resultTitle); gameMutationRequestRepository.save(request);
+        GameMutationRequest request = gameMutationRequestRepository.findById(mutationRequestId)
+                .orElseThrow(() -> new IllegalStateException("mutation request를 찾을 수 없습니다."));
+        request.complete(sessionId, turn, resultTitle);
+        gameMutationRequestRepository.save(request);
     }
+
     private void validateCommitAgainstSession(GameSession session, GameTurnCommit commit) {
         if (session.getCurrentTurn() != commit.expectedTurn()) throw new TurnConflictException("이미 처리되었거나 오래된 턴 요청입니다.");
         if (commit.previousStateVersion() != commit.expectedTurn()) throw new IllegalArgumentException("commit의 이전 state version이 expectedTurn과 일치하지 않습니다.");
         if (commit.nextStateVersion() != commit.expectedTurn() + 1) throw new IllegalArgumentException("commit의 다음 state version이 올바르지 않습니다.");
     }
-    private String persistImageAsset(GameSession session, int turnNumber, ImageAssetService.AssetReference ref) {
-        if (ref == null) return null;
-        ImageAsset asset = new ImageAsset(ref.id(), session, turnNumber, ref.prompt(), ref.aspectRatio(), ref.model(), ref.width(), ref.height(), ref.seed(), ref.safe(), ref.styleVersion());
-        imageAssetRepository.save(asset); return asset.publicUrl();
-    }
-    private GameSession findOwnedSession(String ownerKey, Long sessionId) { return gameSessionRepository.findByIdAndOwnerKey(sessionId, ownerKey).orElseThrow(() -> new GameSessionNotFoundException("존재하지 않는 세션입니다.")); }
-    private boolean isTurnUniqueConstraintViolation(DataIntegrityViolationException exception) {
-        Throwable cause = exception.getMostSpecificCause(); String message = cause == null ? exception.getMessage() : cause.getMessage(); if (message == null) return false;
-        String normalized = message.toLowerCase(); return normalized.contains(GAME_LOG_TURN_UNIQUE_CONSTRAINT) || normalized.contains(IMAGE_ASSET_TURN_UNIQUE_CONSTRAINT);
-    }
-    private GameState loadOrRecoverState(GameSession session) { return gameStateSnapshotRepository.findById(session.getId()).map(s -> gameStateCodec.deserialize(s.getStateJson())).orElseGet(() -> gameStateRecovery.recover(session, gameLogRepository.findByGameSessionOrderByTurnNumberAsc(session))); }
-    private void flushAll() { imageAssetRepository.flush(); gameLogRepository.flush(); gameStateSnapshotRepository.flush(); gameSessionRepository.flush(); gameMutationRequestRepository.flush(); }
 
-    public record LoadedTurn(Long sessionId, int turnNumber, String worldSetting, String characterSetting, String storyText, String choicesJson, String imageUrl, GameState gameState) {}
-    public record CommittedTurn(String storyText, String choicesJson, String imageUrl, GameState gameState, SkillCheckAudit skillCheckAudit) {
-        public CommittedTurn(String storyText, String choicesJson, String imageUrl) { this(storyText, choicesJson, imageUrl, null, null); }
+    private String persistImageAsset(GameSession session, int turnNumber, ImageAssetService.AssetReference assetReference) {
+        if (assetReference == null) return null;
+        ImageAsset asset = new ImageAsset(assetReference.id(), session, turnNumber, assetReference.prompt(),
+                assetReference.aspectRatio(), assetReference.model(), assetReference.width(), assetReference.height(),
+                assetReference.seed(), assetReference.safe(), assetReference.styleVersion());
+        imageAssetRepository.save(asset);
+        return asset.publicUrl();
     }
-    public record SkillCheckAudit(String statType, Integer rawRoll, Integer statModifier, Integer situationalModifier, Integer dc, Integer total, String outcome, Integer rulesetVersion) {
+
+    private GameSession findOwnedSession(String ownerKey, Long sessionId) {
+        return gameSessionRepository.findByIdAndOwnerKey(sessionId, ownerKey)
+                .orElseThrow(() -> new GameSessionNotFoundException("존재하지 않는 세션입니다."));
+    }
+
+    private boolean isTurnUniqueConstraintViolation(DataIntegrityViolationException exception) {
+        Throwable cause = exception.getMostSpecificCause();
+        String message = cause == null ? exception.getMessage() : cause.getMessage();
+        if (message == null) return false;
+        String normalized = message.toLowerCase();
+        return normalized.contains(GAME_LOG_TURN_UNIQUE_CONSTRAINT) || normalized.contains(IMAGE_ASSET_TURN_UNIQUE_CONSTRAINT);
+    }
+
+    private GameState loadOrRecoverState(GameSession session) {
+        return gameStateSnapshotRepository.findById(session.getId()).map(snapshot -> gameStateCodec.deserialize(snapshot.getStateJson()))
+                .orElseGet(() -> gameStateRecovery.recover(session, gameLogRepository.findByGameSessionOrderByTurnNumberAsc(session)));
+    }
+
+    private void flushAll() {
+        imageAssetRepository.flush();
+        gameLogRepository.flush();
+        gameStateSnapshotRepository.flush();
+        gameSessionRepository.flush();
+        gameMutationRequestRepository.flush();
+    }
+
+    public record LoadedTurn(Long sessionId, int turnNumber, String worldSetting, String characterSetting,
+            String storyText, String choicesJson, String imageUrl, GameState gameState) {}
+
+    public record CommittedTurn(
+            String storyText,
+            String choicesJson,
+            String imageUrl,
+            GameState gameState,
+            SkillCheckAudit skillCheckAudit
+    ) {
+        public CommittedTurn(String storyText, String choicesJson, String imageUrl) {
+            this(storyText, choicesJson, imageUrl, null, null);
+        }
+    }
+
+    public record SkillCheckAudit(
+            String statType,
+            Integer rawRoll,
+            Integer statModifier,
+            Integer situationalModifier,
+            Integer dc,
+            Integer total,
+            String outcome,
+            Integer rulesetVersion
+    ) {
         static SkillCheckAudit from(GameLog log) {
             if (log.getSkillCheckStatType() == null) return null;
-            return new SkillCheckAudit(log.getSkillCheckStatType(), log.getSkillCheckRawRoll(), log.getSkillCheckStatModifier(), log.getSkillCheckSituationalModifier(), log.getSkillCheckDc(), log.getSkillCheckTotal(), log.getSkillCheckOutcome(), log.getSkillCheckRulesetVersion());
+            return new SkillCheckAudit(
+                    log.getSkillCheckStatType(),
+                    log.getSkillCheckRawRoll(),
+                    log.getSkillCheckStatModifier(),
+                    log.getSkillCheckSituationalModifier(),
+                    log.getSkillCheckDc(),
+                    log.getSkillCheckTotal(),
+                    log.getSkillCheckOutcome(),
+                    log.getSkillCheckRulesetVersion()
+            );
         }
     }
 }

--- a/src/main/java/com/uctale/uctale/application/game/GamePersistenceService.java
+++ b/src/main/java/com/uctale/uctale/application/game/GamePersistenceService.java
@@ -12,16 +12,17 @@ import com.uctale.uctale.repository.GameMutationRequestRepository;
 import com.uctale.uctale.repository.GameSessionRepository;
 import com.uctale.uctale.repository.GameStateSnapshotRepository;
 import com.uctale.uctale.repository.ImageAssetRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.ObjectMapper;
 
 @Service
 public class GamePersistenceService {
     private static final String GAME_LOG_TURN_UNIQUE_CONSTRAINT = "uk_game_log_session_turn";
     private static final String IMAGE_ASSET_TURN_UNIQUE_CONSTRAINT = "uk_image_asset_session_turn";
-
     private final GameSessionRepository gameSessionRepository;
     private final GameLogRepository gameLogRepository;
     private final GameStateSnapshotRepository gameStateSnapshotRepository;
@@ -29,28 +30,32 @@ public class GamePersistenceService {
     private final GameMutationRequestRepository gameMutationRequestRepository;
     private final GameStateCodec gameStateCodec;
     private final GameStateRecovery gameStateRecovery;
+    private final InventoryAuditCodec inventoryAuditCodec;
+
+    @Autowired
+    public GamePersistenceService(GameSessionRepository gameSessionRepository, GameLogRepository gameLogRepository,
+            GameStateSnapshotRepository gameStateSnapshotRepository, ImageAssetRepository imageAssetRepository,
+            GameMutationRequestRepository gameMutationRequestRepository, GameStateCodec gameStateCodec,
+            GameStateRecovery gameStateRecovery, InventoryAuditCodec inventoryAuditCodec) {
+        this.gameSessionRepository = gameSessionRepository; this.gameLogRepository = gameLogRepository;
+        this.gameStateSnapshotRepository = gameStateSnapshotRepository; this.imageAssetRepository = imageAssetRepository;
+        this.gameMutationRequestRepository = gameMutationRequestRepository; this.gameStateCodec = gameStateCodec;
+        this.gameStateRecovery = gameStateRecovery; this.inventoryAuditCodec = inventoryAuditCodec;
+    }
 
     public GamePersistenceService(GameSessionRepository gameSessionRepository, GameLogRepository gameLogRepository,
             GameStateSnapshotRepository gameStateSnapshotRepository, ImageAssetRepository imageAssetRepository,
             GameMutationRequestRepository gameMutationRequestRepository, GameStateCodec gameStateCodec,
             GameStateRecovery gameStateRecovery) {
-        this.gameSessionRepository = gameSessionRepository;
-        this.gameLogRepository = gameLogRepository;
-        this.gameStateSnapshotRepository = gameStateSnapshotRepository;
-        this.imageAssetRepository = imageAssetRepository;
-        this.gameMutationRequestRepository = gameMutationRequestRepository;
-        this.gameStateCodec = gameStateCodec;
-        this.gameStateRecovery = gameStateRecovery;
+        this(gameSessionRepository, gameLogRepository, gameStateSnapshotRepository, imageAssetRepository,
+                gameMutationRequestRepository, gameStateCodec, gameStateRecovery, new InventoryAuditCodec(new ObjectMapper()));
     }
 
-    @Transactional
-    public GameSession saveOpening(String ownerKey, String worldSetting, String characterSetting, String storyText,
+    @Transactional public GameSession saveOpening(String ownerKey, String worldSetting, String characterSetting, String storyText,
             String choicesJson, ImageAssetService.AssetReference imageAsset) {
         return saveOpening(ownerKey, worldSetting, characterSetting, storyText, choicesJson, imageAsset, null, null);
     }
-
-    @Transactional
-    public GameSession saveOpening(String ownerKey, String worldSetting, String characterSetting, String storyText,
+    @Transactional public GameSession saveOpening(String ownerKey, String worldSetting, String characterSetting, String storyText,
             String choicesJson, ImageAssetService.AssetReference imageAsset, Long mutationRequestId, String resultTitle) {
         try {
             GameSession session = gameSessionRepository.save(new GameSession(ownerKey, worldSetting, characterSetting));
@@ -58,91 +63,52 @@ public class GamePersistenceService {
             GameState initialState = GameState.initial(worldSetting, characterSetting, storyText);
             gameStateSnapshotRepository.save(new GameStateSnapshot(session, gameStateCodec.serialize(initialState)));
             gameLogRepository.save(GameLog.opening(session, storyText, choicesJson, imageUrl));
-            completeMutationRequest(mutationRequestId, session.getId(), 1, resultTitle);
-            flushAll();
-            return session;
-        } catch (DataIntegrityViolationException exception) {
-            throw new PersistenceOperationException("게임 시작 상태를 저장할 수 없습니다.", exception);
-        }
+            completeMutationRequest(mutationRequestId, session.getId(), 1, resultTitle); flushAll(); return session;
+        } catch (DataIntegrityViolationException exception) { throw new PersistenceOperationException("게임 시작 상태를 저장할 수 없습니다.", exception); }
     }
 
-    @Transactional(readOnly = true)
-    public LoadedTurn loadLatestTurn(String ownerKey, Long sessionId, int expectedTurn) {
+    @Transactional(readOnly = true) public LoadedTurn loadLatestTurn(String ownerKey, Long sessionId, int expectedTurn) {
         GameSession session = findOwnedSession(ownerKey, sessionId);
         if (session.getCurrentTurn() != expectedTurn) throw new TurnConflictException("이미 처리되었거나 오래된 턴 요청입니다.");
-        GameLog lastLog = gameLogRepository.findTopByGameSessionOrderByTurnNumberDesc(session)
-                .orElseThrow(() -> new IllegalStateException("게임 로그가 없습니다."));
+        GameLog lastLog = gameLogRepository.findTopByGameSessionOrderByTurnNumberDesc(session).orElseThrow(() -> new IllegalStateException("게임 로그가 없습니다."));
         if (lastLog.getTurnNumber() != expectedTurn) throw new IllegalStateException("세션 턴과 저장된 로그가 일치하지 않습니다.");
         GameState gameState = loadOrRecoverState(session);
-        if (gameState.turnNumber() != expectedTurn || lastLog.getStateVersion() != expectedTurn) {
-            throw new IllegalStateException("세션 턴과 canonical state version이 일치하지 않습니다.");
-        }
-        return new LoadedTurn(session.getId(), session.getCurrentTurn(), session.getWorldSetting(),
-                session.getCharacterSetting(), lastLog.getStoryText(), lastLog.getChoicesJson(), lastLog.getImageUrl(), gameState);
+        if (gameState.turnNumber() != expectedTurn || lastLog.getStateVersion() != expectedTurn) throw new IllegalStateException("세션 턴과 canonical state version이 일치하지 않습니다.");
+        return new LoadedTurn(session.getId(), session.getCurrentTurn(), session.getWorldSetting(), session.getCharacterSetting(), lastLog.getStoryText(), lastLog.getChoicesJson(), lastLog.getImageUrl(), gameState);
     }
 
-    @Transactional(readOnly = true)
-    public CommittedTurn loadCommittedTurn(String ownerKey, Long sessionId, int turnNumber) {
+    @Transactional(readOnly = true) public CommittedTurn loadCommittedTurn(String ownerKey, Long sessionId, int turnNumber) {
         GameSession session = findOwnedSession(ownerKey, sessionId);
-        GameLog log = gameLogRepository.findByGameSessionAndTurnNumber(session, turnNumber)
-                .orElseThrow(() -> new IllegalStateException("완료된 게임 로그를 찾을 수 없습니다."));
-        GameState gameState = loadOrRecoverState(session);
-        return new CommittedTurn(
-                log.getStoryText(),
-                log.getChoicesJson(),
-                log.getImageUrl(),
-                gameState,
-                SkillCheckAudit.from(log)
-        );
+        GameLog log = gameLogRepository.findByGameSessionAndTurnNumber(session, turnNumber).orElseThrow(() -> new IllegalStateException("완료된 게임 로그를 찾을 수 없습니다."));
+        return new CommittedTurn(log.getStoryText(), log.getChoicesJson(), log.getImageUrl(), loadOrRecoverState(session), SkillCheckAudit.from(log));
     }
 
-    @Transactional
-    public int saveNextTurn(String ownerKey, Long sessionId, GameTurnCommit commit) {
-        return saveNextTurn(ownerKey, sessionId, commit, null, null, null);
-    }
-
-    @Transactional
-    public int saveNextTurn(String ownerKey, Long sessionId, GameTurnCommit commit, Long mutationRequestId, String resultTitle) {
-        return saveNextTurn(ownerKey, sessionId, commit, mutationRequestId, resultTitle, null);
-    }
-
-    @Transactional
-    public int saveNextTurn(String ownerKey, Long sessionId, GameTurnCommit commit, Long mutationRequestId,
-            String resultTitle, String reservationOwner) {
+    @Transactional public int saveNextTurn(String ownerKey, Long sessionId, GameTurnCommit commit) { return saveNextTurn(ownerKey, sessionId, commit, null, null, null); }
+    @Transactional public int saveNextTurn(String ownerKey, Long sessionId, GameTurnCommit commit, Long mutationRequestId, String resultTitle) { return saveNextTurn(ownerKey, sessionId, commit, mutationRequestId, resultTitle, null); }
+    @Transactional public int saveNextTurn(String ownerKey, Long sessionId, GameTurnCommit commit, Long mutationRequestId, String resultTitle, String reservationOwner) {
         try {
             if (reservationOwner != null) verifyReservation(sessionId, commit.expectedTurn(), reservationOwner);
-            GameSession session = findOwnedSession(ownerKey, sessionId);
-            validateCommitAgainstSession(session, commit);
-            GameLog previousLog = gameLogRepository.findTopByGameSessionOrderByTurnNumberDesc(session)
-                    .orElseThrow(() -> new IllegalStateException("게임 로그가 없습니다."));
-            if (previousLog.getTurnNumber() != commit.expectedTurn() || previousLog.getStateVersion() != commit.previousStateVersion()) {
-                throw new IllegalStateException("세션 턴과 저장된 로그의 state version이 일치하지 않습니다.");
-            }
+            GameSession session = findOwnedSession(ownerKey, sessionId); validateCommitAgainstSession(session, commit);
+            GameLog previousLog = gameLogRepository.findTopByGameSessionOrderByTurnNumberDesc(session).orElseThrow(() -> new IllegalStateException("게임 로그가 없습니다."));
+            if (previousLog.getTurnNumber() != commit.expectedTurn() || previousLog.getStateVersion() != commit.previousStateVersion()) throw new IllegalStateException("세션 턴과 저장된 로그의 state version이 일치하지 않습니다.");
             GameState canonicalPreviousState = loadOrRecoverState(session);
-            if (!canonicalPreviousState.equals(commit.previousState())) {
-                throw new TurnConflictException("commit의 이전 상태가 현재 canonical state와 일치하지 않습니다.");
-            }
+            if (!canonicalPreviousState.equals(commit.previousState())) throw new TurnConflictException("commit의 이전 상태가 현재 canonical state와 일치하지 않습니다.");
             session.advanceTurn();
-            String imageUrl = commit.imageAsset() == null ? previousLog.getImageUrl()
-                    : persistImageAsset(session, commit.nextStateVersion(), commit.imageAsset());
+            String imageUrl = commit.imageAsset() == null ? previousLog.getImageUrl() : persistImageAsset(session, commit.nextStateVersion(), commit.imageAsset());
+            String inventoryChangesJson = inventoryAuditCodec.serialize(commit.stateChanges());
             gameSessionRepository.save(session);
-            gameLogRepository.save(GameLog.committedTurn(session, commit.nextStateVersion(), commit.inputChoiceId(),
-                    commit.inputChoiceText(), commit.previousStateVersion(), commit.nextStateVersion(),
-                    commit.canonicalResultId(), commit.generatedStoryId(), commit.skillCheckResult(),
-                    commit.storyText(), commit.choicesJson(), imageUrl));
-            GameStateSnapshot snapshot = gameStateSnapshotRepository.findById(sessionId)
-                    .orElseGet(() -> new GameStateSnapshot(session, gameStateCodec.serialize(commit.previousState())));
-            snapshot.updateStateJson(gameStateCodec.serialize(commit.nextState()));
-            gameStateSnapshotRepository.save(snapshot);
+            gameLogRepository.save(GameLog.committedTurn(session, commit.nextStateVersion(), commit.inputChoiceId(), commit.inputChoiceText(),
+                    commit.previousStateVersion(), commit.nextStateVersion(), commit.canonicalResultId(), commit.generatedStoryId(),
+                    commit.skillCheckResult(), inventoryChangesJson, commit.storyText(), commit.choicesJson(), imageUrl));
+            GameStateSnapshot snapshot = gameStateSnapshotRepository.findById(sessionId).orElseGet(() -> new GameStateSnapshot(session, gameStateCodec.serialize(commit.previousState())));
+            snapshot.updateStateJson(gameStateCodec.serialize(commit.nextState())); gameStateSnapshotRepository.save(snapshot);
             completeMutationRequest(mutationRequestId, session.getId(), session.getCurrentTurn(), resultTitle);
             if (reservationOwner != null) {
                 int released = gameMutationRequestRepository.releaseReservation(sessionId, commit.expectedTurn(), mutationRequestId, reservationOwner);
                 if (released != 1) throw new TurnConflictException("턴 reservation 소유권이 변경되었습니다.");
             }
-            flushAll();
-            return session.getCurrentTurn();
-        } catch (ObjectOptimisticLockingFailureException exception) {
-            throw new TurnConflictException("동시에 처리된 턴 요청과 충돌했습니다.", exception);
+            flushAll(); return session.getCurrentTurn();
+        } catch (ObjectOptimisticLockingFailureException exception) { throw new TurnConflictException("동시에 처리된 턴 요청과 충돌했습니다.", exception);
         } catch (DataIntegrityViolationException exception) {
             if (isTurnUniqueConstraintViolation(exception)) throw new TurnConflictException("동시에 처리된 턴 요청과 충돌했습니다.", exception);
             throw new PersistenceOperationException("게임 진행 상태를 저장할 수 없습니다.", exception);
@@ -150,98 +116,40 @@ public class GamePersistenceService {
     }
 
     private void verifyReservation(Long sessionId, int expectedTurn, String reservationOwner) {
-        if (reservationOwner == null) throw new TurnConflictException("턴 reservation 소유권이 없습니다.");
-        String currentOwner = gameMutationRequestRepository.findReservationOwnerForUpdate(sessionId, expectedTurn)
-                .orElseThrow(() -> new TurnConflictException("턴 reservation이 만료되었거나 회수되었습니다."));
+        String currentOwner = gameMutationRequestRepository.findReservationOwnerForUpdate(sessionId, expectedTurn).orElseThrow(() -> new TurnConflictException("턴 reservation이 만료되었거나 회수되었습니다."));
         if (!reservationOwner.equals(currentOwner)) throw new TurnConflictException("턴 reservation 소유권이 변경되었습니다.");
     }
-
     private void completeMutationRequest(Long mutationRequestId, Long sessionId, int turn, String resultTitle) {
         if (mutationRequestId == null) return;
-        GameMutationRequest request = gameMutationRequestRepository.findById(mutationRequestId)
-                .orElseThrow(() -> new IllegalStateException("mutation request를 찾을 수 없습니다."));
-        request.complete(sessionId, turn, resultTitle);
-        gameMutationRequestRepository.save(request);
+        GameMutationRequest request = gameMutationRequestRepository.findById(mutationRequestId).orElseThrow(() -> new IllegalStateException("mutation request를 찾을 수 없습니다."));
+        request.complete(sessionId, turn, resultTitle); gameMutationRequestRepository.save(request);
     }
-
     private void validateCommitAgainstSession(GameSession session, GameTurnCommit commit) {
         if (session.getCurrentTurn() != commit.expectedTurn()) throw new TurnConflictException("이미 처리되었거나 오래된 턴 요청입니다.");
         if (commit.previousStateVersion() != commit.expectedTurn()) throw new IllegalArgumentException("commit의 이전 state version이 expectedTurn과 일치하지 않습니다.");
         if (commit.nextStateVersion() != commit.expectedTurn() + 1) throw new IllegalArgumentException("commit의 다음 state version이 올바르지 않습니다.");
     }
-
-    private String persistImageAsset(GameSession session, int turnNumber, ImageAssetService.AssetReference assetReference) {
-        if (assetReference == null) return null;
-        ImageAsset asset = new ImageAsset(assetReference.id(), session, turnNumber, assetReference.prompt(),
-                assetReference.aspectRatio(), assetReference.model(), assetReference.width(), assetReference.height(),
-                assetReference.seed(), assetReference.safe(), assetReference.styleVersion());
-        imageAssetRepository.save(asset);
-        return asset.publicUrl();
+    private String persistImageAsset(GameSession session, int turnNumber, ImageAssetService.AssetReference ref) {
+        if (ref == null) return null;
+        ImageAsset asset = new ImageAsset(ref.id(), session, turnNumber, ref.prompt(), ref.aspectRatio(), ref.model(), ref.width(), ref.height(), ref.seed(), ref.safe(), ref.styleVersion());
+        imageAssetRepository.save(asset); return asset.publicUrl();
     }
-
-    private GameSession findOwnedSession(String ownerKey, Long sessionId) {
-        return gameSessionRepository.findByIdAndOwnerKey(sessionId, ownerKey)
-                .orElseThrow(() -> new GameSessionNotFoundException("존재하지 않는 세션입니다."));
-    }
-
+    private GameSession findOwnedSession(String ownerKey, Long sessionId) { return gameSessionRepository.findByIdAndOwnerKey(sessionId, ownerKey).orElseThrow(() -> new GameSessionNotFoundException("존재하지 않는 세션입니다.")); }
     private boolean isTurnUniqueConstraintViolation(DataIntegrityViolationException exception) {
-        Throwable cause = exception.getMostSpecificCause();
-        String message = cause == null ? exception.getMessage() : cause.getMessage();
-        if (message == null) return false;
-        String normalized = message.toLowerCase();
-        return normalized.contains(GAME_LOG_TURN_UNIQUE_CONSTRAINT) || normalized.contains(IMAGE_ASSET_TURN_UNIQUE_CONSTRAINT);
+        Throwable cause = exception.getMostSpecificCause(); String message = cause == null ? exception.getMessage() : cause.getMessage(); if (message == null) return false;
+        String normalized = message.toLowerCase(); return normalized.contains(GAME_LOG_TURN_UNIQUE_CONSTRAINT) || normalized.contains(IMAGE_ASSET_TURN_UNIQUE_CONSTRAINT);
     }
+    private GameState loadOrRecoverState(GameSession session) { return gameStateSnapshotRepository.findById(session.getId()).map(s -> gameStateCodec.deserialize(s.getStateJson())).orElseGet(() -> gameStateRecovery.recover(session, gameLogRepository.findByGameSessionOrderByTurnNumberAsc(session))); }
+    private void flushAll() { imageAssetRepository.flush(); gameLogRepository.flush(); gameStateSnapshotRepository.flush(); gameSessionRepository.flush(); gameMutationRequestRepository.flush(); }
 
-    private GameState loadOrRecoverState(GameSession session) {
-        return gameStateSnapshotRepository.findById(session.getId()).map(snapshot -> gameStateCodec.deserialize(snapshot.getStateJson()))
-                .orElseGet(() -> gameStateRecovery.recover(session, gameLogRepository.findByGameSessionOrderByTurnNumberAsc(session)));
+    public record LoadedTurn(Long sessionId, int turnNumber, String worldSetting, String characterSetting, String storyText, String choicesJson, String imageUrl, GameState gameState) {}
+    public record CommittedTurn(String storyText, String choicesJson, String imageUrl, GameState gameState, SkillCheckAudit skillCheckAudit) {
+        public CommittedTurn(String storyText, String choicesJson, String imageUrl) { this(storyText, choicesJson, imageUrl, null, null); }
     }
-
-    private void flushAll() {
-        imageAssetRepository.flush();
-        gameLogRepository.flush();
-        gameStateSnapshotRepository.flush();
-        gameSessionRepository.flush();
-        gameMutationRequestRepository.flush();
-    }
-
-    public record LoadedTurn(Long sessionId, int turnNumber, String worldSetting, String characterSetting,
-            String storyText, String choicesJson, String imageUrl, GameState gameState) {}
-
-    public record CommittedTurn(
-            String storyText,
-            String choicesJson,
-            String imageUrl,
-            GameState gameState,
-            SkillCheckAudit skillCheckAudit
-    ) {
-        public CommittedTurn(String storyText, String choicesJson, String imageUrl) {
-            this(storyText, choicesJson, imageUrl, null, null);
-        }
-    }
-
-    public record SkillCheckAudit(
-            String statType,
-            Integer rawRoll,
-            Integer statModifier,
-            Integer situationalModifier,
-            Integer dc,
-            Integer total,
-            String outcome,
-            Integer rulesetVersion
-    ) {
+    public record SkillCheckAudit(String statType, Integer rawRoll, Integer statModifier, Integer situationalModifier, Integer dc, Integer total, String outcome, Integer rulesetVersion) {
         static SkillCheckAudit from(GameLog log) {
             if (log.getSkillCheckStatType() == null) return null;
-            return new SkillCheckAudit(
-                    log.getSkillCheckStatType(),
-                    log.getSkillCheckRawRoll(),
-                    log.getSkillCheckStatModifier(),
-                    log.getSkillCheckSituationalModifier(),
-                    log.getSkillCheckDc(),
-                    log.getSkillCheckTotal(),
-                    log.getSkillCheckOutcome(),
-                    log.getSkillCheckRulesetVersion()
-            );
+            return new SkillCheckAudit(log.getSkillCheckStatType(), log.getSkillCheckRawRoll(), log.getSkillCheckStatModifier(), log.getSkillCheckSituationalModifier(), log.getSkillCheckDc(), log.getSkillCheckTotal(), log.getSkillCheckOutcome(), log.getSkillCheckRulesetVersion());
         }
     }
 }

--- a/src/main/java/com/uctale/uctale/application/game/GameStateRecovery.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameStateRecovery.java
@@ -3,37 +3,35 @@ package com.uctale.uctale.application.game;
 import com.uctale.uctale.domain.GameLog;
 import com.uctale.uctale.domain.GameSession;
 import com.uctale.uctale.domain.game.GameState;
+import com.uctale.uctale.domain.game.InventoryRules;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
 @Component
 public class GameStateRecovery {
+    private final InventoryAuditCodec inventoryAuditCodec;
+
+    public GameStateRecovery(InventoryAuditCodec inventoryAuditCodec) {
+        this.inventoryAuditCodec = inventoryAuditCodec;
+    }
 
     public GameState recover(GameSession session, List<GameLog> logs) {
-        if (logs.isEmpty()) {
-            throw new IllegalStateException("GameState를 복구할 게임 로그가 없습니다.");
-        }
-
+        if (logs.isEmpty()) throw new IllegalStateException("GameState를 복구할 게임 로그가 없습니다.");
         GameLog opening = logs.getFirst();
-        if (opening.getTurnNumber() != 1 || opening.getPreviousStateVersion() != 0 || opening.getStateVersion() != 1) {
-            throw new IllegalStateException("Opening GameLog의 state transition이 올바르지 않습니다.");
-        }
+        if (opening.getTurnNumber() != 1 || opening.getPreviousStateVersion() != 0 || opening.getStateVersion() != 1) throw new IllegalStateException("Opening GameLog의 state transition이 올바르지 않습니다.");
+        if (!inventoryAuditCodec.deserialize(opening.getInventoryChangesJson()).isEmpty()) throw new IllegalStateException("Opening GameLog에는 inventory state change가 있을 수 없습니다.");
 
-        GameState state = GameState.initial(
-                session.getWorldSetting(),
-                session.getCharacterSetting(),
-                opening.getStoryText()
-        );
+        GameState state = GameState.initial(session.getWorldSetting(), session.getCharacterSetting(), opening.getStoryText());
         for (int i = 1; i < logs.size(); i++) {
             GameLog log = logs.get(i);
             if (log.getTurnNumber() != state.turnNumber() + 1
                     || log.getPreviousStateVersion() != state.turnNumber()
                     || log.getStateVersion() != state.turnNumber() + 1
-                    || log.getInputChoiceText() == null
-                    || log.getInputChoiceText().isBlank()) {
+                    || log.getInputChoiceText() == null || log.getInputChoiceText().isBlank()) {
                 throw new IllegalStateException("GameLog state transition을 복구할 수 없습니다.");
             }
+            state = state.withInventory(InventoryRules.replay(state.inventory(), inventoryAuditCodec.deserialize(log.getInventoryChangesJson())));
             state = state.advance(log.getInputChoiceText(), log.getStoryText());
         }
         return state;

--- a/src/main/java/com/uctale/uctale/application/game/GameStateRecovery.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameStateRecovery.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 @Component
 public class GameStateRecovery {
+
     private final InventoryAuditCodec inventoryAuditCodec;
 
     public GameStateRecovery(InventoryAuditCodec inventoryAuditCodec) {
@@ -17,21 +18,36 @@ public class GameStateRecovery {
     }
 
     public GameState recover(GameSession session, List<GameLog> logs) {
-        if (logs.isEmpty()) throw new IllegalStateException("GameState를 복구할 게임 로그가 없습니다.");
-        GameLog opening = logs.getFirst();
-        if (opening.getTurnNumber() != 1 || opening.getPreviousStateVersion() != 0 || opening.getStateVersion() != 1) throw new IllegalStateException("Opening GameLog의 state transition이 올바르지 않습니다.");
-        if (!inventoryAuditCodec.deserialize(opening.getInventoryChangesJson()).isEmpty()) throw new IllegalStateException("Opening GameLog에는 inventory state change가 있을 수 없습니다.");
+        if (logs.isEmpty()) {
+            throw new IllegalStateException("GameState를 복구할 게임 로그가 없습니다.");
+        }
 
-        GameState state = GameState.initial(session.getWorldSetting(), session.getCharacterSetting(), opening.getStoryText());
+        GameLog opening = logs.getFirst();
+        if (opening.getTurnNumber() != 1 || opening.getPreviousStateVersion() != 0 || opening.getStateVersion() != 1) {
+            throw new IllegalStateException("Opening GameLog의 state transition이 올바르지 않습니다.");
+        }
+        if (!inventoryAuditCodec.deserialize(opening.getInventoryChangesJson()).isEmpty()) {
+            throw new IllegalStateException("Opening GameLog에는 inventory state change가 있을 수 없습니다.");
+        }
+
+        GameState state = GameState.initial(
+                session.getWorldSetting(),
+                session.getCharacterSetting(),
+                opening.getStoryText()
+        );
         for (int i = 1; i < logs.size(); i++) {
             GameLog log = logs.get(i);
             if (log.getTurnNumber() != state.turnNumber() + 1
                     || log.getPreviousStateVersion() != state.turnNumber()
                     || log.getStateVersion() != state.turnNumber() + 1
-                    || log.getInputChoiceText() == null || log.getInputChoiceText().isBlank()) {
+                    || log.getInputChoiceText() == null
+                    || log.getInputChoiceText().isBlank()) {
                 throw new IllegalStateException("GameLog state transition을 복구할 수 없습니다.");
             }
-            state = state.withInventory(InventoryRules.replay(state.inventory(), inventoryAuditCodec.deserialize(log.getInventoryChangesJson())));
+            state = state.withInventory(InventoryRules.replay(
+                    state.inventory(),
+                    inventoryAuditCodec.deserialize(log.getInventoryChangesJson())
+            ));
             state = state.advance(log.getInputChoiceText(), log.getStoryText());
         }
         return state;

--- a/src/main/java/com/uctale/uctale/application/game/GameStateSnapshotFormat.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameStateSnapshotFormat.java
@@ -1,12 +1,9 @@
 package com.uctale.uctale.application.game;
 
 final class GameStateSnapshotFormat {
-
     static final int LEGACY_SCHEMA_VERSION = 0;
     static final int LEGACY_RULESET_VERSION = 1;
-    static final int CURRENT_SCHEMA_VERSION = 2;
+    static final int CURRENT_SCHEMA_VERSION = 3;
     static final int CURRENT_RULESET_VERSION = 1;
-
-    private GameStateSnapshotFormat() {
-    }
+    private GameStateSnapshotFormat() {}
 }

--- a/src/main/java/com/uctale/uctale/application/game/GameStateSnapshotFormat.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameStateSnapshotFormat.java
@@ -1,9 +1,12 @@
 package com.uctale.uctale.application.game;
 
 final class GameStateSnapshotFormat {
+
     static final int LEGACY_SCHEMA_VERSION = 0;
     static final int LEGACY_RULESET_VERSION = 1;
     static final int CURRENT_SCHEMA_VERSION = 3;
     static final int CURRENT_RULESET_VERSION = 1;
-    private GameStateSnapshotFormat() {}
+
+    private GameStateSnapshotFormat() {
+    }
 }

--- a/src/main/java/com/uctale/uctale/application/game/GameStateUpgrader.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameStateUpgrader.java
@@ -8,25 +8,51 @@ import tools.jackson.databind.node.ObjectNode;
 
 @Component
 public class GameStateUpgrader {
+
     public UpgradedSnapshot upgrade(JsonNode snapshotJson) {
         VersionedState versionedState = readSourceVersion(snapshotJson);
-        while (versionedState.schemaVersion() < GameStateSnapshotFormat.CURRENT_SCHEMA_VERSION) versionedState = upgradeOneVersion(versionedState);
-        return new UpgradedSnapshot(versionedState.schemaVersion(), versionedState.rulesetVersion(), versionedState.state());
+        while (versionedState.schemaVersion() < GameStateSnapshotFormat.CURRENT_SCHEMA_VERSION) {
+            versionedState = upgradeOneVersion(versionedState);
+        }
+        return new UpgradedSnapshot(
+                versionedState.schemaVersion(),
+                versionedState.rulesetVersion(),
+                versionedState.state()
+        );
     }
 
     private VersionedState readSourceVersion(JsonNode snapshotJson) {
-        if (snapshotJson == null || !snapshotJson.isObject()) throw new GameStateSnapshotException("GameState snapshot JSON object가 필요합니다.");
-        if (!snapshotJson.has("schemaVersion")) {
-            if (!looksLikeLegacyState(snapshotJson)) throw new GameStateSnapshotException("snapshot schemaVersion이 누락되었습니다.");
-            return new VersionedState(GameStateSnapshotFormat.LEGACY_SCHEMA_VERSION, GameStateSnapshotFormat.LEGACY_RULESET_VERSION, snapshotJson);
+        if (snapshotJson == null || !snapshotJson.isObject()) {
+            throw new GameStateSnapshotException("GameState snapshot JSON object가 필요합니다.");
         }
+
+        if (!snapshotJson.has("schemaVersion")) {
+            if (!looksLikeLegacyState(snapshotJson)) {
+                throw new GameStateSnapshotException("snapshot schemaVersion이 누락되었습니다.");
+            }
+            return new VersionedState(
+                    GameStateSnapshotFormat.LEGACY_SCHEMA_VERSION,
+                    GameStateSnapshotFormat.LEGACY_RULESET_VERSION,
+                    snapshotJson
+            );
+        }
+
         int schemaVersion = requiredInteger(snapshotJson, "schemaVersion");
-        if (schemaVersion > GameStateSnapshotFormat.CURRENT_SCHEMA_VERSION) throw new GameStateSnapshotException("지원하지 않는 미래 snapshot schemaVersion입니다: " + schemaVersion);
-        if (schemaVersion < 1) throw new GameStateSnapshotException("유효하지 않은 snapshot schemaVersion입니다: " + schemaVersion);
+        if (schemaVersion > GameStateSnapshotFormat.CURRENT_SCHEMA_VERSION) {
+            throw new GameStateSnapshotException("지원하지 않는 미래 snapshot schemaVersion입니다: " + schemaVersion);
+        }
+        if (schemaVersion < 1) {
+            throw new GameStateSnapshotException("유효하지 않은 snapshot schemaVersion입니다: " + schemaVersion);
+        }
+
         int rulesetVersion = requiredInteger(snapshotJson, "rulesetVersion");
-        if (rulesetVersion != GameStateSnapshotFormat.CURRENT_RULESET_VERSION) throw new GameStateSnapshotException("지원하지 않는 snapshot rulesetVersion입니다: " + rulesetVersion);
+        if (rulesetVersion != GameStateSnapshotFormat.CURRENT_RULESET_VERSION) {
+            throw new GameStateSnapshotException("지원하지 않는 snapshot rulesetVersion입니다: " + rulesetVersion);
+        }
         JsonNode state = snapshotJson.get("state");
-        if (state == null || !state.isObject()) throw new GameStateSnapshotException("snapshot state가 누락되었거나 손상되었습니다.");
+        if (state == null || !state.isObject()) {
+            throw new GameStateSnapshotException("snapshot state가 누락되었거나 손상되었습니다.");
+        }
         return new VersionedState(schemaVersion, rulesetVersion, state);
     }
 
@@ -35,18 +61,30 @@ public class GameStateUpgrader {
             case GameStateSnapshotFormat.LEGACY_SCHEMA_VERSION -> upgradeV0ToV1(source);
             case 1 -> upgradeV1ToV2(source);
             case 2 -> upgradeV2ToV3(source);
-            default -> throw new GameStateSnapshotException("snapshot schemaVersion " + source.schemaVersion() + "의 다음 upgrade 경로가 없습니다.");
+            default -> throw new GameStateSnapshotException(
+                    "snapshot schemaVersion " + source.schemaVersion() + "의 다음 upgrade 경로가 없습니다."
+            );
         };
     }
 
-    private VersionedState upgradeV0ToV1(VersionedState legacy) { return new VersionedState(1, legacy.rulesetVersion(), legacy.state()); }
+    private VersionedState upgradeV0ToV1(VersionedState legacy) {
+        return new VersionedState(1, legacy.rulesetVersion(), legacy.state());
+    }
 
     private VersionedState upgradeV1ToV2(VersionedState source) {
-        if (!(source.state().deepCopy() instanceof ObjectNode state)) throw new GameStateSnapshotException("snapshot state가 object가 아닙니다.");
+        if (!(source.state().deepCopy() instanceof ObjectNode state)) {
+            throw new GameStateSnapshotException("snapshot state가 object가 아닙니다.");
+        }
         JsonNode playerNode = state.get("playerCharacter");
-        if (!(playerNode instanceof ObjectNode playerCharacter)) throw new GameStateSnapshotException("snapshot playerCharacter가 누락되었거나 손상되었습니다.");
+        if (!(playerNode instanceof ObjectNode playerCharacter)) {
+            throw new GameStateSnapshotException("snapshot playerCharacter가 누락되었거나 손상되었습니다.");
+        }
+
         JsonNode legacyStats = playerCharacter.get("stats");
-        if (legacyStats != null && !legacyStats.isObject()) throw new GameStateSnapshotException("snapshot playerCharacter.stats가 object가 아닙니다.");
+        if (legacyStats != null && !legacyStats.isObject()) {
+            throw new GameStateSnapshotException("snapshot playerCharacter.stats가 object가 아닙니다.");
+        }
+
         ObjectNode normalizedStats = JsonNodeFactory.instance.objectNode();
         normalizedStats.put("might", legacyScore(legacyStats, "MIGHT", "might"));
         normalizedStats.put("agility", legacyScore(legacyStats, "AGILITY", "agility"));
@@ -54,13 +92,18 @@ public class GameStateUpgrader {
         normalizedStats.put("will", legacyScore(legacyStats, "WILL", "will"));
         normalizedStats.put("presence", legacyScore(legacyStats, "PRESENCE", "presence"));
         playerCharacter.set("stats", normalizedStats);
+
         return new VersionedState(2, source.rulesetVersion(), state);
     }
 
     private VersionedState upgradeV2ToV3(VersionedState source) {
-        if (!(source.state().deepCopy() instanceof ObjectNode state)) throw new GameStateSnapshotException("snapshot state가 object가 아닙니다.");
+        if (!(source.state().deepCopy() instanceof ObjectNode state)) {
+            throw new GameStateSnapshotException("snapshot state가 object가 아닙니다.");
+        }
         JsonNode inventory = state.get("inventory");
-        if (inventory != null && !inventory.isObject()) throw new GameStateSnapshotException("snapshot inventory가 object가 아닙니다.");
+        if (inventory != null && !inventory.isObject()) {
+            throw new GameStateSnapshotException("snapshot inventory가 object가 아닙니다.");
+        }
         if (inventory == null) {
             ObjectNode emptyInventory = JsonNodeFactory.instance.objectNode();
             emptyInventory.set("items", JsonNodeFactory.instance.objectNode());
@@ -73,26 +116,50 @@ public class GameStateUpgrader {
     }
 
     private int legacyScore(JsonNode stats, String enumKey, String fieldKey) {
-        if (stats == null) return CharacterStats.DEFAULT_SCORE;
-        JsonNode value = stats.get(fieldKey); if (value == null) value = stats.get(enumKey); if (value == null) return CharacterStats.DEFAULT_SCORE;
-        if (!value.isIntegralNumber()) throw new GameStateSnapshotException("snapshot 능력치 " + enumKey + "가 정수가 아닙니다.");
+        if (stats == null) {
+            return CharacterStats.DEFAULT_SCORE;
+        }
+        JsonNode value = stats.get(fieldKey);
+        if (value == null) {
+            value = stats.get(enumKey);
+        }
+        if (value == null) {
+            return CharacterStats.DEFAULT_SCORE;
+        }
+        if (!value.isIntegralNumber()) {
+            throw new GameStateSnapshotException("snapshot 능력치 " + enumKey + "가 정수가 아닙니다.");
+        }
         long score = value.asLong();
-        if (score < CharacterStats.MIN_SCORE || score > CharacterStats.MAX_SCORE) throw new GameStateSnapshotException("snapshot 능력치 " + enumKey + "가 허용 범위를 벗어났습니다: " + score);
+        if (score < CharacterStats.MIN_SCORE || score > CharacterStats.MAX_SCORE) {
+            throw new GameStateSnapshotException("snapshot 능력치 " + enumKey + "가 허용 범위를 벗어났습니다: " + score);
+        }
         return (int) score;
     }
 
     private boolean looksLikeLegacyState(JsonNode snapshotJson) {
-        return snapshotJson.has("turnNumber") && snapshotJson.has("playerCharacter") && snapshotJson.has("worldState") && snapshotJson.has("storyMemory") && !snapshotJson.has("rulesetVersion") && !snapshotJson.has("state");
+        return snapshotJson.has("turnNumber")
+                && snapshotJson.has("playerCharacter")
+                && snapshotJson.has("worldState")
+                && snapshotJson.has("storyMemory")
+                && !snapshotJson.has("rulesetVersion")
+                && !snapshotJson.has("state");
     }
 
     private int requiredInteger(JsonNode snapshotJson, String fieldName) {
         JsonNode value = snapshotJson.get(fieldName);
-        if (value == null || !value.isIntegralNumber()) throw new GameStateSnapshotException("snapshot " + fieldName + "이 누락되었거나 정수가 아닙니다.");
+        if (value == null || !value.isIntegralNumber()) {
+            throw new GameStateSnapshotException("snapshot " + fieldName + "이 누락되었거나 정수가 아닙니다.");
+        }
         long version = value.asLong();
-        if (version < Integer.MIN_VALUE || version > Integer.MAX_VALUE) throw new GameStateSnapshotException("snapshot " + fieldName + "이 지원 범위를 벗어났습니다: " + version);
+        if (version < Integer.MIN_VALUE || version > Integer.MAX_VALUE) {
+            throw new GameStateSnapshotException("snapshot " + fieldName + "이 지원 범위를 벗어났습니다: " + version);
+        }
         return (int) version;
     }
 
-    private record VersionedState(int schemaVersion, int rulesetVersion, JsonNode state) {}
-    public record UpgradedSnapshot(int schemaVersion, int rulesetVersion, JsonNode state) {}
+    private record VersionedState(int schemaVersion, int rulesetVersion, JsonNode state) {
+    }
+
+    public record UpgradedSnapshot(int schemaVersion, int rulesetVersion, JsonNode state) {
+    }
 }

--- a/src/main/java/com/uctale/uctale/application/game/GameStateUpgrader.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameStateUpgrader.java
@@ -100,18 +100,16 @@ public class GameStateUpgrader {
         if (!(source.state().deepCopy() instanceof ObjectNode state)) {
             throw new GameStateSnapshotException("snapshot state가 object가 아닙니다.");
         }
-        JsonNode inventory = state.get("inventory");
-        if (inventory != null && !inventory.isObject()) {
-            throw new GameStateSnapshotException("snapshot inventory가 object가 아닙니다.");
+        if (state.has("inventory")) {
+            throw new GameStateSnapshotException("schema v2 snapshot에는 inventory 필드가 정의되어 있지 않습니다.");
         }
-        if (inventory == null) {
-            ObjectNode emptyInventory = JsonNodeFactory.instance.objectNode();
-            emptyInventory.set("items", JsonNodeFactory.instance.objectNode());
-            ObjectNode equipment = JsonNodeFactory.instance.objectNode();
-            equipment.set("slots", JsonNodeFactory.instance.objectNode());
-            emptyInventory.set("equipment", equipment);
-            state.set("inventory", emptyInventory);
-        }
+
+        ObjectNode emptyInventory = JsonNodeFactory.instance.objectNode();
+        emptyInventory.set("items", JsonNodeFactory.instance.objectNode());
+        ObjectNode equipment = JsonNodeFactory.instance.objectNode();
+        equipment.set("slots", JsonNodeFactory.instance.objectNode());
+        emptyInventory.set("equipment", equipment);
+        state.set("inventory", emptyInventory);
         return new VersionedState(3, source.rulesetVersion(), state);
     }
 

--- a/src/main/java/com/uctale/uctale/application/game/GameStateUpgrader.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameStateUpgrader.java
@@ -8,51 +8,25 @@ import tools.jackson.databind.node.ObjectNode;
 
 @Component
 public class GameStateUpgrader {
-
     public UpgradedSnapshot upgrade(JsonNode snapshotJson) {
         VersionedState versionedState = readSourceVersion(snapshotJson);
-        while (versionedState.schemaVersion() < GameStateSnapshotFormat.CURRENT_SCHEMA_VERSION) {
-            versionedState = upgradeOneVersion(versionedState);
-        }
-        return new UpgradedSnapshot(
-                versionedState.schemaVersion(),
-                versionedState.rulesetVersion(),
-                versionedState.state()
-        );
+        while (versionedState.schemaVersion() < GameStateSnapshotFormat.CURRENT_SCHEMA_VERSION) versionedState = upgradeOneVersion(versionedState);
+        return new UpgradedSnapshot(versionedState.schemaVersion(), versionedState.rulesetVersion(), versionedState.state());
     }
 
     private VersionedState readSourceVersion(JsonNode snapshotJson) {
-        if (snapshotJson == null || !snapshotJson.isObject()) {
-            throw new GameStateSnapshotException("GameState snapshot JSON object가 필요합니다.");
-        }
-
+        if (snapshotJson == null || !snapshotJson.isObject()) throw new GameStateSnapshotException("GameState snapshot JSON object가 필요합니다.");
         if (!snapshotJson.has("schemaVersion")) {
-            if (!looksLikeLegacyState(snapshotJson)) {
-                throw new GameStateSnapshotException("snapshot schemaVersion이 누락되었습니다.");
-            }
-            return new VersionedState(
-                    GameStateSnapshotFormat.LEGACY_SCHEMA_VERSION,
-                    GameStateSnapshotFormat.LEGACY_RULESET_VERSION,
-                    snapshotJson
-            );
+            if (!looksLikeLegacyState(snapshotJson)) throw new GameStateSnapshotException("snapshot schemaVersion이 누락되었습니다.");
+            return new VersionedState(GameStateSnapshotFormat.LEGACY_SCHEMA_VERSION, GameStateSnapshotFormat.LEGACY_RULESET_VERSION, snapshotJson);
         }
-
         int schemaVersion = requiredInteger(snapshotJson, "schemaVersion");
-        if (schemaVersion > GameStateSnapshotFormat.CURRENT_SCHEMA_VERSION) {
-            throw new GameStateSnapshotException("지원하지 않는 미래 snapshot schemaVersion입니다: " + schemaVersion);
-        }
-        if (schemaVersion < 1) {
-            throw new GameStateSnapshotException("유효하지 않은 snapshot schemaVersion입니다: " + schemaVersion);
-        }
-
+        if (schemaVersion > GameStateSnapshotFormat.CURRENT_SCHEMA_VERSION) throw new GameStateSnapshotException("지원하지 않는 미래 snapshot schemaVersion입니다: " + schemaVersion);
+        if (schemaVersion < 1) throw new GameStateSnapshotException("유효하지 않은 snapshot schemaVersion입니다: " + schemaVersion);
         int rulesetVersion = requiredInteger(snapshotJson, "rulesetVersion");
-        if (rulesetVersion != GameStateSnapshotFormat.CURRENT_RULESET_VERSION) {
-            throw new GameStateSnapshotException("지원하지 않는 snapshot rulesetVersion입니다: " + rulesetVersion);
-        }
+        if (rulesetVersion != GameStateSnapshotFormat.CURRENT_RULESET_VERSION) throw new GameStateSnapshotException("지원하지 않는 snapshot rulesetVersion입니다: " + rulesetVersion);
         JsonNode state = snapshotJson.get("state");
-        if (state == null || !state.isObject()) {
-            throw new GameStateSnapshotException("snapshot state가 누락되었거나 손상되었습니다.");
-        }
+        if (state == null || !state.isObject()) throw new GameStateSnapshotException("snapshot state가 누락되었거나 손상되었습니다.");
         return new VersionedState(schemaVersion, rulesetVersion, state);
     }
 
@@ -60,30 +34,19 @@ public class GameStateUpgrader {
         return switch (source.schemaVersion()) {
             case GameStateSnapshotFormat.LEGACY_SCHEMA_VERSION -> upgradeV0ToV1(source);
             case 1 -> upgradeV1ToV2(source);
-            default -> throw new GameStateSnapshotException(
-                    "snapshot schemaVersion " + source.schemaVersion() + "의 다음 upgrade 경로가 없습니다."
-            );
+            case 2 -> upgradeV2ToV3(source);
+            default -> throw new GameStateSnapshotException("snapshot schemaVersion " + source.schemaVersion() + "의 다음 upgrade 경로가 없습니다.");
         };
     }
 
-    private VersionedState upgradeV0ToV1(VersionedState legacy) {
-        return new VersionedState(1, legacy.rulesetVersion(), legacy.state());
-    }
+    private VersionedState upgradeV0ToV1(VersionedState legacy) { return new VersionedState(1, legacy.rulesetVersion(), legacy.state()); }
 
     private VersionedState upgradeV1ToV2(VersionedState source) {
-        if (!(source.state().deepCopy() instanceof ObjectNode state)) {
-            throw new GameStateSnapshotException("snapshot state가 object가 아닙니다.");
-        }
+        if (!(source.state().deepCopy() instanceof ObjectNode state)) throw new GameStateSnapshotException("snapshot state가 object가 아닙니다.");
         JsonNode playerNode = state.get("playerCharacter");
-        if (!(playerNode instanceof ObjectNode playerCharacter)) {
-            throw new GameStateSnapshotException("snapshot playerCharacter가 누락되었거나 손상되었습니다.");
-        }
-
+        if (!(playerNode instanceof ObjectNode playerCharacter)) throw new GameStateSnapshotException("snapshot playerCharacter가 누락되었거나 손상되었습니다.");
         JsonNode legacyStats = playerCharacter.get("stats");
-        if (legacyStats != null && !legacyStats.isObject()) {
-            throw new GameStateSnapshotException("snapshot playerCharacter.stats가 object가 아닙니다.");
-        }
-
+        if (legacyStats != null && !legacyStats.isObject()) throw new GameStateSnapshotException("snapshot playerCharacter.stats가 object가 아닙니다.");
         ObjectNode normalizedStats = JsonNodeFactory.instance.objectNode();
         normalizedStats.put("might", legacyScore(legacyStats, "MIGHT", "might"));
         normalizedStats.put("agility", legacyScore(legacyStats, "AGILITY", "agility"));
@@ -91,55 +54,45 @@ public class GameStateUpgrader {
         normalizedStats.put("will", legacyScore(legacyStats, "WILL", "will"));
         normalizedStats.put("presence", legacyScore(legacyStats, "PRESENCE", "presence"));
         playerCharacter.set("stats", normalizedStats);
-
         return new VersionedState(2, source.rulesetVersion(), state);
     }
 
+    private VersionedState upgradeV2ToV3(VersionedState source) {
+        if (!(source.state().deepCopy() instanceof ObjectNode state)) throw new GameStateSnapshotException("snapshot state가 object가 아닙니다.");
+        JsonNode inventory = state.get("inventory");
+        if (inventory != null && !inventory.isObject()) throw new GameStateSnapshotException("snapshot inventory가 object가 아닙니다.");
+        if (inventory == null) {
+            ObjectNode emptyInventory = JsonNodeFactory.instance.objectNode();
+            emptyInventory.set("items", JsonNodeFactory.instance.objectNode());
+            ObjectNode equipment = JsonNodeFactory.instance.objectNode();
+            equipment.set("slots", JsonNodeFactory.instance.objectNode());
+            emptyInventory.set("equipment", equipment);
+            state.set("inventory", emptyInventory);
+        }
+        return new VersionedState(3, source.rulesetVersion(), state);
+    }
+
     private int legacyScore(JsonNode stats, String enumKey, String fieldKey) {
-        if (stats == null) {
-            return CharacterStats.DEFAULT_SCORE;
-        }
-        JsonNode value = stats.get(fieldKey);
-        if (value == null) {
-            value = stats.get(enumKey);
-        }
-        if (value == null) {
-            return CharacterStats.DEFAULT_SCORE;
-        }
-        if (!value.isIntegralNumber()) {
-            throw new GameStateSnapshotException("snapshot 능력치 " + enumKey + "가 정수가 아닙니다.");
-        }
+        if (stats == null) return CharacterStats.DEFAULT_SCORE;
+        JsonNode value = stats.get(fieldKey); if (value == null) value = stats.get(enumKey); if (value == null) return CharacterStats.DEFAULT_SCORE;
+        if (!value.isIntegralNumber()) throw new GameStateSnapshotException("snapshot 능력치 " + enumKey + "가 정수가 아닙니다.");
         long score = value.asLong();
-        if (score < CharacterStats.MIN_SCORE || score > CharacterStats.MAX_SCORE) {
-            throw new GameStateSnapshotException("snapshot 능력치 " + enumKey + "가 허용 범위를 벗어났습니다: " + score);
-        }
+        if (score < CharacterStats.MIN_SCORE || score > CharacterStats.MAX_SCORE) throw new GameStateSnapshotException("snapshot 능력치 " + enumKey + "가 허용 범위를 벗어났습니다: " + score);
         return (int) score;
     }
 
     private boolean looksLikeLegacyState(JsonNode snapshotJson) {
-        return snapshotJson.has("turnNumber")
-                && snapshotJson.has("playerCharacter")
-                && snapshotJson.has("worldState")
-                && snapshotJson.has("storyMemory")
-                && !snapshotJson.has("rulesetVersion")
-                && !snapshotJson.has("state");
+        return snapshotJson.has("turnNumber") && snapshotJson.has("playerCharacter") && snapshotJson.has("worldState") && snapshotJson.has("storyMemory") && !snapshotJson.has("rulesetVersion") && !snapshotJson.has("state");
     }
 
     private int requiredInteger(JsonNode snapshotJson, String fieldName) {
         JsonNode value = snapshotJson.get(fieldName);
-        if (value == null || !value.isIntegralNumber()) {
-            throw new GameStateSnapshotException("snapshot " + fieldName + "이 누락되었거나 정수가 아닙니다.");
-        }
+        if (value == null || !value.isIntegralNumber()) throw new GameStateSnapshotException("snapshot " + fieldName + "이 누락되었거나 정수가 아닙니다.");
         long version = value.asLong();
-        if (version < Integer.MIN_VALUE || version > Integer.MAX_VALUE) {
-            throw new GameStateSnapshotException("snapshot " + fieldName + "이 지원 범위를 벗어났습니다: " + version);
-        }
+        if (version < Integer.MIN_VALUE || version > Integer.MAX_VALUE) throw new GameStateSnapshotException("snapshot " + fieldName + "이 지원 범위를 벗어났습니다: " + version);
         return (int) version;
     }
 
-    private record VersionedState(int schemaVersion, int rulesetVersion, JsonNode state) {
-    }
-
-    public record UpgradedSnapshot(int schemaVersion, int rulesetVersion, JsonNode state) {
-    }
+    private record VersionedState(int schemaVersion, int rulesetVersion, JsonNode state) {}
+    public record UpgradedSnapshot(int schemaVersion, int rulesetVersion, JsonNode state) {}
 }

--- a/src/main/java/com/uctale/uctale/application/game/GameTurnCommit.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameTurnCommit.java
@@ -1,9 +1,14 @@
 package com.uctale.uctale.application.game;
 
 import com.uctale.uctale.application.image.ImageAssetService;
+import com.uctale.uctale.domain.game.GameResult;
 import com.uctale.uctale.domain.game.GameState;
+import com.uctale.uctale.domain.game.Inventory;
+import com.uctale.uctale.domain.game.InventoryRules;
 import com.uctale.uctale.domain.game.SkillCheckResult;
 import com.uctale.uctale.domain.game.StateTransition;
+
+import java.util.List;
 
 public record GameTurnCommit(
         int expectedTurn,
@@ -15,112 +20,60 @@ public record GameTurnCommit(
         String canonicalResultId,
         String generatedStoryId,
         SkillCheckResult skillCheckResult,
+        List<GameResult.StateChange> stateChanges,
         ImageAssetService.AssetReference imageAsset
 ) {
     private static final int MAX_LINK_ID_LENGTH = 128;
 
     public GameTurnCommit {
-        if (expectedTurn < 1) {
-            throw new IllegalArgumentException("expectedTurn은 1 이상이어야 합니다.");
-        }
-        if (inputChoiceId < 1) {
-            throw new IllegalArgumentException("inputChoiceId는 1 이상이어야 합니다.");
-        }
-        if (inputChoiceText == null || inputChoiceText.isBlank()) {
-            throw new IllegalArgumentException("inputChoiceText는 비어 있을 수 없습니다.");
-        }
-        if (stateTransition == null) {
-            throw new IllegalArgumentException("stateTransition은 null일 수 없습니다.");
-        }
-        if (stateTransition.previousState().turnNumber() != expectedTurn) {
-            throw new IllegalArgumentException("previousState turn과 expectedTurn이 일치해야 합니다.");
-        }
-        if (stateTransition.nextState().turnNumber() != expectedTurn + 1) {
-            throw new IllegalArgumentException("nextState는 expectedTurn의 다음 turn이어야 합니다.");
-        }
-        if (storyText == null || storyText.isBlank()) {
-            throw new IllegalArgumentException("storyText는 비어 있을 수 없습니다.");
-        }
-        if (choicesJson == null) {
-            throw new IllegalArgumentException("choicesJson은 null일 수 없습니다.");
-        }
-        if ((canonicalResultId == null) != (generatedStoryId == null)) {
-            throw new IllegalArgumentException("canonicalResultId와 generatedStoryId는 함께 기록해야 합니다.");
-        }
+        if (expectedTurn < 1) throw new IllegalArgumentException("expectedTurn은 1 이상이어야 합니다.");
+        if (inputChoiceId < 1) throw new IllegalArgumentException("inputChoiceId는 1 이상이어야 합니다.");
+        if (inputChoiceText == null || inputChoiceText.isBlank()) throw new IllegalArgumentException("inputChoiceText는 비어 있을 수 없습니다.");
+        if (stateTransition == null) throw new IllegalArgumentException("stateTransition은 null일 수 없습니다.");
+        if (stateTransition.previousState().turnNumber() != expectedTurn) throw new IllegalArgumentException("previousState turn과 expectedTurn이 일치해야 합니다.");
+        if (stateTransition.nextState().turnNumber() != expectedTurn + 1) throw new IllegalArgumentException("nextState는 expectedTurn의 다음 turn이어야 합니다.");
+        if (storyText == null || storyText.isBlank()) throw new IllegalArgumentException("storyText는 비어 있을 수 없습니다.");
+        if (choicesJson == null) throw new IllegalArgumentException("choicesJson은 null일 수 없습니다.");
+        if ((canonicalResultId == null) != (generatedStoryId == null)) throw new IllegalArgumentException("canonicalResultId와 generatedStoryId는 함께 기록해야 합니다.");
         validateLinkId("canonicalResultId", canonicalResultId);
         validateLinkId("generatedStoryId", generatedStoryId);
+        stateChanges = stateChanges == null ? List.of() : List.copyOf(stateChanges);
+        Inventory replayedInventory = InventoryRules.replay(stateTransition.previousState().inventory(), stateChanges);
+        if (!replayedInventory.equals(stateTransition.nextState().inventory())) throw new IllegalArgumentException("stateChanges의 inventory audit이 StateTransition과 일치하지 않습니다.");
     }
 
-    public GameTurnCommit(
-            int expectedTurn,
-            int inputChoiceId,
-            String inputChoiceText,
-            StateTransition stateTransition,
-            String storyText,
-            String choicesJson,
-            String canonicalResultId,
-            String generatedStoryId,
-            ImageAssetService.AssetReference imageAsset
-    ) {
+    public GameTurnCommit(int expectedTurn, int inputChoiceId, String inputChoiceText, StateTransition stateTransition,
+                          String storyText, String choicesJson, String canonicalResultId, String generatedStoryId,
+                          SkillCheckResult skillCheckResult, ImageAssetService.AssetReference imageAsset) {
         this(expectedTurn, inputChoiceId, inputChoiceText, stateTransition, storyText, choicesJson,
-                canonicalResultId, generatedStoryId, null, imageAsset);
+                canonicalResultId, generatedStoryId, skillCheckResult, List.of(), imageAsset);
     }
-
-    public GameTurnCommit(
-            int expectedTurn,
-            int inputChoiceId,
-            String inputChoiceText,
-            StateTransition stateTransition,
-            String storyText,
-            String choicesJson,
-            ImageAssetService.AssetReference imageAsset
-    ) {
+    public GameTurnCommit(int expectedTurn, int inputChoiceId, String inputChoiceText, StateTransition stateTransition,
+                          String storyText, String choicesJson, String canonicalResultId, String generatedStoryId,
+                          ImageAssetService.AssetReference imageAsset) {
         this(expectedTurn, inputChoiceId, inputChoiceText, stateTransition, storyText, choicesJson,
-                null, null, null, imageAsset);
+                canonicalResultId, generatedStoryId, null, List.of(), imageAsset);
     }
-
-    public GameTurnCommit(
-            int expectedTurn,
-            int inputChoiceId,
-            String inputChoiceText,
-            GameState previousState,
-            GameState nextState,
-            String storyText,
-            String choicesJson,
-            ImageAssetService.AssetReference imageAsset
-    ) {
+    public GameTurnCommit(int expectedTurn, int inputChoiceId, String inputChoiceText, StateTransition stateTransition,
+                          String storyText, String choicesJson, ImageAssetService.AssetReference imageAsset) {
+        this(expectedTurn, inputChoiceId, inputChoiceText, stateTransition, storyText, choicesJson,
+                null, null, null, List.of(), imageAsset);
+    }
+    public GameTurnCommit(int expectedTurn, int inputChoiceId, String inputChoiceText, GameState previousState,
+                          GameState nextState, String storyText, String choicesJson, ImageAssetService.AssetReference imageAsset) {
         this(expectedTurn, inputChoiceId, inputChoiceText, new StateTransition(previousState, nextState),
-                storyText, choicesJson, null, null, null, imageAsset);
+                storyText, choicesJson, null, null, null, List.of(), imageAsset);
     }
 
-    public GameState previousState() {
-        return stateTransition.previousState();
-    }
-
-    public GameState nextState() {
-        return stateTransition.nextState();
-    }
-
-    public int previousStateVersion() {
-        return previousState().turnNumber();
-    }
-
-    public int nextStateVersion() {
-        return nextState().turnNumber();
-    }
-
-    public boolean hasNarrativeLink() {
-        return canonicalResultId != null;
-    }
-
-    public boolean hasSkillCheck() {
-        return skillCheckResult != null;
-    }
+    public GameState previousState() { return stateTransition.previousState(); }
+    public GameState nextState() { return stateTransition.nextState(); }
+    public int previousStateVersion() { return previousState().turnNumber(); }
+    public int nextStateVersion() { return nextState().turnNumber(); }
+    public boolean hasNarrativeLink() { return canonicalResultId != null; }
+    public boolean hasSkillCheck() { return skillCheckResult != null; }
 
     private static void validateLinkId(String name, String value) {
         if (value == null) return;
-        if (value.isBlank() || value.length() > MAX_LINK_ID_LENGTH) {
-            throw new IllegalArgumentException(name + "가 올바르지 않습니다.");
-        }
+        if (value.isBlank() || value.length() > MAX_LINK_ID_LENGTH) throw new IllegalArgumentException(name + "가 올바르지 않습니다.");
     }
 }

--- a/src/main/java/com/uctale/uctale/application/game/GameTurnCommit.java
+++ b/src/main/java/com/uctale/uctale/application/game/GameTurnCommit.java
@@ -26,54 +26,128 @@ public record GameTurnCommit(
     private static final int MAX_LINK_ID_LENGTH = 128;
 
     public GameTurnCommit {
-        if (expectedTurn < 1) throw new IllegalArgumentException("expectedTurn은 1 이상이어야 합니다.");
-        if (inputChoiceId < 1) throw new IllegalArgumentException("inputChoiceId는 1 이상이어야 합니다.");
-        if (inputChoiceText == null || inputChoiceText.isBlank()) throw new IllegalArgumentException("inputChoiceText는 비어 있을 수 없습니다.");
-        if (stateTransition == null) throw new IllegalArgumentException("stateTransition은 null일 수 없습니다.");
-        if (stateTransition.previousState().turnNumber() != expectedTurn) throw new IllegalArgumentException("previousState turn과 expectedTurn이 일치해야 합니다.");
-        if (stateTransition.nextState().turnNumber() != expectedTurn + 1) throw new IllegalArgumentException("nextState는 expectedTurn의 다음 turn이어야 합니다.");
-        if (storyText == null || storyText.isBlank()) throw new IllegalArgumentException("storyText는 비어 있을 수 없습니다.");
-        if (choicesJson == null) throw new IllegalArgumentException("choicesJson은 null일 수 없습니다.");
-        if ((canonicalResultId == null) != (generatedStoryId == null)) throw new IllegalArgumentException("canonicalResultId와 generatedStoryId는 함께 기록해야 합니다.");
+        if (expectedTurn < 1) {
+            throw new IllegalArgumentException("expectedTurn은 1 이상이어야 합니다.");
+        }
+        if (inputChoiceId < 1) {
+            throw new IllegalArgumentException("inputChoiceId는 1 이상이어야 합니다.");
+        }
+        if (inputChoiceText == null || inputChoiceText.isBlank()) {
+            throw new IllegalArgumentException("inputChoiceText는 비어 있을 수 없습니다.");
+        }
+        if (stateTransition == null) {
+            throw new IllegalArgumentException("stateTransition은 null일 수 없습니다.");
+        }
+        if (stateTransition.previousState().turnNumber() != expectedTurn) {
+            throw new IllegalArgumentException("previousState turn과 expectedTurn이 일치해야 합니다.");
+        }
+        if (stateTransition.nextState().turnNumber() != expectedTurn + 1) {
+            throw new IllegalArgumentException("nextState는 expectedTurn의 다음 turn이어야 합니다.");
+        }
+        if (storyText == null || storyText.isBlank()) {
+            throw new IllegalArgumentException("storyText는 비어 있을 수 없습니다.");
+        }
+        if (choicesJson == null) {
+            throw new IllegalArgumentException("choicesJson은 null일 수 없습니다.");
+        }
+        if ((canonicalResultId == null) != (generatedStoryId == null)) {
+            throw new IllegalArgumentException("canonicalResultId와 generatedStoryId는 함께 기록해야 합니다.");
+        }
         validateLinkId("canonicalResultId", canonicalResultId);
         validateLinkId("generatedStoryId", generatedStoryId);
         stateChanges = stateChanges == null ? List.of() : List.copyOf(stateChanges);
         Inventory replayedInventory = InventoryRules.replay(stateTransition.previousState().inventory(), stateChanges);
-        if (!replayedInventory.equals(stateTransition.nextState().inventory())) throw new IllegalArgumentException("stateChanges의 inventory audit이 StateTransition과 일치하지 않습니다.");
+        if (!replayedInventory.equals(stateTransition.nextState().inventory())) {
+            throw new IllegalArgumentException("stateChanges의 inventory audit이 StateTransition과 일치하지 않습니다.");
+        }
     }
 
-    public GameTurnCommit(int expectedTurn, int inputChoiceId, String inputChoiceText, StateTransition stateTransition,
-                          String storyText, String choicesJson, String canonicalResultId, String generatedStoryId,
-                          SkillCheckResult skillCheckResult, ImageAssetService.AssetReference imageAsset) {
+    public GameTurnCommit(
+            int expectedTurn,
+            int inputChoiceId,
+            String inputChoiceText,
+            StateTransition stateTransition,
+            String storyText,
+            String choicesJson,
+            String canonicalResultId,
+            String generatedStoryId,
+            SkillCheckResult skillCheckResult,
+            ImageAssetService.AssetReference imageAsset
+    ) {
         this(expectedTurn, inputChoiceId, inputChoiceText, stateTransition, storyText, choicesJson,
                 canonicalResultId, generatedStoryId, skillCheckResult, List.of(), imageAsset);
     }
-    public GameTurnCommit(int expectedTurn, int inputChoiceId, String inputChoiceText, StateTransition stateTransition,
-                          String storyText, String choicesJson, String canonicalResultId, String generatedStoryId,
-                          ImageAssetService.AssetReference imageAsset) {
+
+    public GameTurnCommit(
+            int expectedTurn,
+            int inputChoiceId,
+            String inputChoiceText,
+            StateTransition stateTransition,
+            String storyText,
+            String choicesJson,
+            String canonicalResultId,
+            String generatedStoryId,
+            ImageAssetService.AssetReference imageAsset
+    ) {
         this(expectedTurn, inputChoiceId, inputChoiceText, stateTransition, storyText, choicesJson,
                 canonicalResultId, generatedStoryId, null, List.of(), imageAsset);
     }
-    public GameTurnCommit(int expectedTurn, int inputChoiceId, String inputChoiceText, StateTransition stateTransition,
-                          String storyText, String choicesJson, ImageAssetService.AssetReference imageAsset) {
+
+    public GameTurnCommit(
+            int expectedTurn,
+            int inputChoiceId,
+            String inputChoiceText,
+            StateTransition stateTransition,
+            String storyText,
+            String choicesJson,
+            ImageAssetService.AssetReference imageAsset
+    ) {
         this(expectedTurn, inputChoiceId, inputChoiceText, stateTransition, storyText, choicesJson,
                 null, null, null, List.of(), imageAsset);
     }
-    public GameTurnCommit(int expectedTurn, int inputChoiceId, String inputChoiceText, GameState previousState,
-                          GameState nextState, String storyText, String choicesJson, ImageAssetService.AssetReference imageAsset) {
+
+    public GameTurnCommit(
+            int expectedTurn,
+            int inputChoiceId,
+            String inputChoiceText,
+            GameState previousState,
+            GameState nextState,
+            String storyText,
+            String choicesJson,
+            ImageAssetService.AssetReference imageAsset
+    ) {
         this(expectedTurn, inputChoiceId, inputChoiceText, new StateTransition(previousState, nextState),
                 storyText, choicesJson, null, null, null, List.of(), imageAsset);
     }
 
-    public GameState previousState() { return stateTransition.previousState(); }
-    public GameState nextState() { return stateTransition.nextState(); }
-    public int previousStateVersion() { return previousState().turnNumber(); }
-    public int nextStateVersion() { return nextState().turnNumber(); }
-    public boolean hasNarrativeLink() { return canonicalResultId != null; }
-    public boolean hasSkillCheck() { return skillCheckResult != null; }
+    public GameState previousState() {
+        return stateTransition.previousState();
+    }
+
+    public GameState nextState() {
+        return stateTransition.nextState();
+    }
+
+    public int previousStateVersion() {
+        return previousState().turnNumber();
+    }
+
+    public int nextStateVersion() {
+        return nextState().turnNumber();
+    }
+
+    public boolean hasNarrativeLink() {
+        return canonicalResultId != null;
+    }
+
+    public boolean hasSkillCheck() {
+        return skillCheckResult != null;
+    }
 
     private static void validateLinkId(String name, String value) {
         if (value == null) return;
-        if (value.isBlank() || value.length() > MAX_LINK_ID_LENGTH) throw new IllegalArgumentException(name + "가 올바르지 않습니다.");
+        if (value.isBlank() || value.length() > MAX_LINK_ID_LENGTH) {
+            throw new IllegalArgumentException(name + "가 올바르지 않습니다.");
+        }
     }
 }

--- a/src/main/java/com/uctale/uctale/application/game/InventoryAuditCodec.java
+++ b/src/main/java/com/uctale/uctale/application/game/InventoryAuditCodec.java
@@ -1,0 +1,116 @@
+package com.uctale.uctale.application.game;
+
+import com.uctale.uctale.domain.game.EquipmentSlot;
+import com.uctale.uctale.domain.game.GameResult;
+import com.uctale.uctale.domain.game.ItemDefinition;
+import com.uctale.uctale.domain.game.ItemOwnershipType;
+import com.uctale.uctale.domain.game.OwnedItem;
+import org.springframework.stereotype.Component;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.ObjectNode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public final class InventoryAuditCodec {
+    private final ObjectMapper objectMapper;
+    public InventoryAuditCodec(ObjectMapper objectMapper) { this.objectMapper = objectMapper; }
+
+    public String serialize(List<GameResult.StateChange> stateChanges) {
+        ArrayNode root = JsonNodeFactory.instance.arrayNode();
+        if (stateChanges != null) {
+            for (GameResult.StateChange change : stateChanges) {
+                ObjectNode encoded = encode(change);
+                if (encoded != null) root.add(encoded);
+            }
+        }
+        if (root.isEmpty()) return null;
+        try { return objectMapper.writeValueAsString(root); }
+        catch (JacksonException exception) { throw new IllegalStateException("inventory GameLog audit 직렬화에 실패했습니다.", exception); }
+    }
+
+    public List<GameResult.StateChange> deserialize(String json) {
+        if (json == null || json.isBlank()) return List.of();
+        try {
+            JsonNode root = objectMapper.readTree(json);
+            if (root == null || !root.isArray()) throw new IllegalStateException("inventory GameLog audit는 JSON array여야 합니다.");
+            List<GameResult.StateChange> changes = new ArrayList<>();
+            for (JsonNode node : root) {
+                if (!node.isObject()) throw new IllegalStateException("inventory GameLog audit entry는 object여야 합니다.");
+                changes.add(decode(node));
+            }
+            return List.copyOf(changes);
+        } catch (JacksonException | IllegalArgumentException exception) {
+            throw new IllegalStateException("inventory GameLog audit 역직렬화에 실패했습니다.", exception);
+        }
+    }
+
+    private ObjectNode encode(GameResult.StateChange change) {
+        if (change instanceof GameResult.ItemAcquired acquired) {
+            ObjectNode node = typed("ITEM_ACQUIRED"); node.set("item", encodeItem(acquired.item())); node.put("resultingQuantity", acquired.resultingQuantity()); return node;
+        }
+        if (change instanceof GameResult.ItemRemoved removed) {
+            ObjectNode node = typed("ITEM_REMOVED"); node.set("item", encodeItem(removed.item())); return node;
+        }
+        if (change instanceof GameResult.ItemQuantityChanged c) {
+            ObjectNode node = itemReference("ITEM_QUANTITY_CHANGED", c.itemId(), c.definitionId()); node.put("previousQuantity", c.previousQuantity()); node.put("nextQuantity", c.nextQuantity()); return node;
+        }
+        if (change instanceof GameResult.ItemConsumed c) {
+            ObjectNode node = itemReference("ITEM_CONSUMED", c.itemId(), c.definitionId()); node.put("quantity", c.quantity()); node.put("remainingQuantity", c.remainingQuantity()); return node;
+        }
+        if (change instanceof GameResult.ItemEquipped c) {
+            ObjectNode node = itemReference("ITEM_EQUIPPED", c.itemId(), c.definitionId()); node.put("slot", c.slot().name()); return node;
+        }
+        if (change instanceof GameResult.ItemUnequipped c) {
+            ObjectNode node = itemReference("ITEM_UNEQUIPPED", c.itemId(), c.definitionId()); node.put("slot", c.slot().name()); return node;
+        }
+        return null;
+    }
+
+    private GameResult.StateChange decode(JsonNode node) {
+        return switch (requiredText(node, "type")) {
+            case "ITEM_ACQUIRED" -> new GameResult.ItemAcquired(decodeItem(requiredObject(node, "item")), requiredPositiveInt(node, "resultingQuantity"));
+            case "ITEM_REMOVED" -> new GameResult.ItemRemoved(decodeItem(requiredObject(node, "item")));
+            case "ITEM_QUANTITY_CHANGED" -> new GameResult.ItemQuantityChanged(requiredText(node, "itemId"), requiredText(node, "definitionId"), requiredPositiveInt(node, "previousQuantity"), requiredPositiveInt(node, "nextQuantity"));
+            case "ITEM_CONSUMED" -> new GameResult.ItemConsumed(requiredText(node, "itemId"), requiredText(node, "definitionId"), requiredPositiveInt(node, "quantity"), requiredNonNegativeInt(node, "remainingQuantity"));
+            case "ITEM_EQUIPPED" -> new GameResult.ItemEquipped(requiredSlot(node, "slot"), requiredText(node, "itemId"), requiredText(node, "definitionId"));
+            case "ITEM_UNEQUIPPED" -> new GameResult.ItemUnequipped(requiredSlot(node, "slot"), requiredText(node, "itemId"), requiredText(node, "definitionId"));
+            default -> throw new IllegalStateException("지원하지 않는 inventory audit type입니다: " + requiredText(node, "type"));
+        };
+    }
+
+    private ObjectNode encodeItem(OwnedItem item) {
+        ObjectNode node = JsonNodeFactory.instance.objectNode();
+        node.put("id", item.id()); node.put("quantity", item.quantity());
+        ObjectNode definition = JsonNodeFactory.instance.objectNode();
+        definition.put("id", item.definition().id()); definition.put("ownershipType", item.definition().ownershipType().name());
+        if (item.definition().equipmentSlot() == null) definition.putNull("equipmentSlot"); else definition.put("equipmentSlot", item.definition().equipmentSlot().name());
+        node.set("definition", definition); return node;
+    }
+
+    private OwnedItem decodeItem(JsonNode node) {
+        JsonNode definitionNode = requiredObject(node, "definition");
+        EquipmentSlot slot = null;
+        JsonNode slotNode = definitionNode.get("equipmentSlot");
+        if (slotNode != null && !slotNode.isNull()) {
+            if (!slotNode.isTextual()) throw new IllegalStateException("inventory audit equipmentSlot이 문자열이 아닙니다.");
+            slot = EquipmentSlot.valueOf(slotNode.asText());
+        }
+        ItemDefinition definition = new ItemDefinition(requiredText(definitionNode, "id"), ItemOwnershipType.valueOf(requiredText(definitionNode, "ownershipType")), slot);
+        return new OwnedItem(requiredText(node, "id"), definition, requiredPositiveInt(node, "quantity"));
+    }
+
+    private ObjectNode typed(String type) { ObjectNode node = JsonNodeFactory.instance.objectNode(); node.put("type", type); return node; }
+    private ObjectNode itemReference(String type, String itemId, String definitionId) { ObjectNode node = typed(type); node.put("itemId", itemId); node.put("definitionId", definitionId); return node; }
+    private JsonNode requiredObject(JsonNode node, String fieldName) { JsonNode value = node.get(fieldName); if (value == null || !value.isObject()) throw new IllegalStateException("inventory audit " + fieldName + " object가 필요합니다."); return value; }
+    private String requiredText(JsonNode node, String fieldName) { JsonNode value = node.get(fieldName); if (value == null || !value.isTextual() || value.asText().isBlank()) throw new IllegalStateException("inventory audit " + fieldName + " 문자열이 필요합니다."); return value.asText(); }
+    private EquipmentSlot requiredSlot(JsonNode node, String fieldName) { return EquipmentSlot.valueOf(requiredText(node, fieldName)); }
+    private int requiredPositiveInt(JsonNode node, String fieldName) { int value = requiredInt(node, fieldName); if (value < 1) throw new IllegalStateException("inventory audit " + fieldName + "은 1 이상이어야 합니다."); return value; }
+    private int requiredNonNegativeInt(JsonNode node, String fieldName) { int value = requiredInt(node, fieldName); if (value < 0) throw new IllegalStateException("inventory audit " + fieldName + "은 0 이상이어야 합니다."); return value; }
+    private int requiredInt(JsonNode node, String fieldName) { JsonNode value = node.get(fieldName); if (value == null || !value.isIntegralNumber()) throw new IllegalStateException("inventory audit " + fieldName + " 정수가 필요합니다."); long number = value.asLong(); if (number < Integer.MIN_VALUE || number > Integer.MAX_VALUE) throw new IllegalStateException("inventory audit " + fieldName + "이 지원 범위를 벗어났습니다."); return (int) number; }
+}

--- a/src/main/java/com/uctale/uctale/domain/GameLog.java
+++ b/src/main/java/com/uctale/uctale/domain/GameLog.java
@@ -22,203 +22,73 @@ import java.time.LocalDateTime;
 
 @Entity
 @Immutable
-@Table(uniqueConstraints = @UniqueConstraint(
-        name = "uk_game_log_session_turn",
-        columnNames = {"session_id", "turn_number"}
-))
+@Table(uniqueConstraints = @UniqueConstraint(name = "uk_game_log_session_turn", columnNames = {"session_id", "turn_number"}))
 @Getter
 @NoArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 public class GameLog {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) private Long id;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false) @JoinColumn(name = "session_id", nullable = false) private GameSession gameSession;
+    @Column(nullable = false) private int turnNumber;
+    @Column(name = "input_choice_id") private Integer inputChoiceId;
+    @Column(name = "input_choice_text") private String inputChoiceText;
+    @Column(name = "previous_state_version", nullable = false) private int previousStateVersion;
+    @Column(name = "state_version", nullable = false) private int stateVersion;
+    @Column(name = "canonical_result_id", length = 128) private String canonicalResultId;
+    @Column(name = "generated_story_id", length = 128) private String generatedStoryId;
+    @Column(name = "skill_check_stat_type", length = 32) private String skillCheckStatType;
+    @Column(name = "skill_check_raw_roll") private Integer skillCheckRawRoll;
+    @Column(name = "skill_check_stat_modifier") private Integer skillCheckStatModifier;
+    @Column(name = "skill_check_situational_modifier") private Integer skillCheckSituationalModifier;
+    @Column(name = "skill_check_dc") private Integer skillCheckDc;
+    @Column(name = "skill_check_total") private Integer skillCheckTotal;
+    @Column(name = "skill_check_outcome", length = 16) private String skillCheckOutcome;
+    @Column(name = "skill_check_ruleset_version") private Integer skillCheckRulesetVersion;
+    @Column(name = "inventory_changes_json", columnDefinition = "TEXT") private String inventoryChangesJson;
+    @Column(columnDefinition = "TEXT") private String storyText;
+    @Column(columnDefinition = "TEXT") private String choicesJson;
+    @Column(columnDefinition = "TEXT") private String imageUrl;
+    @CreatedDate @Column(name = "created_at") private LocalDateTime committedAt;
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "session_id", nullable = false)
-    private GameSession gameSession;
-
-    @Column(nullable = false)
-    private int turnNumber;
-
-    @Column(name = "input_choice_id")
-    private Integer inputChoiceId;
-
-    @Column(name = "input_choice_text")
-    private String inputChoiceText;
-
-    @Column(name = "previous_state_version", nullable = false)
-    private int previousStateVersion;
-
-    @Column(name = "state_version", nullable = false)
-    private int stateVersion;
-
-    @Column(name = "canonical_result_id", length = 128)
-    private String canonicalResultId;
-
-    @Column(name = "generated_story_id", length = 128)
-    private String generatedStoryId;
-
-    @Column(name = "skill_check_stat_type", length = 32)
-    private String skillCheckStatType;
-
-    @Column(name = "skill_check_raw_roll")
-    private Integer skillCheckRawRoll;
-
-    @Column(name = "skill_check_stat_modifier")
-    private Integer skillCheckStatModifier;
-
-    @Column(name = "skill_check_situational_modifier")
-    private Integer skillCheckSituationalModifier;
-
-    @Column(name = "skill_check_dc")
-    private Integer skillCheckDc;
-
-    @Column(name = "skill_check_total")
-    private Integer skillCheckTotal;
-
-    @Column(name = "skill_check_outcome", length = 16)
-    private String skillCheckOutcome;
-
-    @Column(name = "skill_check_ruleset_version")
-    private Integer skillCheckRulesetVersion;
-
-    @Column(columnDefinition = "TEXT")
-    private String storyText;
-
-    @Column(columnDefinition = "TEXT")
-    private String choicesJson;
-
-    @Column(columnDefinition = "TEXT")
-    private String imageUrl;
-
-    @CreatedDate
-    @Column(name = "created_at")
-    private LocalDateTime committedAt;
-
-    public static GameLog opening(
-            GameSession gameSession,
-            String storyText,
-            String choicesJson,
-            String imageUrl
-    ) {
-        return new GameLog(
-                gameSession,
-                1,
-                null,
-                null,
-                0,
-                1,
-                null,
-                null,
-                null,
-                storyText,
-                choicesJson,
-                imageUrl
-        );
+    public static GameLog opening(GameSession gameSession, String storyText, String choicesJson, String imageUrl) {
+        return new GameLog(gameSession, 1, null, null, 0, 1, null, null, null, null, storyText, choicesJson, imageUrl);
+    }
+    public static GameLog committedTurn(GameSession gameSession, int turnNumber, int inputChoiceId, String inputChoiceText,
+            int previousStateVersion, int stateVersion, String storyText, String choicesJson, String imageUrl) {
+        return committedTurn(gameSession, turnNumber, inputChoiceId, inputChoiceText, previousStateVersion, stateVersion,
+                null, null, null, null, storyText, choicesJson, imageUrl);
+    }
+    public static GameLog committedTurn(GameSession gameSession, int turnNumber, int inputChoiceId, String inputChoiceText,
+            int previousStateVersion, int stateVersion, String canonicalResultId, String generatedStoryId,
+            String storyText, String choicesJson, String imageUrl) {
+        return committedTurn(gameSession, turnNumber, inputChoiceId, inputChoiceText, previousStateVersion, stateVersion,
+                canonicalResultId, generatedStoryId, null, null, storyText, choicesJson, imageUrl);
+    }
+    public static GameLog committedTurn(GameSession gameSession, int turnNumber, int inputChoiceId, String inputChoiceText,
+            int previousStateVersion, int stateVersion, String canonicalResultId, String generatedStoryId,
+            SkillCheckResult skillCheckResult, String storyText, String choicesJson, String imageUrl) {
+        return committedTurn(gameSession, turnNumber, inputChoiceId, inputChoiceText, previousStateVersion, stateVersion,
+                canonicalResultId, generatedStoryId, skillCheckResult, null, storyText, choicesJson, imageUrl);
+    }
+    public static GameLog committedTurn(GameSession gameSession, int turnNumber, int inputChoiceId, String inputChoiceText,
+            int previousStateVersion, int stateVersion, String canonicalResultId, String generatedStoryId,
+            SkillCheckResult skillCheckResult, String inventoryChangesJson, String storyText, String choicesJson, String imageUrl) {
+        return new GameLog(gameSession, turnNumber, inputChoiceId, inputChoiceText, previousStateVersion, stateVersion,
+                canonicalResultId, generatedStoryId, skillCheckResult, inventoryChangesJson, storyText, choicesJson, imageUrl);
     }
 
-    public static GameLog committedTurn(
-            GameSession gameSession,
-            int turnNumber,
-            int inputChoiceId,
-            String inputChoiceText,
-            int previousStateVersion,
-            int stateVersion,
-            String storyText,
-            String choicesJson,
-            String imageUrl
-    ) {
-        return committedTurn(
-                gameSession, turnNumber, inputChoiceId, inputChoiceText, previousStateVersion, stateVersion,
-                null, null, null, storyText, choicesJson, imageUrl
-        );
-    }
-
-    public static GameLog committedTurn(
-            GameSession gameSession,
-            int turnNumber,
-            int inputChoiceId,
-            String inputChoiceText,
-            int previousStateVersion,
-            int stateVersion,
-            String canonicalResultId,
-            String generatedStoryId,
-            String storyText,
-            String choicesJson,
-            String imageUrl
-    ) {
-        return committedTurn(
-                gameSession, turnNumber, inputChoiceId, inputChoiceText, previousStateVersion, stateVersion,
-                canonicalResultId, generatedStoryId, null, storyText, choicesJson, imageUrl
-        );
-    }
-
-    public static GameLog committedTurn(
-            GameSession gameSession,
-            int turnNumber,
-            int inputChoiceId,
-            String inputChoiceText,
-            int previousStateVersion,
-            int stateVersion,
-            String canonicalResultId,
-            String generatedStoryId,
-            SkillCheckResult skillCheckResult,
-            String storyText,
-            String choicesJson,
-            String imageUrl
-    ) {
-        return new GameLog(
-                gameSession,
-                turnNumber,
-                inputChoiceId,
-                inputChoiceText,
-                previousStateVersion,
-                stateVersion,
-                canonicalResultId,
-                generatedStoryId,
-                skillCheckResult,
-                storyText,
-                choicesJson,
-                imageUrl
-        );
-    }
-
-    private GameLog(
-            GameSession gameSession,
-            int turnNumber,
-            Integer inputChoiceId,
-            String inputChoiceText,
-            int previousStateVersion,
-            int stateVersion,
-            String canonicalResultId,
-            String generatedStoryId,
-            SkillCheckResult skillCheckResult,
-            String storyText,
-            String choicesJson,
-            String imageUrl
-    ) {
-        this.gameSession = gameSession;
-        this.turnNumber = turnNumber;
-        this.inputChoiceId = inputChoiceId;
-        this.inputChoiceText = inputChoiceText;
-        this.previousStateVersion = previousStateVersion;
-        this.stateVersion = stateVersion;
-        this.canonicalResultId = canonicalResultId;
-        this.generatedStoryId = generatedStoryId;
+    private GameLog(GameSession gameSession, int turnNumber, Integer inputChoiceId, String inputChoiceText,
+            int previousStateVersion, int stateVersion, String canonicalResultId, String generatedStoryId,
+            SkillCheckResult skillCheckResult, String inventoryChangesJson, String storyText, String choicesJson, String imageUrl) {
+        this.gameSession = gameSession; this.turnNumber = turnNumber; this.inputChoiceId = inputChoiceId;
+        this.inputChoiceText = inputChoiceText; this.previousStateVersion = previousStateVersion; this.stateVersion = stateVersion;
+        this.canonicalResultId = canonicalResultId; this.generatedStoryId = generatedStoryId;
         if (skillCheckResult != null) {
-            this.skillCheckStatType = skillCheckResult.statType().name();
-            this.skillCheckRawRoll = skillCheckResult.rawRoll();
-            this.skillCheckStatModifier = skillCheckResult.statModifier();
-            this.skillCheckSituationalModifier = skillCheckResult.situationalModifier();
-            this.skillCheckDc = skillCheckResult.dc();
-            this.skillCheckTotal = skillCheckResult.total();
-            this.skillCheckOutcome = skillCheckResult.outcome().name();
-            this.skillCheckRulesetVersion = skillCheckResult.rulesetVersion();
+            this.skillCheckStatType = skillCheckResult.statType().name(); this.skillCheckRawRoll = skillCheckResult.rawRoll();
+            this.skillCheckStatModifier = skillCheckResult.statModifier(); this.skillCheckSituationalModifier = skillCheckResult.situationalModifier();
+            this.skillCheckDc = skillCheckResult.dc(); this.skillCheckTotal = skillCheckResult.total();
+            this.skillCheckOutcome = skillCheckResult.outcome().name(); this.skillCheckRulesetVersion = skillCheckResult.rulesetVersion();
         }
-        this.storyText = storyText;
-        this.choicesJson = choicesJson;
-        this.imageUrl = imageUrl;
+        this.inventoryChangesJson = inventoryChangesJson; this.storyText = storyText; this.choicesJson = choicesJson; this.imageUrl = imageUrl;
     }
 }

--- a/src/main/java/com/uctale/uctale/domain/GameLog.java
+++ b/src/main/java/com/uctale/uctale/domain/GameLog.java
@@ -22,73 +22,231 @@ import java.time.LocalDateTime;
 
 @Entity
 @Immutable
-@Table(uniqueConstraints = @UniqueConstraint(name = "uk_game_log_session_turn", columnNames = {"session_id", "turn_number"}))
+@Table(uniqueConstraints = @UniqueConstraint(
+        name = "uk_game_log_session_turn",
+        columnNames = {"session_id", "turn_number"}
+))
 @Getter
 @NoArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 public class GameLog {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) private Long id;
-    @ManyToOne(fetch = FetchType.LAZY, optional = false) @JoinColumn(name = "session_id", nullable = false) private GameSession gameSession;
-    @Column(nullable = false) private int turnNumber;
-    @Column(name = "input_choice_id") private Integer inputChoiceId;
-    @Column(name = "input_choice_text") private String inputChoiceText;
-    @Column(name = "previous_state_version", nullable = false) private int previousStateVersion;
-    @Column(name = "state_version", nullable = false) private int stateVersion;
-    @Column(name = "canonical_result_id", length = 128) private String canonicalResultId;
-    @Column(name = "generated_story_id", length = 128) private String generatedStoryId;
-    @Column(name = "skill_check_stat_type", length = 32) private String skillCheckStatType;
-    @Column(name = "skill_check_raw_roll") private Integer skillCheckRawRoll;
-    @Column(name = "skill_check_stat_modifier") private Integer skillCheckStatModifier;
-    @Column(name = "skill_check_situational_modifier") private Integer skillCheckSituationalModifier;
-    @Column(name = "skill_check_dc") private Integer skillCheckDc;
-    @Column(name = "skill_check_total") private Integer skillCheckTotal;
-    @Column(name = "skill_check_outcome", length = 16) private String skillCheckOutcome;
-    @Column(name = "skill_check_ruleset_version") private Integer skillCheckRulesetVersion;
-    @Column(name = "inventory_changes_json", columnDefinition = "TEXT") private String inventoryChangesJson;
-    @Column(columnDefinition = "TEXT") private String storyText;
-    @Column(columnDefinition = "TEXT") private String choicesJson;
-    @Column(columnDefinition = "TEXT") private String imageUrl;
-    @CreatedDate @Column(name = "created_at") private LocalDateTime committedAt;
 
-    public static GameLog opening(GameSession gameSession, String storyText, String choicesJson, String imageUrl) {
-        return new GameLog(gameSession, 1, null, null, 0, 1, null, null, null, null, storyText, choicesJson, imageUrl);
-    }
-    public static GameLog committedTurn(GameSession gameSession, int turnNumber, int inputChoiceId, String inputChoiceText,
-            int previousStateVersion, int stateVersion, String storyText, String choicesJson, String imageUrl) {
-        return committedTurn(gameSession, turnNumber, inputChoiceId, inputChoiceText, previousStateVersion, stateVersion,
-                null, null, null, null, storyText, choicesJson, imageUrl);
-    }
-    public static GameLog committedTurn(GameSession gameSession, int turnNumber, int inputChoiceId, String inputChoiceText,
-            int previousStateVersion, int stateVersion, String canonicalResultId, String generatedStoryId,
-            String storyText, String choicesJson, String imageUrl) {
-        return committedTurn(gameSession, turnNumber, inputChoiceId, inputChoiceText, previousStateVersion, stateVersion,
-                canonicalResultId, generatedStoryId, null, null, storyText, choicesJson, imageUrl);
-    }
-    public static GameLog committedTurn(GameSession gameSession, int turnNumber, int inputChoiceId, String inputChoiceText,
-            int previousStateVersion, int stateVersion, String canonicalResultId, String generatedStoryId,
-            SkillCheckResult skillCheckResult, String storyText, String choicesJson, String imageUrl) {
-        return committedTurn(gameSession, turnNumber, inputChoiceId, inputChoiceText, previousStateVersion, stateVersion,
-                canonicalResultId, generatedStoryId, skillCheckResult, null, storyText, choicesJson, imageUrl);
-    }
-    public static GameLog committedTurn(GameSession gameSession, int turnNumber, int inputChoiceId, String inputChoiceText,
-            int previousStateVersion, int stateVersion, String canonicalResultId, String generatedStoryId,
-            SkillCheckResult skillCheckResult, String inventoryChangesJson, String storyText, String choicesJson, String imageUrl) {
-        return new GameLog(gameSession, turnNumber, inputChoiceId, inputChoiceText, previousStateVersion, stateVersion,
-                canonicalResultId, generatedStoryId, skillCheckResult, inventoryChangesJson, storyText, choicesJson, imageUrl);
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "session_id", nullable = false)
+    private GameSession gameSession;
+
+    @Column(nullable = false)
+    private int turnNumber;
+
+    @Column(name = "input_choice_id")
+    private Integer inputChoiceId;
+
+    @Column(name = "input_choice_text")
+    private String inputChoiceText;
+
+    @Column(name = "previous_state_version", nullable = false)
+    private int previousStateVersion;
+
+    @Column(name = "state_version", nullable = false)
+    private int stateVersion;
+
+    @Column(name = "canonical_result_id", length = 128)
+    private String canonicalResultId;
+
+    @Column(name = "generated_story_id", length = 128)
+    private String generatedStoryId;
+
+    @Column(name = "skill_check_stat_type", length = 32)
+    private String skillCheckStatType;
+
+    @Column(name = "skill_check_raw_roll")
+    private Integer skillCheckRawRoll;
+
+    @Column(name = "skill_check_stat_modifier")
+    private Integer skillCheckStatModifier;
+
+    @Column(name = "skill_check_situational_modifier")
+    private Integer skillCheckSituationalModifier;
+
+    @Column(name = "skill_check_dc")
+    private Integer skillCheckDc;
+
+    @Column(name = "skill_check_total")
+    private Integer skillCheckTotal;
+
+    @Column(name = "skill_check_outcome", length = 16)
+    private String skillCheckOutcome;
+
+    @Column(name = "skill_check_ruleset_version")
+    private Integer skillCheckRulesetVersion;
+
+    @Column(name = "inventory_changes_json", columnDefinition = "TEXT")
+    private String inventoryChangesJson;
+
+    @Column(columnDefinition = "TEXT")
+    private String storyText;
+
+    @Column(columnDefinition = "TEXT")
+    private String choicesJson;
+
+    @Column(columnDefinition = "TEXT")
+    private String imageUrl;
+
+    @CreatedDate
+    @Column(name = "created_at")
+    private LocalDateTime committedAt;
+
+    public static GameLog opening(
+            GameSession gameSession,
+            String storyText,
+            String choicesJson,
+            String imageUrl
+    ) {
+        return new GameLog(
+                gameSession,
+                1,
+                null,
+                null,
+                0,
+                1,
+                null,
+                null,
+                null,
+                null,
+                storyText,
+                choicesJson,
+                imageUrl
+        );
     }
 
-    private GameLog(GameSession gameSession, int turnNumber, Integer inputChoiceId, String inputChoiceText,
-            int previousStateVersion, int stateVersion, String canonicalResultId, String generatedStoryId,
-            SkillCheckResult skillCheckResult, String inventoryChangesJson, String storyText, String choicesJson, String imageUrl) {
-        this.gameSession = gameSession; this.turnNumber = turnNumber; this.inputChoiceId = inputChoiceId;
-        this.inputChoiceText = inputChoiceText; this.previousStateVersion = previousStateVersion; this.stateVersion = stateVersion;
-        this.canonicalResultId = canonicalResultId; this.generatedStoryId = generatedStoryId;
+    public static GameLog committedTurn(
+            GameSession gameSession,
+            int turnNumber,
+            int inputChoiceId,
+            String inputChoiceText,
+            int previousStateVersion,
+            int stateVersion,
+            String storyText,
+            String choicesJson,
+            String imageUrl
+    ) {
+        return committedTurn(
+                gameSession, turnNumber, inputChoiceId, inputChoiceText, previousStateVersion, stateVersion,
+                null, null, null, null, storyText, choicesJson, imageUrl
+        );
+    }
+
+    public static GameLog committedTurn(
+            GameSession gameSession,
+            int turnNumber,
+            int inputChoiceId,
+            String inputChoiceText,
+            int previousStateVersion,
+            int stateVersion,
+            String canonicalResultId,
+            String generatedStoryId,
+            String storyText,
+            String choicesJson,
+            String imageUrl
+    ) {
+        return committedTurn(
+                gameSession, turnNumber, inputChoiceId, inputChoiceText, previousStateVersion, stateVersion,
+                canonicalResultId, generatedStoryId, null, null, storyText, choicesJson, imageUrl
+        );
+    }
+
+    public static GameLog committedTurn(
+            GameSession gameSession,
+            int turnNumber,
+            int inputChoiceId,
+            String inputChoiceText,
+            int previousStateVersion,
+            int stateVersion,
+            String canonicalResultId,
+            String generatedStoryId,
+            SkillCheckResult skillCheckResult,
+            String storyText,
+            String choicesJson,
+            String imageUrl
+    ) {
+        return committedTurn(
+                gameSession, turnNumber, inputChoiceId, inputChoiceText, previousStateVersion, stateVersion,
+                canonicalResultId, generatedStoryId, skillCheckResult, null, storyText, choicesJson, imageUrl
+        );
+    }
+
+    public static GameLog committedTurn(
+            GameSession gameSession,
+            int turnNumber,
+            int inputChoiceId,
+            String inputChoiceText,
+            int previousStateVersion,
+            int stateVersion,
+            String canonicalResultId,
+            String generatedStoryId,
+            SkillCheckResult skillCheckResult,
+            String inventoryChangesJson,
+            String storyText,
+            String choicesJson,
+            String imageUrl
+    ) {
+        return new GameLog(
+                gameSession,
+                turnNumber,
+                inputChoiceId,
+                inputChoiceText,
+                previousStateVersion,
+                stateVersion,
+                canonicalResultId,
+                generatedStoryId,
+                skillCheckResult,
+                inventoryChangesJson,
+                storyText,
+                choicesJson,
+                imageUrl
+        );
+    }
+
+    private GameLog(
+            GameSession gameSession,
+            int turnNumber,
+            Integer inputChoiceId,
+            String inputChoiceText,
+            int previousStateVersion,
+            int stateVersion,
+            String canonicalResultId,
+            String generatedStoryId,
+            SkillCheckResult skillCheckResult,
+            String inventoryChangesJson,
+            String storyText,
+            String choicesJson,
+            String imageUrl
+    ) {
+        this.gameSession = gameSession;
+        this.turnNumber = turnNumber;
+        this.inputChoiceId = inputChoiceId;
+        this.inputChoiceText = inputChoiceText;
+        this.previousStateVersion = previousStateVersion;
+        this.stateVersion = stateVersion;
+        this.canonicalResultId = canonicalResultId;
+        this.generatedStoryId = generatedStoryId;
         if (skillCheckResult != null) {
-            this.skillCheckStatType = skillCheckResult.statType().name(); this.skillCheckRawRoll = skillCheckResult.rawRoll();
-            this.skillCheckStatModifier = skillCheckResult.statModifier(); this.skillCheckSituationalModifier = skillCheckResult.situationalModifier();
-            this.skillCheckDc = skillCheckResult.dc(); this.skillCheckTotal = skillCheckResult.total();
-            this.skillCheckOutcome = skillCheckResult.outcome().name(); this.skillCheckRulesetVersion = skillCheckResult.rulesetVersion();
+            this.skillCheckStatType = skillCheckResult.statType().name();
+            this.skillCheckRawRoll = skillCheckResult.rawRoll();
+            this.skillCheckStatModifier = skillCheckResult.statModifier();
+            this.skillCheckSituationalModifier = skillCheckResult.situationalModifier();
+            this.skillCheckDc = skillCheckResult.dc();
+            this.skillCheckTotal = skillCheckResult.total();
+            this.skillCheckOutcome = skillCheckResult.outcome().name();
+            this.skillCheckRulesetVersion = skillCheckResult.rulesetVersion();
         }
-        this.inventoryChangesJson = inventoryChangesJson; this.storyText = storyText; this.choicesJson = choicesJson; this.imageUrl = imageUrl;
+        this.inventoryChangesJson = inventoryChangesJson;
+        this.storyText = storyText;
+        this.choicesJson = choicesJson;
+        this.imageUrl = imageUrl;
     }
 }

--- a/src/main/java/com/uctale/uctale/domain/game/ActionResolver.java
+++ b/src/main/java/com/uctale/uctale/domain/game/ActionResolver.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Objects;
 
 public final class ActionResolver {
+    private final InventoryRules inventoryRules = new InventoryRules();
 
     public boolean requiresSkillCheck(PlayerAction action) {
         Objects.requireNonNull(action, "PlayerAction은 필수입니다.");
@@ -17,104 +18,70 @@ public final class ActionResolver {
 
     public SkillCheckResult rollSkillCheck(GameState state, PlayerAction action, RandomSource randomSource) {
         validateBase(state, action);
-        if (action.type() != ActionType.SKILL_CHECK) {
-            throw new IllegalArgumentException("Skill Check가 필요하지 않은 action입니다.");
-        }
-        SkillCheck skillCheck = parseSkillCheck(action);
-        return skillCheck.resolve(state.playerCharacter().stats(), randomSource);
+        if (action.type() != ActionType.SKILL_CHECK) throw new IllegalArgumentException("Skill Check가 필요하지 않은 action입니다.");
+        return parseSkillCheck(action).resolve(state.playerCharacter().stats(), randomSource);
     }
 
-    public TurnResolution resolve(GameState state, PlayerAction action) {
+    public TurnResolution resolve(GameState state, PlayerAction action) { return resolveWithInventory(state, action, List.of()); }
+
+    public TurnResolution resolveWithInventory(GameState state, PlayerAction action, List<InventoryCommand> inventoryCommands) {
         validateBase(state, action);
-        if (action.type() == ActionType.SKILL_CHECK) {
-            throw new IllegalArgumentException("SKILL_CHECK action에는 서버가 확정한 SkillCheckResult가 필요합니다.");
-        }
+        if (action.type() == ActionType.SKILL_CHECK) throw new IllegalArgumentException("SKILL_CHECK action에는 서버가 확정한 SkillCheckResult가 필요합니다.");
         validateNarrativeChoice(action);
-        return resolved(state, action, null);
+        return resolved(state, action, null, inventoryCommands);
     }
 
     public TurnResolution resolve(GameState state, PlayerAction action, SkillCheckResult skillCheckResult) {
+        return resolveWithInventory(state, action, skillCheckResult, List.of());
+    }
+
+    public TurnResolution resolveWithInventory(GameState state, PlayerAction action, SkillCheckResult skillCheckResult,
+                                               List<InventoryCommand> inventoryCommands) {
         validateBase(state, action);
         if (action.type() != ActionType.SKILL_CHECK) {
-            if (skillCheckResult != null) {
-                throw new IllegalArgumentException("Skill Check가 아닌 action에 판정 결과를 연결할 수 없습니다.");
-            }
+            if (skillCheckResult != null) throw new IllegalArgumentException("Skill Check가 아닌 action에 판정 결과를 연결할 수 없습니다.");
             validateNarrativeChoice(action);
-            return resolved(state, action, null);
+            return resolved(state, action, null, inventoryCommands);
         }
         Objects.requireNonNull(skillCheckResult, "SkillCheckResult는 필수입니다.");
         SkillCheck skillCheck = parseSkillCheck(action);
         validateSkillCheckResult(state, skillCheck, skillCheckResult);
-        return resolved(state, action, skillCheckResult);
+        return resolved(state, action, skillCheckResult, inventoryCommands);
     }
 
-    private TurnResolution resolved(GameState state, PlayerAction action, SkillCheckResult skillCheckResult) {
-        GameState nextState = state.advanceTurn();
+    private TurnResolution resolved(GameState state, PlayerAction action, SkillCheckResult skillCheckResult,
+                                    List<InventoryCommand> inventoryCommands) {
+        InventoryRules.Result inventoryResult = inventoryRules.apply(state.inventory(), inventoryCommands);
+        GameState nextState = state.withInventory(inventoryResult.inventory()).advanceTurn();
         List<GameResult.GameEvent> events = new ArrayList<>();
         events.add(GameResult.GameEvent.ACTION_RESOLVED);
-        if (skillCheckResult != null) {
-            events.add(GameResult.GameEvent.SKILL_CHECK_RESOLVED);
-        }
-        GameResult result = new GameResult(
-                action,
-                GameResult.Outcome.RESOLVED,
-                skillCheckResult,
-                List.of(),
-                events,
-                List.of(new GameResult.TurnAdvanced(state.turnNumber(), nextState.turnNumber())),
-                List.of(action.displayText())
-        );
+        if (skillCheckResult != null) events.add(GameResult.GameEvent.SKILL_CHECK_RESOLVED);
+        List<GameResult.StateChange> changes = new ArrayList<>(inventoryResult.stateChanges());
+        changes.add(new GameResult.TurnAdvanced(state.turnNumber(), nextState.turnNumber()));
+        GameResult result = new GameResult(action, GameResult.Outcome.RESOLVED, skillCheckResult, List.of(), events, changes,
+                List.of(action.displayText()));
         return new TurnResolution(result, new StateTransition(state, nextState));
     }
 
     private void validateBase(GameState state, PlayerAction action) {
         Objects.requireNonNull(state, "GameState는 필수입니다.");
         Objects.requireNonNull(action, "PlayerAction은 필수입니다.");
-        if (action.sourceTurn() != state.turnNumber()) {
-            throw new IllegalArgumentException("PlayerAction source turn이 현재 GameState와 일치하지 않습니다.");
-        }
-        if (action.type() != ActionType.NARRATIVE_CHOICE && action.type() != ActionType.SKILL_CHECK) {
-            throw new IllegalArgumentException("지원하지 않는 action type입니다: " + action.type());
-        }
+        if (action.sourceTurn() != state.turnNumber()) throw new IllegalArgumentException("PlayerAction source turn이 현재 GameState와 일치하지 않습니다.");
+        if (action.type() != ActionType.NARRATIVE_CHOICE && action.type() != ActionType.SKILL_CHECK) throw new IllegalArgumentException("지원하지 않는 action type입니다: " + action.type());
     }
-
     private void validateNarrativeChoice(PlayerAction action) {
-        Map<String, String> arguments = action.arguments();
-        String choiceId = arguments.get("choiceId");
-        if (arguments.size() != 1 || !Integer.toString(action.legacyChoiceId()).equals(choiceId)) {
-            throw new IllegalArgumentException("NARRATIVE_CHOICE arguments가 action과 일치하지 않습니다.");
-        }
+        Map<String,String> arguments = action.arguments();
+        if (arguments.size() != 1 || !Integer.toString(action.legacyChoiceId()).equals(arguments.get("choiceId"))) throw new IllegalArgumentException("NARRATIVE_CHOICE arguments가 action과 일치하지 않습니다.");
     }
-
     private SkillCheck parseSkillCheck(PlayerAction action) {
-        Map<String, String> arguments = action.arguments();
-        if (arguments.size() != 4
-                || !Integer.toString(action.legacyChoiceId()).equals(arguments.get("choiceId"))) {
-            throw new IllegalArgumentException("SKILL_CHECK arguments가 action과 일치하지 않습니다.");
-        }
+        Map<String,String> arguments = action.arguments();
+        if (arguments.size() != 4 || !Integer.toString(action.legacyChoiceId()).equals(arguments.get("choiceId"))) throw new IllegalArgumentException("SKILL_CHECK arguments가 action과 일치하지 않습니다.");
         try {
-            StatType statType = StatType.valueOf(arguments.get("statType"));
-            int dc = Integer.parseInt(arguments.get("dc"));
-            int situationalModifier = Integer.parseInt(arguments.get("situationalModifier"));
-            return new SkillCheck(statType, new Difficulty(dc), situationalModifier);
-        } catch (RuntimeException exception) {
-            throw new IllegalArgumentException("SKILL_CHECK arguments가 올바르지 않습니다.", exception);
-        }
+            return new SkillCheck(StatType.valueOf(arguments.get("statType")), new Difficulty(Integer.parseInt(arguments.get("dc"))), Integer.parseInt(arguments.get("situationalModifier")));
+        } catch (RuntimeException exception) { throw new IllegalArgumentException("SKILL_CHECK arguments가 올바르지 않습니다.", exception); }
     }
-
-    private void validateSkillCheckResult(
-            GameState state,
-            SkillCheck skillCheck,
-            SkillCheckResult result
-    ) {
-        if (result.statType() != skillCheck.statType()
-                || result.dc() != skillCheck.difficulty().dc()
-                || result.situationalModifier() != skillCheck.situationalModifier()) {
-            throw new IllegalArgumentException("저장된 Skill Check 결과가 action 규칙과 일치하지 않습니다.");
-        }
-        int expectedStatModifier = state.playerCharacter().stats().modifier(skillCheck.statType());
-        if (result.statModifier() != expectedStatModifier) {
-            throw new IllegalArgumentException("저장된 Skill Check 결과가 현재 canonical 능력치와 일치하지 않습니다.");
-        }
+    private void validateSkillCheckResult(GameState state, SkillCheck skillCheck, SkillCheckResult result) {
+        if (result.statType() != skillCheck.statType() || result.dc() != skillCheck.difficulty().dc() || result.situationalModifier() != skillCheck.situationalModifier()) throw new IllegalArgumentException("저장된 Skill Check 결과가 action 규칙과 일치하지 않습니다.");
+        if (result.statModifier() != state.playerCharacter().stats().modifier(skillCheck.statType())) throw new IllegalArgumentException("저장된 Skill Check 결과가 현재 canonical 능력치와 일치하지 않습니다.");
     }
 }

--- a/src/main/java/com/uctale/uctale/domain/game/ActionResolver.java
+++ b/src/main/java/com/uctale/uctale/domain/game/ActionResolver.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Objects;
 
 public final class ActionResolver {
+
     private final InventoryRules inventoryRules = new InventoryRules();
 
     public boolean requiresSkillCheck(PlayerAction action) {
@@ -18,15 +19,22 @@ public final class ActionResolver {
 
     public SkillCheckResult rollSkillCheck(GameState state, PlayerAction action, RandomSource randomSource) {
         validateBase(state, action);
-        if (action.type() != ActionType.SKILL_CHECK) throw new IllegalArgumentException("Skill Check가 필요하지 않은 action입니다.");
-        return parseSkillCheck(action).resolve(state.playerCharacter().stats(), randomSource);
+        if (action.type() != ActionType.SKILL_CHECK) {
+            throw new IllegalArgumentException("Skill Check가 필요하지 않은 action입니다.");
+        }
+        SkillCheck skillCheck = parseSkillCheck(action);
+        return skillCheck.resolve(state.playerCharacter().stats(), randomSource);
     }
 
-    public TurnResolution resolve(GameState state, PlayerAction action) { return resolveWithInventory(state, action, List.of()); }
+    public TurnResolution resolve(GameState state, PlayerAction action) {
+        return resolveWithInventory(state, action, List.of());
+    }
 
     public TurnResolution resolveWithInventory(GameState state, PlayerAction action, List<InventoryCommand> inventoryCommands) {
         validateBase(state, action);
-        if (action.type() == ActionType.SKILL_CHECK) throw new IllegalArgumentException("SKILL_CHECK action에는 서버가 확정한 SkillCheckResult가 필요합니다.");
+        if (action.type() == ActionType.SKILL_CHECK) {
+            throw new IllegalArgumentException("SKILL_CHECK action에는 서버가 확정한 SkillCheckResult가 필요합니다.");
+        }
         validateNarrativeChoice(action);
         return resolved(state, action, null, inventoryCommands);
     }
@@ -35,11 +43,17 @@ public final class ActionResolver {
         return resolveWithInventory(state, action, skillCheckResult, List.of());
     }
 
-    public TurnResolution resolveWithInventory(GameState state, PlayerAction action, SkillCheckResult skillCheckResult,
-                                               List<InventoryCommand> inventoryCommands) {
+    public TurnResolution resolveWithInventory(
+            GameState state,
+            PlayerAction action,
+            SkillCheckResult skillCheckResult,
+            List<InventoryCommand> inventoryCommands
+    ) {
         validateBase(state, action);
         if (action.type() != ActionType.SKILL_CHECK) {
-            if (skillCheckResult != null) throw new IllegalArgumentException("Skill Check가 아닌 action에 판정 결과를 연결할 수 없습니다.");
+            if (skillCheckResult != null) {
+                throw new IllegalArgumentException("Skill Check가 아닌 action에 판정 결과를 연결할 수 없습니다.");
+            }
             validateNarrativeChoice(action);
             return resolved(state, action, null, inventoryCommands);
         }
@@ -49,39 +63,81 @@ public final class ActionResolver {
         return resolved(state, action, skillCheckResult, inventoryCommands);
     }
 
-    private TurnResolution resolved(GameState state, PlayerAction action, SkillCheckResult skillCheckResult,
-                                    List<InventoryCommand> inventoryCommands) {
+    private TurnResolution resolved(
+            GameState state,
+            PlayerAction action,
+            SkillCheckResult skillCheckResult,
+            List<InventoryCommand> inventoryCommands
+    ) {
         InventoryRules.Result inventoryResult = inventoryRules.apply(state.inventory(), inventoryCommands);
         GameState nextState = state.withInventory(inventoryResult.inventory()).advanceTurn();
         List<GameResult.GameEvent> events = new ArrayList<>();
         events.add(GameResult.GameEvent.ACTION_RESOLVED);
-        if (skillCheckResult != null) events.add(GameResult.GameEvent.SKILL_CHECK_RESOLVED);
-        List<GameResult.StateChange> changes = new ArrayList<>(inventoryResult.stateChanges());
-        changes.add(new GameResult.TurnAdvanced(state.turnNumber(), nextState.turnNumber()));
-        GameResult result = new GameResult(action, GameResult.Outcome.RESOLVED, skillCheckResult, List.of(), events, changes,
-                List.of(action.displayText()));
+        if (skillCheckResult != null) {
+            events.add(GameResult.GameEvent.SKILL_CHECK_RESOLVED);
+        }
+        List<GameResult.StateChange> stateChanges = new ArrayList<>(inventoryResult.stateChanges());
+        stateChanges.add(new GameResult.TurnAdvanced(state.turnNumber(), nextState.turnNumber()));
+        GameResult result = new GameResult(
+                action,
+                GameResult.Outcome.RESOLVED,
+                skillCheckResult,
+                List.of(),
+                events,
+                stateChanges,
+                List.of(action.displayText())
+        );
         return new TurnResolution(result, new StateTransition(state, nextState));
     }
 
     private void validateBase(GameState state, PlayerAction action) {
         Objects.requireNonNull(state, "GameState는 필수입니다.");
         Objects.requireNonNull(action, "PlayerAction은 필수입니다.");
-        if (action.sourceTurn() != state.turnNumber()) throw new IllegalArgumentException("PlayerAction source turn이 현재 GameState와 일치하지 않습니다.");
-        if (action.type() != ActionType.NARRATIVE_CHOICE && action.type() != ActionType.SKILL_CHECK) throw new IllegalArgumentException("지원하지 않는 action type입니다: " + action.type());
+        if (action.sourceTurn() != state.turnNumber()) {
+            throw new IllegalArgumentException("PlayerAction source turn이 현재 GameState와 일치하지 않습니다.");
+        }
+        if (action.type() != ActionType.NARRATIVE_CHOICE && action.type() != ActionType.SKILL_CHECK) {
+            throw new IllegalArgumentException("지원하지 않는 action type입니다: " + action.type());
+        }
     }
+
     private void validateNarrativeChoice(PlayerAction action) {
-        Map<String,String> arguments = action.arguments();
-        if (arguments.size() != 1 || !Integer.toString(action.legacyChoiceId()).equals(arguments.get("choiceId"))) throw new IllegalArgumentException("NARRATIVE_CHOICE arguments가 action과 일치하지 않습니다.");
+        Map<String, String> arguments = action.arguments();
+        String choiceId = arguments.get("choiceId");
+        if (arguments.size() != 1 || !Integer.toString(action.legacyChoiceId()).equals(choiceId)) {
+            throw new IllegalArgumentException("NARRATIVE_CHOICE arguments가 action과 일치하지 않습니다.");
+        }
     }
+
     private SkillCheck parseSkillCheck(PlayerAction action) {
-        Map<String,String> arguments = action.arguments();
-        if (arguments.size() != 4 || !Integer.toString(action.legacyChoiceId()).equals(arguments.get("choiceId"))) throw new IllegalArgumentException("SKILL_CHECK arguments가 action과 일치하지 않습니다.");
+        Map<String, String> arguments = action.arguments();
+        if (arguments.size() != 4
+                || !Integer.toString(action.legacyChoiceId()).equals(arguments.get("choiceId"))) {
+            throw new IllegalArgumentException("SKILL_CHECK arguments가 action과 일치하지 않습니다.");
+        }
         try {
-            return new SkillCheck(StatType.valueOf(arguments.get("statType")), new Difficulty(Integer.parseInt(arguments.get("dc"))), Integer.parseInt(arguments.get("situationalModifier")));
-        } catch (RuntimeException exception) { throw new IllegalArgumentException("SKILL_CHECK arguments가 올바르지 않습니다.", exception); }
+            StatType statType = StatType.valueOf(arguments.get("statType"));
+            int dc = Integer.parseInt(arguments.get("dc"));
+            int situationalModifier = Integer.parseInt(arguments.get("situationalModifier"));
+            return new SkillCheck(statType, new Difficulty(dc), situationalModifier);
+        } catch (RuntimeException exception) {
+            throw new IllegalArgumentException("SKILL_CHECK arguments가 올바르지 않습니다.", exception);
+        }
     }
-    private void validateSkillCheckResult(GameState state, SkillCheck skillCheck, SkillCheckResult result) {
-        if (result.statType() != skillCheck.statType() || result.dc() != skillCheck.difficulty().dc() || result.situationalModifier() != skillCheck.situationalModifier()) throw new IllegalArgumentException("저장된 Skill Check 결과가 action 규칙과 일치하지 않습니다.");
-        if (result.statModifier() != state.playerCharacter().stats().modifier(skillCheck.statType())) throw new IllegalArgumentException("저장된 Skill Check 결과가 현재 canonical 능력치와 일치하지 않습니다.");
+
+    private void validateSkillCheckResult(
+            GameState state,
+            SkillCheck skillCheck,
+            SkillCheckResult result
+    ) {
+        if (result.statType() != skillCheck.statType()
+                || result.dc() != skillCheck.difficulty().dc()
+                || result.situationalModifier() != skillCheck.situationalModifier()) {
+            throw new IllegalArgumentException("저장된 Skill Check 결과가 action 규칙과 일치하지 않습니다.");
+        }
+        int expectedStatModifier = state.playerCharacter().stats().modifier(skillCheck.statType());
+        if (result.statModifier() != expectedStatModifier) {
+            throw new IllegalArgumentException("저장된 Skill Check 결과가 현재 canonical 능력치와 일치하지 않습니다.");
+        }
     }
 }

--- a/src/main/java/com/uctale/uctale/domain/game/Equipment.java
+++ b/src/main/java/com/uctale/uctale/domain/game/Equipment.java
@@ -1,0 +1,74 @@
+package com.uctale.uctale.domain.game;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public record Equipment(Map<EquipmentSlot, String> slots) {
+
+    public Equipment {
+        Objects.requireNonNull(slots, "equipment slots는 필수입니다.");
+        if (slots.isEmpty()) {
+            slots = Map.of();
+        } else {
+            EnumMap<EquipmentSlot, String> copy = new EnumMap<>(EquipmentSlot.class);
+            Set<String> itemIds = new HashSet<>();
+            for (Map.Entry<EquipmentSlot, String> entry : slots.entrySet()) {
+                EquipmentSlot slot = Objects.requireNonNull(entry.getKey(), "equipment slot은 null일 수 없습니다.");
+                String itemId = entry.getValue();
+                if (itemId == null || itemId.isBlank()) {
+                    throw new IllegalArgumentException("equipped item id는 비어 있을 수 없습니다.");
+                }
+                if (!itemIds.add(itemId)) {
+                    throw new IllegalArgumentException("같은 item을 둘 이상의 slot에 장착할 수 없습니다.");
+                }
+                copy.put(slot, itemId);
+            }
+            slots = Collections.unmodifiableMap(copy);
+        }
+    }
+
+    public static Equipment empty() {
+        return new Equipment(Map.of());
+    }
+
+    public String itemIdAt(EquipmentSlot slot) {
+        Objects.requireNonNull(slot, "equipment slot은 필수입니다.");
+        return slots.get(slot);
+    }
+
+    public boolean containsItem(String itemId) {
+        return slots.containsValue(itemId);
+    }
+
+    public Equipment equip(EquipmentSlot slot, String itemId) {
+        Objects.requireNonNull(slot, "equipment slot은 필수입니다.");
+        if (itemId == null || itemId.isBlank()) {
+            throw new IllegalArgumentException("equipped item id는 비어 있을 수 없습니다.");
+        }
+        if (slots.containsKey(slot)) {
+            throw new IllegalStateException("이미 사용 중인 equipment slot입니다: " + slot);
+        }
+        if (containsItem(itemId)) {
+            throw new IllegalStateException("같은 item을 중복 장착할 수 없습니다: " + itemId);
+        }
+        EnumMap<EquipmentSlot, String> next = new EnumMap<>(EquipmentSlot.class);
+        next.putAll(slots);
+        next.put(slot, itemId);
+        return new Equipment(next);
+    }
+
+    public Equipment unequip(EquipmentSlot slot) {
+        Objects.requireNonNull(slot, "equipment slot은 필수입니다.");
+        if (!slots.containsKey(slot)) {
+            throw new IllegalStateException("비어 있는 equipment slot은 해제할 수 없습니다: " + slot);
+        }
+        EnumMap<EquipmentSlot, String> next = new EnumMap<>(EquipmentSlot.class);
+        next.putAll(slots);
+        next.remove(slot);
+        return new Equipment(next);
+    }
+}

--- a/src/main/java/com/uctale/uctale/domain/game/EquipmentSlot.java
+++ b/src/main/java/com/uctale/uctale/domain/game/EquipmentSlot.java
@@ -1,0 +1,8 @@
+package com.uctale.uctale.domain.game;
+
+public enum EquipmentSlot {
+    MAIN_HAND,
+    OFF_HAND,
+    BODY,
+    ACCESSORY
+}

--- a/src/main/java/com/uctale/uctale/domain/game/GameResult.java
+++ b/src/main/java/com/uctale/uctale/domain/game/GameResult.java
@@ -23,33 +23,61 @@ public record GameResult(
         narrativeCues = narrativeCues == null ? List.of() : List.copyOf(narrativeCues);
     }
 
-    public GameResult(
-            PlayerAction resolvedAction,
-            Outcome outcome,
-            List<CanonicalFact> canonicalFacts,
-            List<GameEvent> events,
-            List<StateChange> stateChanges,
-            List<String> narrativeCues
-    ) {
+    public GameResult(PlayerAction resolvedAction, Outcome outcome, List<CanonicalFact> canonicalFacts,
+                      List<GameEvent> events, List<StateChange> stateChanges, List<String> narrativeCues) {
         this(resolvedAction, outcome, null, canonicalFacts, events, stateChanges, narrativeCues);
     }
 
-    public enum Outcome {
-        RESOLVED
-    }
+    public enum Outcome { RESOLVED }
+    public enum GameEvent { ACTION_RESOLVED, SKILL_CHECK_RESOLVED }
 
-    public enum GameEvent {
-        ACTION_RESOLVED,
-        SKILL_CHECK_RESOLVED
+    public sealed interface StateChange permits TurnAdvanced, ItemAcquired, ItemRemoved,
+            ItemQuantityChanged, ItemConsumed, ItemEquipped, ItemUnequipped {
+        default String getType() {
+            if (this instanceof TurnAdvanced) return "TURN_ADVANCED";
+            if (this instanceof ItemAcquired) return "ITEM_ACQUIRED";
+            if (this instanceof ItemRemoved) return "ITEM_REMOVED";
+            if (this instanceof ItemQuantityChanged) return "ITEM_QUANTITY_CHANGED";
+            if (this instanceof ItemConsumed) return "ITEM_CONSUMED";
+            if (this instanceof ItemEquipped) return "ITEM_EQUIPPED";
+            if (this instanceof ItemUnequipped) return "ITEM_UNEQUIPPED";
+            throw new IllegalStateException("지원하지 않는 state change입니다.");
+        }
     }
-
-    public sealed interface StateChange permits TurnAdvanced {}
 
     public record TurnAdvanced(int previousTurn, int nextTurn) implements StateChange {
         public TurnAdvanced {
-            if (previousTurn < 1 || nextTurn != previousTurn + 1) {
-                throw new IllegalArgumentException("turn state change가 올바르지 않습니다.");
-            }
+            if (previousTurn < 1 || nextTurn != previousTurn + 1) throw new IllegalArgumentException("turn state change가 올바르지 않습니다.");
         }
+    }
+    public record ItemAcquired(OwnedItem item, int resultingQuantity) implements StateChange {
+        public ItemAcquired {
+            Objects.requireNonNull(item, "acquired item은 필수입니다.");
+            if (resultingQuantity < item.quantity()) throw new IllegalArgumentException("획득 후 quantity가 획득 quantity보다 작을 수 없습니다.");
+        }
+    }
+    public record ItemRemoved(OwnedItem item) implements StateChange {
+        public ItemRemoved { Objects.requireNonNull(item, "removed item은 필수입니다."); }
+    }
+    public record ItemQuantityChanged(String itemId, String definitionId, int previousQuantity, int nextQuantity) implements StateChange {
+        public ItemQuantityChanged {
+            validateItemReference(itemId, definitionId);
+            if (previousQuantity < 1 || nextQuantity < 1 || previousQuantity == nextQuantity) throw new IllegalArgumentException("item quantity state change가 올바르지 않습니다.");
+        }
+    }
+    public record ItemConsumed(String itemId, String definitionId, int quantity, int remainingQuantity) implements StateChange {
+        public ItemConsumed {
+            validateItemReference(itemId, definitionId);
+            if (quantity < 1 || remainingQuantity < 0) throw new IllegalArgumentException("item consume state change가 올바르지 않습니다.");
+        }
+    }
+    public record ItemEquipped(EquipmentSlot slot, String itemId, String definitionId) implements StateChange {
+        public ItemEquipped { Objects.requireNonNull(slot, "equipment slot은 필수입니다."); validateItemReference(itemId, definitionId); }
+    }
+    public record ItemUnequipped(EquipmentSlot slot, String itemId, String definitionId) implements StateChange {
+        public ItemUnequipped { Objects.requireNonNull(slot, "equipment slot은 필수입니다."); validateItemReference(itemId, definitionId); }
+    }
+    private static void validateItemReference(String itemId, String definitionId) {
+        if (itemId == null || itemId.isBlank() || definitionId == null || definitionId.isBlank()) throw new IllegalArgumentException("item state change 식별자가 올바르지 않습니다.");
     }
 }

--- a/src/main/java/com/uctale/uctale/domain/game/GameState.java
+++ b/src/main/java/com/uctale/uctale/domain/game/GameState.java
@@ -4,15 +4,25 @@ public record GameState(
         int turnNumber,
         PlayerCharacter playerCharacter,
         WorldState worldState,
-        StoryMemory storyMemory
+        StoryMemory storyMemory,
+        Inventory inventory
 ) {
     public GameState {
         if (turnNumber < 1) {
             throw new IllegalArgumentException("turnNumber는 1 이상이어야 합니다.");
         }
-        if (playerCharacter == null || worldState == null || storyMemory == null) {
+        if (playerCharacter == null || worldState == null || storyMemory == null || inventory == null) {
             throw new IllegalArgumentException("GameState 구성 요소는 null일 수 없습니다.");
         }
+    }
+
+    public GameState(
+            int turnNumber,
+            PlayerCharacter playerCharacter,
+            WorldState worldState,
+            StoryMemory storyMemory
+    ) {
+        this(turnNumber, playerCharacter, worldState, storyMemory, Inventory.empty());
     }
 
     public static GameState initial(String worldSetting, String characterSetting, String openingStory) {
@@ -20,8 +30,16 @@ public record GameState(
                 1,
                 PlayerCharacter.initial(characterSetting),
                 WorldState.initial(worldSetting),
-                StoryMemory.initial(worldSetting, characterSetting, openingStory)
+                StoryMemory.initial(worldSetting, characterSetting, openingStory),
+                Inventory.empty()
         );
+    }
+
+    public GameState withInventory(Inventory nextInventory) {
+        if (nextInventory == null) {
+            throw new IllegalArgumentException("inventory는 null일 수 없습니다.");
+        }
+        return new GameState(turnNumber, playerCharacter, worldState, storyMemory, nextInventory);
     }
 
     public GameState advanceTurn() {
@@ -29,7 +47,8 @@ public record GameState(
                 turnNumber + 1,
                 playerCharacter,
                 worldState,
-                storyMemory
+                storyMemory,
+                inventory
         );
     }
 
@@ -42,7 +61,8 @@ public record GameState(
                 turnNumber,
                 playerCharacter,
                 worldState,
-                storyMemory.append(new GameTurn(turnNumber, playerAction, storyText))
+                storyMemory.append(new GameTurn(turnNumber, playerAction, storyText)),
+                inventory
         );
     }
 

--- a/src/main/java/com/uctale/uctale/domain/game/Inventory.java
+++ b/src/main/java/com/uctale/uctale/domain/game/Inventory.java
@@ -1,0 +1,155 @@
+package com.uctale.uctale.domain.game;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+
+public record Inventory(
+        Map<String, OwnedItem> items,
+        Equipment equipment
+) {
+
+    public Inventory {
+        Objects.requireNonNull(items, "inventory items는 필수입니다.");
+        Objects.requireNonNull(equipment, "equipment는 필수입니다.");
+        if (items.isEmpty()) {
+            items = Map.of();
+        } else {
+            TreeMap<String, OwnedItem> copy = new TreeMap<>();
+            Map<String, ItemDefinition> definitionsById = new HashMap<>();
+            for (Map.Entry<String, OwnedItem> entry : items.entrySet()) {
+                String key = entry.getKey();
+                OwnedItem item = Objects.requireNonNull(entry.getValue(), "inventory item은 null일 수 없습니다.");
+                if (key == null || !key.equals(item.id())) {
+                    throw new IllegalArgumentException("inventory key와 owned item id가 일치해야 합니다.");
+                }
+                ItemDefinition previousDefinition = definitionsById.putIfAbsent(item.definition().id(), item.definition());
+                if (previousDefinition != null && !previousDefinition.equals(item.definition())) {
+                    throw new IllegalArgumentException("같은 item definition id는 동일한 definition을 사용해야 합니다.");
+                }
+                copy.put(key, item);
+            }
+            items = Collections.unmodifiableMap(copy);
+        }
+        validateEquipment(items, equipment);
+    }
+
+    public static Inventory empty() {
+        return new Inventory(Map.of(), Equipment.empty());
+    }
+
+    public OwnedItem requireItem(String itemId) {
+        if (itemId == null || itemId.isBlank()) {
+            throw new IllegalArgumentException("owned item id는 비어 있을 수 없습니다.");
+        }
+        OwnedItem item = items.get(itemId);
+        if (item == null) {
+            throw new IllegalArgumentException("존재하지 않는 item입니다: " + itemId);
+        }
+        return item;
+    }
+
+    public Inventory acquire(OwnedItem acquired) {
+        Objects.requireNonNull(acquired, "acquired item은 필수입니다.");
+        LinkedHashMap<String, OwnedItem> next = new LinkedHashMap<>(items);
+        OwnedItem existing = next.get(acquired.id());
+        if (existing == null) {
+            next.put(acquired.id(), acquired);
+            return new Inventory(next, equipment);
+        }
+        if (existing.definition().ownershipType() != ItemOwnershipType.STACK
+                || acquired.definition().ownershipType() != ItemOwnershipType.STACK
+                || !existing.definition().equals(acquired.definition())) {
+            throw new IllegalArgumentException("같은 owned item id를 다른 instance/definition에 재사용할 수 없습니다.");
+        }
+        int quantity;
+        try {
+            quantity = Math.addExact(existing.quantity(), acquired.quantity());
+        } catch (ArithmeticException exception) {
+            throw new IllegalArgumentException("item quantity가 지원 범위를 벗어났습니다.", exception);
+        }
+        next.put(existing.id(), existing.withQuantity(quantity));
+        return new Inventory(next, equipment);
+    }
+
+    public Inventory remove(String itemId) {
+        requireNotEquipped(itemId);
+        requireItem(itemId);
+        LinkedHashMap<String, OwnedItem> next = new LinkedHashMap<>(items);
+        next.remove(itemId);
+        return new Inventory(next, equipment);
+    }
+
+    public Inventory changeQuantity(String itemId, int newQuantity) {
+        if (newQuantity < 1) {
+            throw new IllegalArgumentException("변경할 item quantity는 1 이상이어야 합니다.");
+        }
+        OwnedItem item = requireItem(itemId);
+        if (item.definition().ownershipType() != ItemOwnershipType.STACK) {
+            throw new IllegalArgumentException("INSTANCE item의 quantity는 변경할 수 없습니다.");
+        }
+        if (item.quantity() == newQuantity) {
+            throw new IllegalArgumentException("item quantity는 실제로 변경되어야 합니다.");
+        }
+        LinkedHashMap<String, OwnedItem> next = new LinkedHashMap<>(items);
+        next.put(itemId, item.withQuantity(newQuantity));
+        return new Inventory(next, equipment);
+    }
+
+    public Inventory consume(String itemId, int quantity) {
+        if (quantity < 1) {
+            throw new IllegalArgumentException("소비 quantity는 1 이상이어야 합니다.");
+        }
+        OwnedItem item = requireItem(itemId);
+        if (quantity > item.quantity()) {
+            throw new IllegalArgumentException("보유 quantity보다 많이 소비할 수 없습니다.");
+        }
+        int remaining = item.quantity() - quantity;
+        if (remaining == 0) {
+            requireNotEquipped(itemId);
+            LinkedHashMap<String, OwnedItem> next = new LinkedHashMap<>(items);
+            next.remove(itemId);
+            return new Inventory(next, equipment);
+        }
+        if (item.definition().ownershipType() != ItemOwnershipType.STACK) {
+            throw new IllegalArgumentException("INSTANCE item은 부분 소비할 수 없습니다.");
+        }
+        LinkedHashMap<String, OwnedItem> next = new LinkedHashMap<>(items);
+        next.put(itemId, item.withQuantity(remaining));
+        return new Inventory(next, equipment);
+    }
+
+    public Inventory equip(String itemId, EquipmentSlot slot) {
+        OwnedItem item = requireItem(itemId);
+        Objects.requireNonNull(slot, "equipment slot은 필수입니다.");
+        if (!item.definition().equippable() || item.definition().equipmentSlot() != slot) {
+            throw new IllegalArgumentException("item을 요청한 equipment slot에 장착할 수 없습니다.");
+        }
+        return new Inventory(items, equipment.equip(slot, itemId));
+    }
+
+    public Inventory unequip(EquipmentSlot slot) {
+        return new Inventory(items, equipment.unequip(slot));
+    }
+
+    private void requireNotEquipped(String itemId) {
+        if (equipment.containsItem(itemId)) {
+            throw new IllegalStateException("장착 중인 item은 제거하거나 모두 소비할 수 없습니다.");
+        }
+    }
+
+    private static void validateEquipment(Map<String, OwnedItem> items, Equipment equipment) {
+        for (Map.Entry<EquipmentSlot, String> entry : equipment.slots().entrySet()) {
+            OwnedItem item = items.get(entry.getValue());
+            if (item == null) {
+                throw new IllegalArgumentException("equipment가 존재하지 않는 item을 참조합니다.");
+            }
+            if (!item.definition().equippable() || item.definition().equipmentSlot() != entry.getKey()) {
+                throw new IllegalArgumentException("equipment slot과 item definition이 일치하지 않습니다.");
+            }
+        }
+    }
+}

--- a/src/main/java/com/uctale/uctale/domain/game/InventoryCommand.java
+++ b/src/main/java/com/uctale/uctale/domain/game/InventoryCommand.java
@@ -1,0 +1,61 @@
+package com.uctale.uctale.domain.game;
+
+import java.util.Objects;
+
+public sealed interface InventoryCommand permits
+        InventoryCommand.Acquire,
+        InventoryCommand.Remove,
+        InventoryCommand.ChangeQuantity,
+        InventoryCommand.Consume,
+        InventoryCommand.Equip,
+        InventoryCommand.Unequip {
+
+    record Acquire(OwnedItem item) implements InventoryCommand {
+        public Acquire {
+            Objects.requireNonNull(item, "acquire item은 필수입니다.");
+        }
+    }
+
+    record Remove(String itemId) implements InventoryCommand {
+        public Remove {
+            validateItemId(itemId);
+        }
+    }
+
+    record ChangeQuantity(String itemId, int newQuantity) implements InventoryCommand {
+        public ChangeQuantity {
+            validateItemId(itemId);
+            if (newQuantity < 1) {
+                throw new IllegalArgumentException("newQuantity는 1 이상이어야 합니다.");
+            }
+        }
+    }
+
+    record Consume(String itemId, int quantity) implements InventoryCommand {
+        public Consume {
+            validateItemId(itemId);
+            if (quantity < 1) {
+                throw new IllegalArgumentException("consume quantity는 1 이상이어야 합니다.");
+            }
+        }
+    }
+
+    record Equip(String itemId, EquipmentSlot slot) implements InventoryCommand {
+        public Equip {
+            validateItemId(itemId);
+            Objects.requireNonNull(slot, "equipment slot은 필수입니다.");
+        }
+    }
+
+    record Unequip(EquipmentSlot slot) implements InventoryCommand {
+        public Unequip {
+            Objects.requireNonNull(slot, "equipment slot은 필수입니다.");
+        }
+    }
+
+    private static void validateItemId(String itemId) {
+        if (itemId == null || itemId.isBlank()) {
+            throw new IllegalArgumentException("owned item id는 비어 있을 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/com/uctale/uctale/domain/game/InventoryRules.java
+++ b/src/main/java/com/uctale/uctale/domain/game/InventoryRules.java
@@ -1,0 +1,140 @@
+package com.uctale.uctale.domain.game;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public final class InventoryRules {
+
+    public Result apply(Inventory inventory, List<InventoryCommand> commands) {
+        Objects.requireNonNull(inventory, "inventory는 필수입니다.");
+        if (commands == null || commands.isEmpty()) {
+            return new Result(inventory, List.of());
+        }
+
+        Inventory current = inventory;
+        List<GameResult.StateChange> changes = new ArrayList<>();
+        for (InventoryCommand command : commands) {
+            Objects.requireNonNull(command, "inventory command는 null일 수 없습니다.");
+            Applied applied = applyOne(current, command);
+            current = applied.inventory();
+            changes.add(applied.stateChange());
+        }
+        return new Result(current, changes);
+    }
+
+    public static Inventory replay(Inventory inventory, List<GameResult.StateChange> stateChanges) {
+        Objects.requireNonNull(inventory, "inventory는 필수입니다.");
+        if (stateChanges == null || stateChanges.isEmpty()) {
+            return inventory;
+        }
+
+        Inventory current = inventory;
+        for (GameResult.StateChange stateChange : stateChanges) {
+            Objects.requireNonNull(stateChange, "stateChange는 null일 수 없습니다.");
+            if (stateChange instanceof GameResult.ItemAcquired acquired) {
+                current = current.acquire(acquired.item());
+                int actual = current.requireItem(acquired.item().id()).quantity();
+                if (actual != acquired.resultingQuantity()) {
+                    throw new IllegalStateException("ItemAcquired audit 결과 quantity가 canonical replay와 일치하지 않습니다.");
+                }
+            } else if (stateChange instanceof GameResult.ItemRemoved removed) {
+                if (!current.requireItem(removed.item().id()).equals(removed.item())) {
+                    throw new IllegalStateException("ItemRemoved audit의 기존 item이 canonical state와 일치하지 않습니다.");
+                }
+                current = current.remove(removed.item().id());
+            } else if (stateChange instanceof GameResult.ItemQuantityChanged quantityChanged) {
+                OwnedItem existing = current.requireItem(quantityChanged.itemId());
+                requireDefinition(existing, quantityChanged.definitionId());
+                if (existing.quantity() != quantityChanged.previousQuantity()) {
+                    throw new IllegalStateException("ItemQuantityChanged audit의 이전 quantity가 canonical state와 일치하지 않습니다.");
+                }
+                current = current.changeQuantity(quantityChanged.itemId(), quantityChanged.nextQuantity());
+            } else if (stateChange instanceof GameResult.ItemConsumed consumed) {
+                OwnedItem existing = current.requireItem(consumed.itemId());
+                requireDefinition(existing, consumed.definitionId());
+                current = current.consume(consumed.itemId(), consumed.quantity());
+                OwnedItem remaining = current.items().get(consumed.itemId());
+                int actualRemaining = remaining == null ? 0 : remaining.quantity();
+                if (actualRemaining != consumed.remainingQuantity()) {
+                    throw new IllegalStateException("ItemConsumed audit의 남은 quantity가 canonical replay와 일치하지 않습니다.");
+                }
+            } else if (stateChange instanceof GameResult.ItemEquipped equipped) {
+                OwnedItem existing = current.requireItem(equipped.itemId());
+                requireDefinition(existing, equipped.definitionId());
+                current = current.equip(equipped.itemId(), equipped.slot());
+            } else if (stateChange instanceof GameResult.ItemUnequipped unequipped) {
+                String equippedItemId = current.equipment().itemIdAt(unequipped.slot());
+                if (!unequipped.itemId().equals(equippedItemId)) {
+                    throw new IllegalStateException("ItemUnequipped audit가 canonical equipment와 일치하지 않습니다.");
+                }
+                OwnedItem existing = current.requireItem(unequipped.itemId());
+                requireDefinition(existing, unequipped.definitionId());
+                current = current.unequip(unequipped.slot());
+            }
+        }
+        return current;
+    }
+
+    private Applied applyOne(Inventory inventory, InventoryCommand command) {
+        if (command instanceof InventoryCommand.Acquire acquire) {
+            Inventory next = inventory.acquire(acquire.item());
+            int resultingQuantity = next.requireItem(acquire.item().id()).quantity();
+            return new Applied(next, new GameResult.ItemAcquired(acquire.item(), resultingQuantity));
+        }
+        if (command instanceof InventoryCommand.Remove remove) {
+            OwnedItem removed = inventory.requireItem(remove.itemId());
+            return new Applied(inventory.remove(remove.itemId()), new GameResult.ItemRemoved(removed));
+        }
+        if (command instanceof InventoryCommand.ChangeQuantity changeQuantity) {
+            OwnedItem existing = inventory.requireItem(changeQuantity.itemId());
+            Inventory next = inventory.changeQuantity(changeQuantity.itemId(), changeQuantity.newQuantity());
+            return new Applied(next, new GameResult.ItemQuantityChanged(
+                    existing.id(), existing.definition().id(), existing.quantity(), changeQuantity.newQuantity()
+            ));
+        }
+        if (command instanceof InventoryCommand.Consume consume) {
+            OwnedItem existing = inventory.requireItem(consume.itemId());
+            Inventory next = inventory.consume(consume.itemId(), consume.quantity());
+            OwnedItem remaining = next.items().get(consume.itemId());
+            return new Applied(next, new GameResult.ItemConsumed(
+                    existing.id(), existing.definition().id(), consume.quantity(), remaining == null ? 0 : remaining.quantity()
+            ));
+        }
+        if (command instanceof InventoryCommand.Equip equip) {
+            OwnedItem existing = inventory.requireItem(equip.itemId());
+            return new Applied(
+                    inventory.equip(equip.itemId(), equip.slot()),
+                    new GameResult.ItemEquipped(equip.slot(), existing.id(), existing.definition().id())
+            );
+        }
+        if (command instanceof InventoryCommand.Unequip unequip) {
+            String itemId = inventory.equipment().itemIdAt(unequip.slot());
+            if (itemId == null) {
+                throw new IllegalStateException("비어 있는 equipment slot은 해제할 수 없습니다: " + unequip.slot());
+            }
+            OwnedItem existing = inventory.requireItem(itemId);
+            return new Applied(
+                    inventory.unequip(unequip.slot()),
+                    new GameResult.ItemUnequipped(unequip.slot(), existing.id(), existing.definition().id())
+            );
+        }
+        throw new IllegalArgumentException("지원하지 않는 inventory command입니다: " + command.getClass().getName());
+    }
+
+    private static void requireDefinition(OwnedItem item, String definitionId) {
+        if (!item.definition().id().equals(definitionId)) {
+            throw new IllegalStateException("inventory audit의 item definition이 canonical state와 일치하지 않습니다.");
+        }
+    }
+
+    public record Result(Inventory inventory, List<GameResult.StateChange> stateChanges) {
+        public Result {
+            Objects.requireNonNull(inventory, "inventory는 필수입니다.");
+            stateChanges = stateChanges == null ? List.of() : List.copyOf(stateChanges);
+        }
+    }
+
+    private record Applied(Inventory inventory, GameResult.StateChange stateChange) {
+    }
+}

--- a/src/main/java/com/uctale/uctale/domain/game/ItemDefinition.java
+++ b/src/main/java/com/uctale/uctale/domain/game/ItemDefinition.java
@@ -1,0 +1,26 @@
+package com.uctale.uctale.domain.game;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+public record ItemDefinition(
+        String id,
+        ItemOwnershipType ownershipType,
+        EquipmentSlot equipmentSlot
+) {
+    private static final Pattern ID_PATTERN = Pattern.compile("[A-Za-z0-9][A-Za-z0-9._:-]{0,127}");
+
+    public ItemDefinition {
+        if (id == null || !ID_PATTERN.matcher(id).matches()) {
+            throw new IllegalArgumentException("item definition id가 올바르지 않습니다.");
+        }
+        Objects.requireNonNull(ownershipType, "item ownershipType은 필수입니다.");
+        if (equipmentSlot != null && ownershipType != ItemOwnershipType.INSTANCE) {
+            throw new IllegalArgumentException("장착 가능한 item은 INSTANCE ownership이어야 합니다.");
+        }
+    }
+
+    public boolean equippable() {
+        return equipmentSlot != null;
+    }
+}

--- a/src/main/java/com/uctale/uctale/domain/game/ItemOwnershipType.java
+++ b/src/main/java/com/uctale/uctale/domain/game/ItemOwnershipType.java
@@ -1,0 +1,6 @@
+package com.uctale.uctale.domain.game;
+
+public enum ItemOwnershipType {
+    STACK,
+    INSTANCE
+}

--- a/src/main/java/com/uctale/uctale/domain/game/OwnedItem.java
+++ b/src/main/java/com/uctale/uctale/domain/game/OwnedItem.java
@@ -1,0 +1,29 @@
+package com.uctale.uctale.domain.game;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+public record OwnedItem(
+        String id,
+        ItemDefinition definition,
+        int quantity
+) {
+    private static final Pattern ID_PATTERN = Pattern.compile("[A-Za-z0-9][A-Za-z0-9._:-]{0,127}");
+
+    public OwnedItem {
+        if (id == null || !ID_PATTERN.matcher(id).matches()) {
+            throw new IllegalArgumentException("owned item id가 올바르지 않습니다.");
+        }
+        Objects.requireNonNull(definition, "item definition은 필수입니다.");
+        if (quantity < 1) {
+            throw new IllegalArgumentException("item quantity는 1 이상이어야 합니다.");
+        }
+        if (definition.ownershipType() == ItemOwnershipType.INSTANCE && quantity != 1) {
+            throw new IllegalArgumentException("INSTANCE item quantity는 1이어야 합니다.");
+        }
+    }
+
+    public OwnedItem withQuantity(int newQuantity) {
+        return new OwnedItem(id, definition, newQuantity);
+    }
+}

--- a/src/main/resources/db/migration/V13__add_inventory_change_audit.sql
+++ b/src/main/resources/db/migration/V13__add_inventory_change_audit.sql
@@ -1,0 +1,2 @@
+ALTER TABLE game_log
+    ADD COLUMN inventory_changes_json TEXT;

--- a/src/test/java/com/uctale/uctale/application/game/GamePersistenceIntegrityTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/GamePersistenceIntegrityTest.java
@@ -29,6 +29,7 @@ class GamePersistenceIntegrityTest {
     @Mock private GameMutationRequestRepository gameMutationRequestRepository;
     @Mock private GameStateCodec gameStateCodec;
     @Mock private GameStateRecovery gameStateRecovery;
+    @Mock private InventoryAuditCodec inventoryAuditCodec;
 
     private GamePersistenceService persistenceService;
     private GameTurnCommit commit;
@@ -42,7 +43,8 @@ class GamePersistenceIntegrityTest {
                 imageAssetRepository,
                 gameMutationRequestRepository,
                 gameStateCodec,
-                gameStateRecovery
+                gameStateRecovery,
+                inventoryAuditCodec
         );
         GameState previousState = GameState.initial("세계관", "캐릭터", "첫 이야기");
         commit = new GameTurnCommit(

--- a/src/test/java/com/uctale/uctale/application/game/GameResultStateChangeSerializationTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/GameResultStateChangeSerializationTest.java
@@ -1,0 +1,28 @@
+package com.uctale.uctale.application.game;
+
+import com.uctale.uctale.domain.game.EquipmentSlot;
+import com.uctale.uctale.domain.game.GameResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GameResultStateChangeSerializationTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("NarrativeContext JSON에서 equip과 unequip state change type을 구분할 수 있다")
+    void stateChanges_ExposeExplicitTypeForProviderProjection() throws Exception {
+        String json = objectMapper.writeValueAsString(List.of(
+                new GameResult.ItemEquipped(EquipmentSlot.MAIN_HAND, "sword:001", "iron-sword"),
+                new GameResult.ItemUnequipped(EquipmentSlot.MAIN_HAND, "sword:001", "iron-sword")
+        ));
+
+        assertThat(json).contains("\"type\":\"ITEM_EQUIPPED\"");
+        assertThat(json).contains("\"type\":\"ITEM_UNEQUIPPED\"");
+    }
+}

--- a/src/test/java/com/uctale/uctale/application/game/GameStateCodecCompatibilityTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/GameStateCodecCompatibilityTest.java
@@ -11,15 +11,40 @@ class GameStateCodecCompatibilityTest {
     private final GameStateCodec codec = new GameStateCodec(new ObjectMapper(), new GameStateUpgrader());
 
     @Test
-    @DisplayName("현재 schema v2에서 stats가 누락된 손상 snapshot은 기본값으로 숨기지 않는다")
+    @DisplayName("현재 schema v3에서 stats가 누락된 손상 snapshot은 기본값으로 숨기지 않는다")
     void currentSchemaMissingStats_FailsExplicitly() {
         String json = """
                 {
-                  "schemaVersion": 2,
+                  "schemaVersion": 3,
                   "rulesetVersion": 1,
                   "state": {
                     "turnNumber": 1,
                     "playerCharacter": {"description": "캐릭터"},
+                    "worldState": {"premise": "세계관", "flags": {}},
+                    "storyMemory": {"canonicalFacts": [], "rollingSummary": "", "recentTurns": []},
+                    "inventory": {"items": {}, "equipment": {"slots": {}}}
+                  }
+                }
+                """;
+
+        assertThatThrownBy(() -> codec.deserialize(json))
+                .isInstanceOf(GameStateSnapshotException.class)
+                .hasMessageContaining("역직렬화");
+    }
+
+    @Test
+    @DisplayName("현재 schema v3에서 inventory가 누락된 손상 snapshot은 빈 inventory로 숨기지 않는다")
+    void currentSchemaMissingInventory_FailsExplicitly() {
+        String json = """
+                {
+                  "schemaVersion": 3,
+                  "rulesetVersion": 1,
+                  "state": {
+                    "turnNumber": 1,
+                    "playerCharacter": {
+                      "description": "캐릭터",
+                      "stats": {"might":10,"agility":10,"intellect":10,"will":10,"presence":10}
+                    },
                     "worldState": {"premise": "세계관", "flags": {}},
                     "storyMemory": {"canonicalFacts": [], "rollingSummary": "", "recentTurns": []}
                   }

--- a/src/test/java/com/uctale/uctale/application/game/GameStateUpgraderTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/GameStateUpgraderTest.java
@@ -120,7 +120,29 @@ class GameStateUpgraderTest {
     }
 
     @Test
-    @DisplayName("schema v2 inventory 필드가 손상되어 있으면 빈 값으로 덮지 않고 실패한다")
+    @DisplayName("schema v2에 inventory 필드가 있으면 의미를 추정하지 않고 실패한다")
+    void schemaV2WithInventory_FailsExplicitly() throws Exception {
+        JsonNode snapshot = objectMapper.readTree("""
+                {
+                  "schemaVersion": 2,
+                  "rulesetVersion": 1,
+                  "state": {
+                    "turnNumber": 1,
+                    "playerCharacter": {"description":"캐릭터","stats":{"might":10,"agility":10,"intellect":10,"will":10,"presence":10}},
+                    "worldState": {"premise": "세계관", "flags": {}},
+                    "storyMemory": {"canonicalFacts": [], "rollingSummary": "", "recentTurns": []},
+                    "inventory": {"items": {}, "equipment": {"slots": {}}}
+                  }
+                }
+                """);
+        assertThatThrownBy(() -> upgrader.upgrade(snapshot))
+                .isInstanceOf(GameStateSnapshotException.class)
+                .hasMessageContaining("schema v2")
+                .hasMessageContaining("inventory");
+    }
+
+    @Test
+    @DisplayName("schema v2 inventory 필드가 손상되어 있어도 임의 기본값으로 덮지 않고 실패한다")
     void damagedLegacyInventory_FailsExplicitly() throws Exception {
         JsonNode snapshot = objectMapper.readTree("""
                 {

--- a/src/test/java/com/uctale/uctale/application/game/GameStateUpgraderTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/GameStateUpgraderTest.java
@@ -14,25 +14,24 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class GameStateUpgraderTest {
 
     private static final String LEGACY_FIXTURE = "fixtures/game-state/snapshot-v0-production.json";
-
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final GameStateUpgrader upgrader = new GameStateUpgrader();
 
     @Test
-    @DisplayName("production legacy raw GameState를 schema v2와 기본 능력치로 순수 upgrade한다")
+    @DisplayName("production legacy raw GameState를 schema v3, 기본 능력치, 빈 inventory로 순수 upgrade한다")
     void legacyRawState_IsUpgradedToCurrentSchema() throws Exception {
         JsonNode legacy = objectMapper.readTree(legacyStateJson());
-
         GameStateUpgrader.UpgradedSnapshot upgraded = upgrader.upgrade(legacy);
-
-        assertThat(upgraded.schemaVersion()).isEqualTo(2);
+        assertThat(upgraded.schemaVersion()).isEqualTo(3);
         assertThat(upgraded.rulesetVersion()).isEqualTo(1);
         assertThat(upgraded.state().get("playerCharacter").get("stats").get("might").asInt()).isEqualTo(10);
         assertThat(upgraded.state().get("playerCharacter").get("stats").get("presence").asInt()).isEqualTo(10);
+        assertThat(upgraded.state().get("inventory").get("items").isEmpty()).isTrue();
+        assertThat(upgraded.state().get("inventory").get("equipment").get("slots").isEmpty()).isTrue();
     }
 
     @Test
-    @DisplayName("schema v1 legacy stats의 canonical 키는 v2 typed stats로 보존한다")
+    @DisplayName("schema v1 legacy stats의 canonical 키는 v3까지 보존한다")
     void schemaV1Stats_AreNormalizedWithoutLosingCanonicalValues() throws Exception {
         JsonNode snapshot = objectMapper.readTree("""
                 {
@@ -40,53 +39,63 @@ class GameStateUpgraderTest {
                   "rulesetVersion": 1,
                   "state": {
                     "turnNumber": 1,
-                    "playerCharacter": {
-                      "description": "캐릭터",
-                      "stats": {"MIGHT": 14, "agility": 12}
-                    },
+                    "playerCharacter": {"description": "캐릭터", "stats": {"MIGHT": 14, "agility": 12}},
                     "worldState": {"premise": "세계관", "flags": {}},
-                    "storyMemory": {
-                      "canonicalFacts": [],
-                      "rollingSummary": "",
-                      "recentTurns": []
-                    }
+                    "storyMemory": {"canonicalFacts": [], "rollingSummary": "", "recentTurns": []}
                   }
                 }
                 """);
-
         GameStateUpgrader.UpgradedSnapshot upgraded = upgrader.upgrade(snapshot);
         JsonNode stats = upgraded.state().get("playerCharacter").get("stats");
-
-        assertThat(upgraded.schemaVersion()).isEqualTo(2);
+        assertThat(upgraded.schemaVersion()).isEqualTo(3);
         assertThat(stats.get("might").asInt()).isEqualTo(14);
         assertThat(stats.get("agility").asInt()).isEqualTo(12);
         assertThat(stats.get("intellect").asInt()).isEqualTo(10);
         assertThat(stats.get("will").asInt()).isEqualTo(10);
         assertThat(stats.get("presence").asInt()).isEqualTo(10);
+        assertThat(upgraded.state().get("inventory").get("items").isEmpty()).isTrue();
     }
 
     @Test
-    @DisplayName("schema v2 snapshot은 state를 그대로 읽는다")
-    void schemaV2_IsReadWithoutMutation() throws Exception {
+    @DisplayName("schema v2 snapshot은 기존 의미를 보존하고 빈 inventory를 명시적으로 추가한다")
+    void schemaV2_IsUpgradedWithEmptyInventory() throws Exception {
         JsonNode snapshot = objectMapper.readTree("""
                 {
                   "schemaVersion": 2,
                   "rulesetVersion": 1,
                   "state": {
                     "turnNumber": 1,
-                    "playerCharacter": {
-                      "description": "캐릭터",
-                      "stats": {"might":10,"agility":10,"intellect":10,"will":10,"presence":10}
-                    },
+                    "playerCharacter": {"description": "캐릭터", "stats": {"might":10,"agility":10,"intellect":10,"will":10,"presence":10}},
                     "worldState": {"premise": "세계관", "flags": {}},
                     "storyMemory": {"canonicalFacts": [], "rollingSummary": "", "recentTurns": []}
                   }
                 }
                 """);
-
         GameStateUpgrader.UpgradedSnapshot upgraded = upgrader.upgrade(snapshot);
+        assertThat(upgraded.schemaVersion()).isEqualTo(3);
+        assertThat(upgraded.rulesetVersion()).isEqualTo(1);
+        assertThat(upgraded.state().get("turnNumber").asInt()).isEqualTo(1);
+        assertThat(upgraded.state().get("inventory").get("items").isEmpty()).isTrue();
+    }
 
-        assertThat(upgraded.schemaVersion()).isEqualTo(2);
+    @Test
+    @DisplayName("schema v3 snapshot은 state를 그대로 읽는다")
+    void schemaV3_IsReadWithoutMutation() throws Exception {
+        JsonNode snapshot = objectMapper.readTree("""
+                {
+                  "schemaVersion": 3,
+                  "rulesetVersion": 1,
+                  "state": {
+                    "turnNumber": 1,
+                    "playerCharacter": {"description": "캐릭터", "stats": {"might":10,"agility":10,"intellect":10,"will":10,"presence":10}},
+                    "worldState": {"premise": "세계관", "flags": {}},
+                    "storyMemory": {"canonicalFacts": [], "rollingSummary": "", "recentTurns": []},
+                    "inventory": {"items": {}, "equipment": {"slots": {}}}
+                  }
+                }
+                """);
+        GameStateUpgrader.UpgradedSnapshot upgraded = upgrader.upgrade(snapshot);
+        assertThat(upgraded.schemaVersion()).isEqualTo(3);
         assertThat(upgraded.rulesetVersion()).isEqualTo(1);
         assertThat(upgraded.state()).isEqualTo(snapshot.get("state"));
     }
@@ -106,58 +115,60 @@ class GameStateUpgraderTest {
                   }
                 }
                 """);
-
         assertThatThrownBy(() -> upgrader.upgrade(snapshot))
-                .isInstanceOf(GameStateSnapshotException.class)
-                .hasMessageContaining("MIGHT");
+                .isInstanceOf(GameStateSnapshotException.class).hasMessageContaining("MIGHT");
+    }
+
+    @Test
+    @DisplayName("schema v2 inventory 필드가 손상되어 있으면 빈 값으로 덮지 않고 실패한다")
+    void damagedLegacyInventory_FailsExplicitly() throws Exception {
+        JsonNode snapshot = objectMapper.readTree("""
+                {
+                  "schemaVersion": 2,
+                  "rulesetVersion": 1,
+                  "state": {
+                    "turnNumber": 1,
+                    "playerCharacter": {"description":"캐릭터","stats":{"might":10,"agility":10,"intellect":10,"will":10,"presence":10}},
+                    "worldState": {"premise": "세계관", "flags": {}},
+                    "storyMemory": {"canonicalFacts": [], "rollingSummary": "", "recentTurns": []},
+                    "inventory": "broken"
+                  }
+                }
+                """);
+        assertThatThrownBy(() -> upgrader.upgrade(snapshot))
+                .isInstanceOf(GameStateSnapshotException.class).hasMessageContaining("inventory");
     }
 
     @Test
     @DisplayName("미래 schema version은 기본값 처리하지 않고 실패한다")
     void futureSchemaVersion_FailsExplicitly() throws Exception {
-        JsonNode snapshot = objectMapper.readTree("""
-                {"schemaVersion": 3, "rulesetVersion": 1, "state": {}}
-                """);
-
+        JsonNode snapshot = objectMapper.readTree("""{"schemaVersion": 4, "rulesetVersion": 1, "state": {}}""");
         assertThatThrownBy(() -> upgrader.upgrade(snapshot))
-                .isInstanceOf(GameStateSnapshotException.class)
-                .hasMessageContaining("미래 snapshot schemaVersion");
+                .isInstanceOf(GameStateSnapshotException.class).hasMessageContaining("미래 snapshot schemaVersion");
     }
 
     @Test
     @DisplayName("미지원 ruleset version은 자동 재판정하지 않고 실패한다")
     void unsupportedRulesetVersion_FailsExplicitly() throws Exception {
-        JsonNode snapshot = objectMapper.readTree("""
-                {"schemaVersion": 2, "rulesetVersion": 2, "state": {}}
-                """);
-
+        JsonNode snapshot = objectMapper.readTree("""{"schemaVersion": 3, "rulesetVersion": 2, "state": {}}""");
         assertThatThrownBy(() -> upgrader.upgrade(snapshot))
-                .isInstanceOf(GameStateSnapshotException.class)
-                .hasMessageContaining("rulesetVersion");
+                .isInstanceOf(GameStateSnapshotException.class).hasMessageContaining("rulesetVersion");
     }
 
     @Test
     @DisplayName("envelope에서 schemaVersion만 누락된 손상 snapshot은 legacy로 오인하지 않는다")
     void damagedEnvelopeMissingSchemaVersion_FailsExplicitly() throws Exception {
-        JsonNode snapshot = objectMapper.readTree("""
-                {"rulesetVersion": 1, "state": {}}
-                """);
-
+        JsonNode snapshot = objectMapper.readTree("""{"rulesetVersion": 1, "state": {}}""");
         assertThatThrownBy(() -> upgrader.upgrade(snapshot))
-                .isInstanceOf(GameStateSnapshotException.class)
-                .hasMessageContaining("schemaVersion이 누락");
+                .isInstanceOf(GameStateSnapshotException.class).hasMessageContaining("schemaVersion이 누락");
     }
 
     @Test
     @DisplayName("schemaVersion이 있어도 state가 누락되면 손상 snapshot으로 실패한다")
     void missingState_FailsExplicitly() throws Exception {
-        JsonNode snapshot = objectMapper.readTree("""
-                {"schemaVersion": 2, "rulesetVersion": 1}
-                """);
-
+        JsonNode snapshot = objectMapper.readTree("""{"schemaVersion": 3, "rulesetVersion": 1}""");
         assertThatThrownBy(() -> upgrader.upgrade(snapshot))
-                .isInstanceOf(GameStateSnapshotException.class)
-                .hasMessageContaining("state가 누락");
+                .isInstanceOf(GameStateSnapshotException.class).hasMessageContaining("state가 누락");
     }
 
     private String legacyStateJson() throws Exception {

--- a/src/test/java/com/uctale/uctale/application/game/GameStateUpgraderTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/GameStateUpgraderTest.java
@@ -142,7 +142,7 @@ class GameStateUpgraderTest {
     @Test
     @DisplayName("미래 schema version은 기본값 처리하지 않고 실패한다")
     void futureSchemaVersion_FailsExplicitly() throws Exception {
-        JsonNode snapshot = objectMapper.readTree("""{"schemaVersion": 4, "rulesetVersion": 1, "state": {}}""");
+        JsonNode snapshot = objectMapper.readTree("{\"schemaVersion\": 4, \"rulesetVersion\": 1, \"state\": {}}");
         assertThatThrownBy(() -> upgrader.upgrade(snapshot))
                 .isInstanceOf(GameStateSnapshotException.class).hasMessageContaining("미래 snapshot schemaVersion");
     }
@@ -150,7 +150,7 @@ class GameStateUpgraderTest {
     @Test
     @DisplayName("미지원 ruleset version은 자동 재판정하지 않고 실패한다")
     void unsupportedRulesetVersion_FailsExplicitly() throws Exception {
-        JsonNode snapshot = objectMapper.readTree("""{"schemaVersion": 3, "rulesetVersion": 2, "state": {}}""");
+        JsonNode snapshot = objectMapper.readTree("{\"schemaVersion\": 3, \"rulesetVersion\": 2, \"state\": {}}");
         assertThatThrownBy(() -> upgrader.upgrade(snapshot))
                 .isInstanceOf(GameStateSnapshotException.class).hasMessageContaining("rulesetVersion");
     }
@@ -158,7 +158,7 @@ class GameStateUpgraderTest {
     @Test
     @DisplayName("envelope에서 schemaVersion만 누락된 손상 snapshot은 legacy로 오인하지 않는다")
     void damagedEnvelopeMissingSchemaVersion_FailsExplicitly() throws Exception {
-        JsonNode snapshot = objectMapper.readTree("""{"rulesetVersion": 1, "state": {}}""");
+        JsonNode snapshot = objectMapper.readTree("{\"rulesetVersion\": 1, \"state\": {}}");
         assertThatThrownBy(() -> upgrader.upgrade(snapshot))
                 .isInstanceOf(GameStateSnapshotException.class).hasMessageContaining("schemaVersion이 누락");
     }
@@ -166,7 +166,7 @@ class GameStateUpgraderTest {
     @Test
     @DisplayName("schemaVersion이 있어도 state가 누락되면 손상 snapshot으로 실패한다")
     void missingState_FailsExplicitly() throws Exception {
-        JsonNode snapshot = objectMapper.readTree("""{"schemaVersion": 3, "rulesetVersion": 1}""");
+        JsonNode snapshot = objectMapper.readTree("{\"schemaVersion\": 3, \"rulesetVersion\": 1}");
         assertThatThrownBy(() -> upgrader.upgrade(snapshot))
                 .isInstanceOf(GameStateSnapshotException.class).hasMessageContaining("state가 누락");
     }

--- a/src/test/java/com/uctale/uctale/application/game/GameTurnCommitInventoryTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/GameTurnCommitInventoryTest.java
@@ -1,0 +1,45 @@
+package com.uctale.uctale.application.game;
+
+import com.uctale.uctale.domain.action.ActionType;
+import com.uctale.uctale.domain.action.PlayerAction;
+import com.uctale.uctale.domain.game.ActionResolver;
+import com.uctale.uctale.domain.game.GameState;
+import com.uctale.uctale.domain.game.InventoryCommand;
+import com.uctale.uctale.domain.game.ItemDefinition;
+import com.uctale.uctale.domain.game.ItemOwnershipType;
+import com.uctale.uctale.domain.game.OwnedItem;
+import com.uctale.uctale.domain.game.StateTransition;
+import com.uctale.uctale.domain.game.TurnResolution;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GameTurnCommitInventoryTest {
+
+    @Test
+    @DisplayName("GameTurnCommit은 inventory가 변했는데 audit이 누락되거나 변조되면 거절한다")
+    void commit_RequiresStateChangesThatReplayToNextInventory() {
+        GameState state = GameState.initial("세계관", "캐릭터", "오프닝");
+        PlayerAction action = new PlayerAction(
+                1, "token", ActionType.NARRATIVE_CHOICE, 1, Map.of("choiceId", "1"), "상자를 연다"
+        );
+        OwnedItem potion = new OwnedItem(
+                "stack:potion", new ItemDefinition("potion", ItemOwnershipType.STACK, null), 1
+        );
+        TurnResolution resolution = new ActionResolver().resolveWithInventory(
+                state, action, List.of(new InventoryCommand.Acquire(potion))
+        );
+        StateTransition committed = resolution.attachNarrative("상자에서 물약을 얻었다.");
+
+        assertThatThrownBy(() -> new GameTurnCommit(
+                1, 1, "상자를 연다", committed, "상자에서 물약을 얻었다.", "[]",
+                "game-result:1", "story:1", null, null
+        ))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("inventory audit");
+    }
+}

--- a/src/test/java/com/uctale/uctale/application/game/InventoryAuditCodecTest.java
+++ b/src/test/java/com/uctale/uctale/application/game/InventoryAuditCodecTest.java
@@ -1,0 +1,49 @@
+package com.uctale.uctale.application.game;
+
+import com.uctale.uctale.domain.game.EquipmentSlot;
+import com.uctale.uctale.domain.game.GameResult;
+import com.uctale.uctale.domain.game.ItemDefinition;
+import com.uctale.uctale.domain.game.ItemOwnershipType;
+import com.uctale.uctale.domain.game.OwnedItem;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class InventoryAuditCodecTest {
+    private final InventoryAuditCodec codec = new InventoryAuditCodec(new ObjectMapper());
+
+    @Test
+    @DisplayName("inventory state change만 GameLog audit JSON으로 round-trip한다")
+    void roundTrip_InventoryChangesOnly() {
+        OwnedItem sword = new OwnedItem("sword:001",
+                new ItemDefinition("iron-sword", ItemOwnershipType.INSTANCE, EquipmentSlot.MAIN_HAND), 1);
+        List<GameResult.StateChange> changes = List.of(
+                new GameResult.ItemAcquired(sword, 1),
+                new GameResult.ItemEquipped(EquipmentSlot.MAIN_HAND, "sword:001", "iron-sword"),
+                new GameResult.TurnAdvanced(1, 2));
+        String json = codec.serialize(changes);
+        assertThat(json).contains("ITEM_ACQUIRED", "ITEM_EQUIPPED").doesNotContain("TurnAdvanced");
+        assertThat(codec.deserialize(json)).containsExactly(changes.get(0), changes.get(1));
+    }
+
+    @Test
+    @DisplayName("inventory change가 없으면 legacy 호환을 위해 null audit을 저장한다")
+    void noInventoryChanges_SerializesAsNull() {
+        assertThat(codec.serialize(List.of(new GameResult.TurnAdvanced(1, 2)))).isNull();
+        assertThat(codec.deserialize(null)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("손상되거나 미래 type의 audit은 조용히 무시하지 않는다")
+    void damagedAudit_FailsExplicitly() {
+        assertThatThrownBy(() -> codec.deserialize("{\"type\":\"ITEM_ACQUIRED\"}"))
+                .isInstanceOf(IllegalStateException.class).hasMessageContaining("JSON array");
+        assertThatThrownBy(() -> codec.deserialize("[{\"type\":\"FUTURE_ITEM_CHANGE\"}]"))
+                .isInstanceOf(IllegalStateException.class).hasMessageContaining("지원하지 않는");
+    }
+}

--- a/src/test/java/com/uctale/uctale/domain/game/ActionResolverInventoryTest.java
+++ b/src/test/java/com/uctale/uctale/domain/game/ActionResolverInventoryTest.java
@@ -1,0 +1,36 @@
+package com.uctale.uctale.domain.game;
+
+import com.uctale.uctale.domain.action.ActionType;
+import com.uctale.uctale.domain.action.PlayerAction;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ActionResolverInventoryTest {
+    private final ActionResolver resolver = new ActionResolver();
+
+    @Test
+    @DisplayName("서버가 전달한 inventory command만 canonical next state와 GameResult를 변경한다")
+    void resolve_AppliesServerInventoryCommandsBeforeNarrative() {
+        GameState state = GameState.initial("세계관", "캐릭터", "오프닝");
+        PlayerAction action = new PlayerAction(1, "token", ActionType.NARRATIVE_CHOICE, 1,
+                Map.of("choiceId", "1"), "상자를 연다");
+        OwnedItem potion = new OwnedItem("stack:potion",
+                new ItemDefinition("potion", ItemOwnershipType.STACK, null), 2);
+
+        TurnResolution withoutServerEffect = resolver.resolve(state, action);
+        TurnResolution withServerEffect = resolver.resolveWithInventory(
+                state, action, List.of(new InventoryCommand.Acquire(potion)));
+
+        assertThat(withoutServerEffect.stateTransition().nextState().inventory()).isEqualTo(Inventory.empty());
+        assertThat(withServerEffect.stateTransition().nextState().inventory().requireItem("stack:potion").quantity())
+                .isEqualTo(2);
+        assertThat(withServerEffect.gameResult().stateChanges()).containsExactly(
+                new GameResult.ItemAcquired(potion, 2),
+                new GameResult.TurnAdvanced(1, 2));
+    }
+}

--- a/src/test/java/com/uctale/uctale/domain/game/InventoryRulesTest.java
+++ b/src/test/java/com/uctale/uctale/domain/game/InventoryRulesTest.java
@@ -1,0 +1,129 @@
+package com.uctale.uctale.domain.game;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class InventoryRulesTest {
+    private final InventoryRules rules = new InventoryRules();
+
+    @Test
+    @DisplayName("신규 inventory는 비어 있고 획득/수량변경/소비가 typed state change로 결정된다")
+    void stackTransitions_AreDeterministicAndAuditable() {
+        OwnedItem potion = stack("stack:potion", "potion", null, 3);
+        InventoryRules.Result acquired = rules.apply(Inventory.empty(), List.of(new InventoryCommand.Acquire(potion)));
+        InventoryRules.Result changed = rules.apply(acquired.inventory(), List.of(
+                new InventoryCommand.ChangeQuantity("stack:potion", 5), new InventoryCommand.Consume("stack:potion", 2)));
+        assertThat(acquired.inventory().requireItem("stack:potion").quantity()).isEqualTo(3);
+        assertThat(acquired.stateChanges()).containsExactly(new GameResult.ItemAcquired(potion, 3));
+        assertThat(changed.inventory().requireItem("stack:potion").quantity()).isEqualTo(3);
+        assertThat(changed.stateChanges()).containsExactly(
+                new GameResult.ItemQuantityChanged("stack:potion", "potion", 3, 5),
+                new GameResult.ItemConsumed("stack:potion", "potion", 2, 3));
+        assertThat(InventoryRules.replay(Inventory.empty(), acquired.stateChanges())).isEqualTo(acquired.inventory());
+        assertThat(InventoryRules.replay(acquired.inventory(), changed.stateChanges())).isEqualTo(changed.inventory());
+    }
+
+    @Test
+    @DisplayName("stack 획득은 같은 definition과 owned id만 합산하고 overflow를 거절한다")
+    void acquireStack_ValidatesIdentityAndOverflow() {
+        Inventory inventory = Inventory.empty().acquire(stack("stack:potion", "potion", null, Integer.MAX_VALUE));
+        assertThatThrownBy(() -> inventory.acquire(stack("stack:potion", "potion", null, 1)))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("지원 범위");
+        assertThatThrownBy(() -> Inventory.empty().acquire(stack("stack:potion", "potion", null, 1))
+                .acquire(stack("stack:potion", "elixir", null, 1)))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("definition");
+    }
+
+    @Test
+    @DisplayName("instance item은 owned id별 단일 인스턴스로 유지되고 quantity 변경을 허용하지 않는다")
+    void instanceItems_KeepStableOwnedIdentity() {
+        ItemDefinition sword = new ItemDefinition("iron-sword", ItemOwnershipType.INSTANCE, EquipmentSlot.MAIN_HAND);
+        Inventory inventory = Inventory.empty().acquire(new OwnedItem("sword:001", sword, 1)).acquire(new OwnedItem("sword:002", sword, 1));
+        assertThat(inventory.items()).containsOnlyKeys("sword:001", "sword:002");
+        assertThatThrownBy(() -> inventory.changeQuantity("sword:001", 2)).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("INSTANCE");
+        assertThatThrownBy(() -> new OwnedItem("sword:003", sword, 2)).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("quantity");
+    }
+
+    @Test
+    @DisplayName("같은 definition ID를 서로 다른 의미로 소유할 수 없다")
+    void inventory_RejectsConflictingDefinitionIdentity() {
+        ItemDefinition mainHand = new ItemDefinition("artifact", ItemOwnershipType.INSTANCE, EquipmentSlot.MAIN_HAND);
+        ItemDefinition body = new ItemDefinition("artifact", ItemOwnershipType.INSTANCE, EquipmentSlot.BODY);
+        assertThatThrownBy(() -> new Inventory(Map.of(
+                "artifact:001", new OwnedItem("artifact:001", mainHand, 1),
+                "artifact:002", new OwnedItem("artifact:002", body, 1)), Equipment.empty()))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("definition id");
+    }
+
+    @Test
+    @DisplayName("장착 가능한 definition은 개별 INSTANCE ownership만 허용한다")
+    void equippableDefinition_MustBeInstance() {
+        assertThatThrownBy(() -> new ItemDefinition("stack-sword", ItemOwnershipType.STACK, EquipmentSlot.MAIN_HAND))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("INSTANCE");
+    }
+
+    @Test
+    @DisplayName("장착은 존재하는 item의 정의된 slot만 허용하고 해제 결과도 audit한다")
+    void equipmentTransitions_EnforceSlotInvariant() {
+        OwnedItem sword = instance("sword:001", "iron-sword", EquipmentSlot.MAIN_HAND);
+        Inventory inventory = Inventory.empty().acquire(sword);
+        assertThatThrownBy(() -> inventory.equip("sword:001", EquipmentSlot.BODY)).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("slot");
+        InventoryRules.Result equipped = rules.apply(inventory, List.of(new InventoryCommand.Equip("sword:001", EquipmentSlot.MAIN_HAND)));
+        InventoryRules.Result unequipped = rules.apply(equipped.inventory(), List.of(new InventoryCommand.Unequip(EquipmentSlot.MAIN_HAND)));
+        assertThat(equipped.inventory().equipment().itemIdAt(EquipmentSlot.MAIN_HAND)).isEqualTo("sword:001");
+        assertThat(equipped.stateChanges()).containsExactly(new GameResult.ItemEquipped(EquipmentSlot.MAIN_HAND, "sword:001", "iron-sword"));
+        assertThat(unequipped.inventory().equipment()).isEqualTo(Equipment.empty());
+        assertThat(unequipped.stateChanges()).containsExactly(new GameResult.ItemUnequipped(EquipmentSlot.MAIN_HAND, "sword:001", "iron-sword"));
+    }
+
+    @Test
+    @DisplayName("같은 item의 중복 장착과 사용 중 slot 덮어쓰기를 거절한다")
+    void equipment_RejectsDuplicateOwnershipReferences() {
+        assertThatThrownBy(() -> new Equipment(Map.of(EquipmentSlot.MAIN_HAND, "same-item", EquipmentSlot.OFF_HAND, "same-item")))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("둘 이상의 slot");
+        Inventory inventory = Inventory.empty().acquire(instance("sword:001", "iron-sword", EquipmentSlot.MAIN_HAND))
+                .acquire(instance("sword:002", "steel-sword", EquipmentSlot.MAIN_HAND)).equip("sword:001", EquipmentSlot.MAIN_HAND);
+        assertThatThrownBy(() -> inventory.equip("sword:002", EquipmentSlot.MAIN_HAND)).isInstanceOf(IllegalStateException.class).hasMessageContaining("사용 중");
+    }
+
+    @Test
+    @DisplayName("음수/0 수량, 존재하지 않는 item, 보유량 초과 소비를 거절한다")
+    void invalidQuantityAndMissingItem_AreRejected() {
+        assertThatThrownBy(() -> stack("bad", "potion", null, 0)).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("quantity");
+        assertThatThrownBy(() -> new InventoryCommand.Consume("missing", 0)).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("quantity");
+        assertThatThrownBy(() -> Inventory.empty().consume("missing", 1)).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("존재하지 않는");
+        Inventory inventory = Inventory.empty().acquire(stack("stack:potion", "potion", null, 2));
+        assertThatThrownBy(() -> inventory.consume("stack:potion", 3)).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("보유 quantity");
+        assertThatThrownBy(() -> inventory.changeQuantity("stack:potion", 0)).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("1 이상");
+        assertThatThrownBy(() -> inventory.changeQuantity("stack:potion", 2)).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("실제로 변경");
+    }
+
+    @Test
+    @DisplayName("장착 중 item은 명시적 해제 없이 제거하거나 전량 소비할 수 없다")
+    void equippedItem_CannotDisappearImplicitly() {
+        Inventory equipped = Inventory.empty().acquire(instance("sword:001", "iron-sword", EquipmentSlot.MAIN_HAND)).equip("sword:001", EquipmentSlot.MAIN_HAND);
+        assertThatThrownBy(() -> equipped.remove("sword:001")).isInstanceOf(IllegalStateException.class).hasMessageContaining("장착 중");
+        assertThatThrownBy(() -> equipped.consume("sword:001", 1)).isInstanceOf(IllegalStateException.class).hasMessageContaining("장착 중");
+    }
+
+    @Test
+    @DisplayName("손상된 audit은 canonical state와 불일치하면 replay에서 실패한다")
+    void replay_RejectsTamperedAudit() {
+        Inventory inventory = Inventory.empty().acquire(stack("stack:potion", "potion", null, 2));
+        GameResult.ItemConsumed tampered = new GameResult.ItemConsumed("stack:potion", "potion", 1, 0);
+        assertThatThrownBy(() -> InventoryRules.replay(inventory, List.of(tampered))).isInstanceOf(IllegalStateException.class).hasMessageContaining("남은 quantity");
+    }
+
+    private OwnedItem stack(String ownedId, String definitionId, EquipmentSlot slot, int quantity) {
+        return new OwnedItem(ownedId, new ItemDefinition(definitionId, ItemOwnershipType.STACK, slot), quantity);
+    }
+    private OwnedItem instance(String ownedId, String definitionId, EquipmentSlot slot) {
+        return new OwnedItem(ownedId, new ItemDefinition(definitionId, ItemOwnershipType.INSTANCE, slot), 1);
+    }
+}

--- a/src/test/java/com/uctale/uctale/persistence/PostgresGameStateSnapshotCompatibilityTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/PostgresGameStateSnapshotCompatibilityTest.java
@@ -22,10 +22,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 class PostgresGameStateSnapshotCompatibilityTest extends PostgresIntegrationTestSupport {
-
     private static final String OWNER_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
     private static final String LEGACY_FIXTURE = "fixtures/game-state/snapshot-v0-production.json";
-
     @Autowired private GamePersistenceService gamePersistenceService;
     @Autowired private JdbcTemplate jdbcTemplate;
     @Autowired private ObjectMapper objectMapper;
@@ -36,80 +34,57 @@ class PostgresGameStateSnapshotCompatibilityTest extends PostgresIntegrationTest
     }
 
     @Test
-    @DisplayName("기존 production raw snapshot을 기본 typed stats로 읽고 다음 write에서 schema v2로 저장한다")
+    @DisplayName("기존 production raw snapshot을 기본 typed stats와 빈 inventory로 읽고 다음 write에서 schema v3로 저장한다")
     void legacyRawSnapshot_IsReadAndRewrittenOnNextCanonicalWrite() throws Exception {
-        GameSession session = gamePersistenceService.saveOpening(
-                OWNER_KEY, "세계관", "캐릭터", "첫 이야기", "[]", null
-        );
+        GameSession session = gamePersistenceService.saveOpening(OWNER_KEY, "세계관", "캐릭터", "첫 이야기", "[]", null);
         String openingSnapshotJson = jdbcTemplate.queryForObject(
-                "select state_json from game_state_snapshot where session_id = ?",
-                String.class,
-                session.getId()
-        );
+                "select state_json from game_state_snapshot where session_id = ?", String.class, session.getId());
         JsonNode openingSnapshot = objectMapper.readTree(openingSnapshotJson);
-        assertThat(openingSnapshot.get("schemaVersion").asInt()).isEqualTo(2);
+        assertThat(openingSnapshot.get("schemaVersion").asInt()).isEqualTo(3);
         assertThat(openingSnapshot.get("rulesetVersion").asInt()).isEqualTo(1);
         assertThat(openingSnapshot.get("state").get("turnNumber").asInt()).isEqualTo(1);
         assertThat(openingSnapshot.get("state").get("playerCharacter").get("stats").get("might").asInt())
                 .isEqualTo(CharacterStats.DEFAULT_SCORE);
+        assertThat(openingSnapshot.get("state").get("inventory").get("items").isEmpty()).isTrue();
 
         GameState initialState = gamePersistenceService.loadLatestTurn(OWNER_KEY, session.getId(), 1).gameState();
         String legacyRawJson = legacyStateJson();
-        jdbcTemplate.update(
-                "update game_state_snapshot set state_json = ? where session_id = ?",
-                legacyRawJson,
-                session.getId()
-        );
-
+        jdbcTemplate.update("update game_state_snapshot set state_json = ? where session_id = ?", legacyRawJson, session.getId());
         GameState recovered = gamePersistenceService.loadLatestTurn(OWNER_KEY, session.getId(), 1).gameState();
-
         assertThat(recovered).isEqualTo(initialState);
         assertThat(recovered.playerCharacter().stats()).isEqualTo(CharacterStats.defaults());
-        assertThat(jdbcTemplate.queryForObject(
-                "select state_json from game_state_snapshot where session_id = ?",
-                String.class,
-                session.getId()
-        )).isEqualTo(legacyRawJson);
+        assertThat(recovered.inventory().items()).isEmpty();
+        assertThat(jdbcTemplate.queryForObject("select state_json from game_state_snapshot where session_id = ?", String.class, session.getId()))
+                .isEqualTo(legacyRawJson);
 
         GameState nextState = recovered.advance("진행", "두 번째 이야기");
-        gamePersistenceService.saveNextTurn(
-                OWNER_KEY,
-                session.getId(),
-                new GameTurnCommit(1, 1, "진행", recovered, nextState, "두 번째 이야기", "[]", null)
-        );
+        gamePersistenceService.saveNextTurn(OWNER_KEY, session.getId(),
+                new GameTurnCommit(1, 1, "진행", recovered, nextState, "두 번째 이야기", "[]", null));
 
-        String rewrittenJson = jdbcTemplate.queryForObject(
-                "select state_json from game_state_snapshot where session_id = ?",
-                String.class,
-                session.getId()
-        );
-        JsonNode rewritten = objectMapper.readTree(rewrittenJson);
-        assertThat(rewritten.get("schemaVersion").asInt()).isEqualTo(2);
+        JsonNode rewritten = objectMapper.readTree(jdbcTemplate.queryForObject(
+                "select state_json from game_state_snapshot where session_id = ?", String.class, session.getId()));
+        assertThat(rewritten.get("schemaVersion").asInt()).isEqualTo(3);
         assertThat(rewritten.get("rulesetVersion").asInt()).isEqualTo(1);
         assertThat(rewritten.get("state").get("turnNumber").asInt()).isEqualTo(2);
         assertThat(rewritten.get("state").get("playerCharacter").get("stats").get("presence").asInt())
                 .isEqualTo(CharacterStats.DEFAULT_SCORE);
+        assertThat(rewritten.get("state").get("inventory").get("equipment").get("slots").isEmpty()).isTrue();
     }
 
     @Test
-    @DisplayName("snapshot 없는 기존 session은 append-only GameLog 원장에서 현재 GameState와 기본 stats를 복구한다")
+    @DisplayName("snapshot 없는 기존 session은 append-only GameLog 원장에서 현재 GameState와 빈 inventory를 복구한다")
     void snapshotlessSession_RecoversFromCommittedTurnLedger() {
-        GameSession session = gamePersistenceService.saveOpening(
-                OWNER_KEY, "세계관", "캐릭터", "첫 이야기", "[]", null
-        );
+        GameSession session = gamePersistenceService.saveOpening(OWNER_KEY, "세계관", "캐릭터", "첫 이야기", "[]", null);
         GameState initialState = gamePersistenceService.loadLatestTurn(OWNER_KEY, session.getId(), 1).gameState();
         GameState nextState = initialState.advance("진행", "두 번째 이야기");
-        gamePersistenceService.saveNextTurn(
-                OWNER_KEY,
-                session.getId(),
-                new GameTurnCommit(1, 1, "진행", initialState, nextState, "두 번째 이야기", "[]", null)
-        );
+        gamePersistenceService.saveNextTurn(OWNER_KEY, session.getId(),
+                new GameTurnCommit(1, 1, "진행", initialState, nextState, "두 번째 이야기", "[]", null));
         jdbcTemplate.update("delete from game_state_snapshot where session_id = ?", session.getId());
 
         GameState recovered = gamePersistenceService.loadLatestTurn(OWNER_KEY, session.getId(), 2).gameState();
-
         assertThat(recovered).isEqualTo(nextState);
         assertThat(recovered.playerCharacter().stats()).isEqualTo(CharacterStats.defaults());
+        assertThat(recovered.inventory().items()).isEmpty();
         assertThat(recovered.storyMemory().recentTurns().getLast().playerAction()).isEqualTo("진행");
     }
 

--- a/src/test/java/com/uctale/uctale/persistence/PostgresInventoryPersistenceTest.java
+++ b/src/test/java/com/uctale/uctale/persistence/PostgresInventoryPersistenceTest.java
@@ -1,0 +1,116 @@
+package com.uctale.uctale.persistence;
+
+import com.uctale.uctale.application.game.GameMutationRequestService;
+import com.uctale.uctale.application.game.GamePersistenceService;
+import com.uctale.uctale.application.game.GameTurnCommit;
+import com.uctale.uctale.domain.GameSession;
+import com.uctale.uctale.domain.action.ActionType;
+import com.uctale.uctale.domain.action.PlayerAction;
+import com.uctale.uctale.domain.game.ActionResolver;
+import com.uctale.uctale.domain.game.EquipmentSlot;
+import com.uctale.uctale.domain.game.GameState;
+import com.uctale.uctale.domain.game.InventoryCommand;
+import com.uctale.uctale.domain.game.ItemDefinition;
+import com.uctale.uctale.domain.game.ItemOwnershipType;
+import com.uctale.uctale.domain.game.OwnedItem;
+import com.uctale.uctale.domain.game.StateTransition;
+import com.uctale.uctale.domain.game.TurnResolution;
+import com.uctale.uctale.support.PostgresIntegrationTestSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class PostgresInventoryPersistenceTest extends PostgresIntegrationTestSupport {
+    private static final String OWNER_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    @Autowired private GamePersistenceService gamePersistenceService;
+    @Autowired private GameMutationRequestService mutationRequestService;
+    @Autowired private JdbcTemplate jdbcTemplate;
+    private final ActionResolver resolver = new ActionResolver();
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.execute("truncate table game_turn_reservation, game_mutation_request, image_asset, game_state_snapshot, game_log, game_session restart identity cascade");
+    }
+
+    @Test
+    @DisplayName("inventory/equipment transition은 snapshot과 GameLog audit에 저장되고 snapshot 없이도 동일하게 복구된다")
+    void inventoryTransition_PersistsAndRecoversFromLedger() {
+        GameSession session = gamePersistenceService.saveOpening(OWNER_KEY, "세계관", "캐릭터", "오프닝", "[]", null);
+        GameState previous = gamePersistenceService.loadLatestTurn(OWNER_KEY, session.getId(), 1).gameState();
+        OwnedItem sword = new OwnedItem("sword:001",
+                new ItemDefinition("iron-sword", ItemOwnershipType.INSTANCE, EquipmentSlot.MAIN_HAND), 1);
+        OwnedItem potion = new OwnedItem("stack:potion",
+                new ItemDefinition("potion", ItemOwnershipType.STACK, null), 3);
+        TurnResolution resolution = resolver.resolveWithInventory(previous, action(1, 1, "상자를 연다"), List.of(
+                new InventoryCommand.Acquire(sword),
+                new InventoryCommand.Acquire(potion),
+                new InventoryCommand.Equip("sword:001", EquipmentSlot.MAIN_HAND)));
+        StateTransition committed = resolution.attachNarrative("검과 물약을 챙겼다.");
+        gamePersistenceService.saveNextTurn(OWNER_KEY, session.getId(), commit(1, committed, resolution, "검과 물약을 챙겼다."));
+
+        GameState loaded = gamePersistenceService.loadLatestTurn(OWNER_KEY, session.getId(), 2).gameState();
+        assertThat(loaded).isEqualTo(committed.nextState());
+        assertThat(loaded.inventory().requireItem("stack:potion").quantity()).isEqualTo(3);
+        assertThat(loaded.inventory().equipment().itemIdAt(EquipmentSlot.MAIN_HAND)).isEqualTo("sword:001");
+        String audit = jdbcTemplate.queryForObject(
+                "select inventory_changes_json from game_log where session_id = ? and turn_number = 2",
+                String.class, session.getId());
+        assertThat(audit).contains("ITEM_ACQUIRED", "ITEM_EQUIPPED", "sword:001", "stack:potion");
+
+        jdbcTemplate.update("delete from game_state_snapshot where session_id = ?", session.getId());
+        GameState recovered = gamePersistenceService.loadLatestTurn(OWNER_KEY, session.getId(), 2).gameState();
+        assertThat(recovered).isEqualTo(committed.nextState());
+    }
+
+    @Test
+    @DisplayName("동일 idempotency request replay는 item 소비를 두 번 적용하지 않는다")
+    void completedIdempotencyReplay_DoesNotConsumeTwice() {
+        GameSession session = gamePersistenceService.saveOpening(OWNER_KEY, "세계관", "캐릭터", "오프닝", "[]", null);
+        GameState opening = gamePersistenceService.loadLatestTurn(OWNER_KEY, session.getId(), 1).gameState();
+        OwnedItem potion = new OwnedItem("stack:potion", new ItemDefinition("potion", ItemOwnershipType.STACK, null), 3);
+        TurnResolution acquire = resolver.resolveWithInventory(opening, action(1, 1, "물약을 얻는다"),
+                List.of(new InventoryCommand.Acquire(potion)));
+        StateTransition acquired = acquire.attachNarrative("물약 세 개를 얻었다.");
+        gamePersistenceService.saveNextTurn(OWNER_KEY, session.getId(), commit(1, acquired, acquire, "물약 세 개를 얻었다."));
+
+        String key = "inventory-consume-retry";
+        String fingerprint = "consume-potion-once";
+        GameMutationRequestService.BeginResult first = mutationRequestService.begin(
+                OWNER_KEY, GameMutationRequestService.PROGRESS, key, session.getId(), 2, fingerprint);
+        GameState beforeConsume = gamePersistenceService.loadLatestTurn(OWNER_KEY, session.getId(), 2).gameState();
+        TurnResolution consume = resolver.resolveWithInventory(beforeConsume, action(2, 1, "물약을 마신다"),
+                List.of(new InventoryCommand.Consume("stack:potion", 1)));
+        StateTransition consumed = consume.attachNarrative("물약 하나를 마셨다.");
+        gamePersistenceService.saveNextTurn(OWNER_KEY, session.getId(), commit(2, consumed, consume, "물약 하나를 마셨다."),
+                first.requestId(), "물약 사용", first.reservationOwner());
+
+        GameMutationRequestService.BeginResult replay = mutationRequestService.begin(
+                OWNER_KEY, GameMutationRequestService.PROGRESS, key, session.getId(), 2, fingerprint);
+        assertThat(replay.replay()).isTrue();
+        assertThat(replay.resultTurn()).isEqualTo(3);
+        assertThat(gamePersistenceService.loadLatestTurn(OWNER_KEY, session.getId(), 3)
+                .gameState().inventory().requireItem("stack:potion").quantity()).isEqualTo(2);
+        assertThat(jdbcTemplate.queryForObject(
+                "select count(*) from game_log where session_id = ? and turn_number = 3", Integer.class, session.getId()))
+                .isEqualTo(1);
+    }
+
+    private GameTurnCommit commit(int expectedTurn, StateTransition transition, TurnResolution resolution, String storyText) {
+        return new GameTurnCommit(expectedTurn, 1, resolution.gameResult().resolvedAction().displayText(), transition,
+                storyText, "[]", null, null, resolution.gameResult().skillCheckResult(), resolution.gameResult().stateChanges(), null);
+    }
+
+    private PlayerAction action(int sourceTurn, int choiceId, String text) {
+        return new PlayerAction(choiceId, "token", ActionType.NARRATIVE_CHOICE, sourceTurn,
+                Map.of("choiceId", Integer.toString(choiceId)), text);
+    }
+}


### PR DESCRIPTION
## 왜 필요한가요?

아이템 획득·소비·장착은 narrative가 임의로 선언해서는 안 되는 canonical state입니다. 전투 보상과 장비 modifier보다 먼저 서버가 소유하는 작고 검증 가능한 Inventory/Equipment aggregate와 저장·복구 경계가 필요합니다.

- Closes #39

## 무엇이 바뀌나요?

- 게임 규칙·상태: stable item definition/owned item ID, STACK/INSTANCE ownership, 최소 equipment slot, acquire/remove/quantity/consume/equip/unequip 순수 규칙과 invariant를 추가합니다.
- Backend / API / DB: `GameState.inventory`, typed `GameResult.StateChange`, `GameTurnCommit` audit equality 검증, snapshot schema v3, `game_log.inventory_changes_json` migration과 snapshotless recovery를 추가합니다. public API 계약은 변경하지 않습니다.
- AI narrative / prompt: provider는 서버가 확정한 inventory/equipment state change만 서술할 수 있고 story prose만으로 canonical item 상태를 변경할 수 없습니다. equip/unequip state change는 명시적 type으로 구분됩니다.
- Image generation: 변경 없음.
- Frontend / UX: 변경 없음. 전체 inventory UI는 Issue 범위 밖입니다.
- Build / deploy / docs: Inventory/Equipment architecture, snapshot evolution, GameState/Action Resolution, README를 현재 구현 상태에 맞게 갱신합니다.

## 책임 경계

게임 기능이나 AI 변경이 있다면 아래를 명확히 적어 주세요.

- **서버가 결정하는 사실:** item definition/owned ID, 수량, 획득·제거·소비, equipment slot과 장착/해제, canonical next Inventory/Equipment, GameResult state change와 GameLog audit.
- **LLM이 서술하는 내용:** 서버가 확정한 state change의 내러티브 표현과 다음 choice 후보.
- **LLM이 변경하면 안 되는 사실:** item 생성·소비·수량·장착 상태, audit, canonical next state. 이번 PR은 InventoryCommand를 새 LLM 출력 필드나 public API로 노출하지 않습니다.

## 어떻게 검증했나요?

- [x] PR 작성 전 변경 diff를 비판적으로 검토하고 타당한 지적을 반영했습니다.
- [x] `./gradlew clean test`
- [x] `./gradlew postgresIntegrationTest`
- [x] `./gradlew build`
- [x] `cd frontend && npm ci && npm test && npm run lint && npm run build`
- [ ] 정상 흐름을 직접 확인했습니다.
- [x] 잘못된 입력/실패 흐름을 확인했습니다.
- [x] 중복 요청 또는 상태 전이가 관련되면 이를 검증했습니다.

최종 GitHub Actions CI run `34150553107`에서 backend unit/H2 suite, PostgreSQL integration suite, backend build, frontend install/test/lint/build가 모두 성공했습니다.

추가한 자동 테스트는 pure Inventory/Equipment invariant, resolver 경계, GameTurnCommit audit 일치, audit codec 손상 데이터, snapshot v0/v1/v2 -> v3 upgrade와 current-v3 손상 데이터, PostgreSQL snapshot/GameLog 복구, completed idempotency replay에서 소비 1회 적용을 검증합니다.

수동 UI/API smoke는 수행하지 않았습니다. 이번 PR은 public API/UI 계약을 변경하지 않으며 정상/실패/중복 상태 전이는 unit 및 PostgreSQL integration test로 검증했습니다.

초기 CI에서 발견된 회귀도 수정했습니다.

- 첫 run: 신규 `GameStateUpgraderTest`의 잘못된 Java text block 문법으로 `compileTestJava` 실패 -> 일반 문자열 리터럴로 수정.
- 두 번째 run: 기존 crash-regression test subclass가 사용하던 `GamePersistenceService` 7-인자 생성자 호환성 누락 -> Spring 주입은 신규 8-인자 생성자로 명시하고 기존 생성자 compatibility를 복원.
- 이후 전체 CI 성공.

비판적 자체 리뷰에서 다음을 발견해 반영했습니다.

- 장착 가능한 STACK은 "스택 전체 장착 vs 단일 개체 장착" 의미가 모호하므로 장착 가능한 definition은 INSTANCE만 허용하도록 제한했습니다.
- 동일 definition ID가 서로 다른 slot/ownership 의미를 가질 수 있는 경계를 막았습니다.
- stack 수량 합산 overflow를 `Math.addExact` 기반 명시적 실패로 처리했습니다.
- current schema v3에서 inventory 누락을 legacy 기본값으로 조용히 복구하지 않고 손상 snapshot으로 실패하게 했습니다.
- equip/unequip state change가 provider JSON에서 구조만으로 모호해질 수 있어 명시적 type을 추가하고 직렬화 회귀 테스트를 넣었습니다.
- canonical next inventory가 바뀌었는데 state-change audit이 누락·변조된 commit을 거부하도록 replay equality를 추가했습니다.
- 재검토에서 schema v2는 inventory 의미를 정의하지 않았는데 object 형태의 `inventory`가 있으면 v3 canonical state로 승격되던 경계를 발견했습니다. v2에 `inventory` 키가 조금이라도 있으면 형식과 무관하게 명시적으로 실패하도록 수정하고 회귀 테스트와 architecture 문서를 함께 갱신했습니다.
- 초안에서 기존 파일 포맷을 불필요하게 크게 다시 쓴 diff를 발견해 기존 스타일을 복원하고 실질 변경만 남겼습니다.
- README의 "snapshot v2 / inventory 미구현" 설명을 실제 구현 상태에 맞게 갱신했습니다.
- 최종 diff에서 상점/거래, loot table, 강화/내구도, 전투 modifier, frontend inventory UI가 유입되지 않았음을 재확인했습니다.

## 게임 상태·AI 안전성

해당하지 않는 항목은 이유를 적어 주세요.

- [x] 게임의 결정적 상태는 서버에서 검증·저장됩니다.
- [x] LLM 출력만으로 HP, 보상, 성공/실패 등 결정적 상태가 임의 변경되지 않습니다.
- [x] AI 요청에 필요한 최소 문맥만 전달합니다.
- [x] AI 응답 파싱 실패와 provider 오류가 게임 상태를 오염시키지 않습니다.
- [x] 기존 저장 데이터 또는 GameState 호환성 영향을 확인했습니다.

InventoryCommand는 provider 응답이나 public request에서 생성하지 않습니다. provider가 받는 것은 서버가 이미 확정한 typed state change이며, provider 실패 시 기존 canonical commit 경계를 그대로 유지합니다.

## 보안·비용

- [x] API Key, 토큰, 비밀번호가 코드·로그·URL·클라이언트 응답에 노출되지 않습니다.
- [x] 외부 AI/Image 호출 횟수와 실패 시 동작을 검토했습니다.
- [x] 사용자 입력 길이와 외부 API 비용 증가 가능성을 검토했습니다.
- [x] CORS 또는 공개 endpoint 변경이 있다면 의도된 변경입니다.

외부 provider 호출, 사용자 입력 필드, public endpoint, CORS 변경은 없습니다. Inventory 규칙은 pure server-side operation입니다.

## API·DB·운영 영향

- [x] API 계약 변경 시 Frontend 호출부와 문서를 함께 갱신했습니다.
- [x] DB schema 변경 시 migration 전략을 포함했습니다.
- [x] 환경변수는 이름과 용도만 문서화했고 실제 Secret은 포함하지 않았습니다.
- [ ] 배포 후 확인할 smoke test가 있습니다.

API wire contract 변경은 없습니다. DB에는 nullable `game_log.inventory_changes_json`을 추가하며 legacy/opening `NULL`은 변화 없음으로 읽습니다. snapshot은 schema v3로 올라가며 v0/v1/v2는 deterministic read-time upgrade 후 다음 canonical write에서 v3로 저장됩니다. schema v2에 정의되지 않은 `inventory` 키가 이미 있는 경우는 의미를 추정하지 않고 명시적으로 실패합니다.

별도 feature-specific post-deploy smoke는 추가하지 않았습니다. 기존 production smoke script의 syntax 검증은 CI에서 성공했습니다.

## 화면 / 응답 예시

Frontend/API 응답 변경은 없습니다. Inventory 전체 UI는 #39 범위 밖입니다.